### PR TITLE
ci: change arm runner name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
           - os: linux-intel
             runs-on: ubuntu-latest
           - os: linux-arm
-            runs-on: aarch64
+            runs-on: ubuntu-24.04-arm
           - os: macos-arm
             runs-on: macos-15
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           - "3.14"
         runner:
           - ubuntu-latest
-          - aarch64
+          - ubuntu-24.04-arm
           - macos-15
 
     runs-on: ${{ matrix.runner}}
@@ -278,7 +278,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - aarch64
+          - ubuntu-24.04-arm
           - macos-15
 
     steps:


### PR DESCRIPTION
This pull request updates the runner configuration for ARM-based jobs in the GitHub Actions workflows. The main change is replacing the generic `aarch64` runner label with the more specific `ubuntu-24.04-arm` label for both deployment and testing workflows. This ensures that ARM jobs run on the correct runners for public repos.

See https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories.