### PR TITLE
perf(bindings): ⚡ apply ARCH_FLAG to _core so the kernels vectorise

### DIFF
--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -79,3 +79,104 @@ Both use a ``lower_atol`` of 1e-4; ``--hubbard-lower-atol`` / ``--pauli-lower-at
 override each model's coefficient-truncation tolerance.
 
 See ``benches/README.md`` for the full list of options and details.
+
+Profiling the bound C++ code
+============================
+
+The benchmarks drive the compiled ``monoprop._core`` extension, so a sampling
+CPU profiler (``perf``, Intel VTune) attributes time straight to the C++
+kernels. Two properties of the *installed* extension make it unprofilable as
+shipped, both fixed by a one-off rebuild:
+
+- nanobind **strips** the symbol table from ``Release`` builds, so samples land
+  on bare addresses with no function names.
+- ``Release`` carries no debug info, so there is no line-level attribution.
+
+Rebuild ``_core`` as ``RelWithDebInfo`` — the same ``-O3 -DNDEBUG`` codegen as
+the shipped wheel, plus ``-g`` and an unstripped symbol table:
+
+.. code-block:: bash
+
+   env -u VIRTUAL_ENV uv sync --all-extras --group bench \
+       --reinstall-package monoprop --no-cache \
+       --config-settings-package="monoprop:cmake.build-type=RelWithDebInfo"
+
+Capture one benchmark under ``perf``. Invoke pytest directly (not through
+``just bench``) so the profiler's target is the Python process, pin to a single
+thread for clean attribution, and unwind with DWARF — the build omits frame
+pointers, so ``--call-graph fp`` will not work:
+
+.. code-block:: bash
+
+   monoprop_NUM_THREADS=1 perf record -g --call-graph dwarf,16384 -F 999 \
+       -o build.perf -- .venv/bin/python -m pytest \
+       benches/bench_random.py::test_random_build_graph \
+       --num-modes 64 --cutoff 8 --bench-rounds 3 -q
+
+``perf`` resolves the full mixed stack (Python → nanobind trampoline → the
+templated ``MonomialPropagator<N>`` kernels, inlined frames included). Read it
+back as a flat hotspot list, by source line, or as a flame graph (the latter
+needs `FlameGraph <https://github.com/brendangregg/FlameGraph>`_ on your
+``PATH``):
+
+.. code-block:: bash
+
+   perf report -i build.perf --stdio --no-children -g none   # flat hot functions
+   perf report -i build.perf --stdio --sort srcline          # hot source lines
+   perf script -i build.perf | stackcollapse-perf.pl | flamegraph.pl > build.svg
+
+Sampling user space needs no special privileges (only kernel symbols stay
+restricted, which does not affect the C++ kernels). Intel VTune profiles the
+same rebuilt extension — ``vtune -collect hotspots`` for the hotspot view, or
+``vtune -collect memory-access`` for per-object bandwidth and loaded latency.
+
+.. note::
+
+   The profile reflects whatever flags ``_core`` was actually compiled with;
+   confirm them in ``build/editable/*/compile_commands.json``. Vectorisation
+   flags (``-march``) on the binding translation units in particular change
+   which kernels dominate — e.g. hardware versus software ``popcount``.
+
+Worked example: vectorising the ``_core`` kernels
+==================================================
+
+The profiling pass above surfaced a concrete defect. On ``build_graph`` the
+flat profile was ~31% ``fused_find_and_collect`` and **~18% libgcc
+``__popcountdi2``** — a *software* popcount. The cause: the hot
+``MonomialPropagator<N>`` kernels are header templates instantiated in the
+``_core`` extension's own translation units, but the architecture flag
+(``-march=native``) was applied only to the ``monoprop`` library, not to
+``_core``. So those translation units compiled to scalar baseline ``x86-64``
+and popcounts fell back to libgcc.
+
+The fix applies the same flag block to the ``_core`` target (see
+``src/monoprop/bindings/CMakeLists.txt``); the extension then emits hardware
+``popcnt`` and vectorises the scan/bitset kernels. Measured on a large random
+system — **500 generators**, 128 modes, cutoff 8, single thread, on an
+i9-10900X — ``build_graph`` in the Heisenberg picture (median of 5 builds):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - ``_core`` build
+     - median
+     - min
+     - mean
+   * - baseline (``-march=x86-64``)
+     - 16.56 s
+     - 16.20 s
+     - 17.55 s
+   * - ``-march=native`` (fixed)
+     - 11.82 s
+     - 11.60 s
+     - 12.21 s
+   * - **speedup**
+     - **−28.6% (1.40×)**
+     - −28.4%
+     - −30.5%
+
+The change is codegen-only and correctness-preserving: the core test suite
+(``pytest tests/ -m "not mpi and not slow"``) gives an identical 405 passed
+before and after. The win is larger than the popcount share alone because
+``-march=native`` also vectorises the bitset/scan kernels.

--- a/src/monoprop/bindings/CMakeLists.txt
+++ b/src/monoprop/bindings/CMakeLists.txt
@@ -105,6 +105,23 @@ target_include_directories(
 
 target_link_libraries(_core PRIVATE monoprop)
 
+# Architecture/optimization flags must be applied to _core itself, not just to the
+# monoprop library. The hot MonomialPropagator<N> kernels are header templates that
+# are *instantiated* in this target's translation units (bindings.cpp + the generated
+# binders), so they pick up _core's flags, not the library's. Without this, ARCH_FLAG
+# only reached libmonoprop and the kernels compiled to scalar baseline x86-64 — most
+# visibly, popcounts fell back to libgcc's software __popcountdi2. Mirroring the
+# library's flag block here emits hardware popcnt and vectorises the scan/bitset
+# kernels (see docs/benchmarks.rst, "Profiling the bound C++ code").
+target_compile_options(
+  _core
+  BEFORE
+  PRIVATE
+    "${monoprop_CXX_FLAGS}"
+    "${ARCH_FLAG}"
+)
+target_compile_options(_core PRIVATE "${EXTRA_CXXFLAGS}")
+
 file(
   RELATIVE_PATH
   _rel


### PR DESCRIPTION
## What

Apply the architecture/optimization flag (`ARCH_FLAG`, i.e. `-march=native`) to the
`_core` extension target, not just to the `monoprop` library.

## Why — the finding

Profiling the Python benches (which drive the bound C++) showed `build_graph` spending
**~18% in libgcc's software `__popcountdi2`**, on top of ~31% in `fused_find_and_collect`.

Root cause: the hot `MonomialPropagator<N>` kernels are **header templates instantiated in
`_core`'s own translation units** (`bindings.cpp` + the generated binders). `ARCH_FLAG` was
applied to the `monoprop` library target but never to `_core`, so those TUs compiled to
scalar baseline `x86-64` — no hardware `popcnt`, no AVX on the scan/bitset kernels.

The compile commands confirm it: 8 `libmonoprop` TUs carried `-march=native`, the `_core`
TU carried `-march=x86-64`. After the fix the extension emits **1101 `popcnt` instructions
and zero libgcc `__popcountdi2` imports**.

## Result — fresh benchmarks, large system

Random system, **500 generators**, 128 modes, cutoff 8, single thread, i9-10900X;
`build_graph` (Heisenberg), median of 5 builds:

| `_core` build | median | min | mean |
|---|--:|--:|--:|
| baseline (`-march=x86-64`) | 16.56 s | 16.20 s | 17.55 s |
| `-march=native` (this PR) | **11.82 s** | 11.60 s | 12.21 s |
| **speedup** | **−28.6% (1.40×)** | −28.4% | −30.5% |

The win exceeds the popcount share alone because `-march=native` also vectorises the
bitset/scan kernels. (A smaller-scale spot check — 100 generators, 64 modes — showed
−24% Heisenberg / −37% Schrödinger on the same path.)

## Correctness

Codegen-only change. The core test suite is **identical before and after**:

```
pytest tests/ -m "not mpi and not slow"  →  405 passed  (baseline and fixed)
```

## How it was found

`docs/benchmarks.rst` gains a "Profiling the bound C++ code" section (symboled
`RelWithDebInfo` rebuild → `perf record --call-graph dwarf`) plus a worked example
documenting this finding, so the workflow is reproducible.

## Test plan

- [x] `pytest tests/ -m "not mpi and not slow"` — 405 passed, unchanged
- [x] Verified `_core` emits hardware `popcnt` (1101) and no `__popcountdi2`
- [x] Re-ran the 500-generator `build_graph` A/B on a clean Release build of each variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
