### PR TITLE
build(cxxflags): re-enable -Wunused

### DIFF
--- a/cmake/compiler_flags/GNU.CXX.cmake
+++ b/cmake/compiler_flags/GNU.CXX.cmake
@@ -1,7 +1,7 @@
 if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
   set(
     monoprop_CXX_FLAGS
-    "-Wall -Wno-unknown-pragmas -Wno-sign-compare -Woverloaded-virtual -Wwrite-strings -Wno-unused -Wextra -Wconversion -Wnon-virtual-dtor -Wcast-align -Wunused-parameter -fdiagnostics-color=always -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+    "-Wall -Wno-unknown-pragmas -Wno-sign-compare -Woverloaded-virtual -Wwrite-strings -Wextra -Wconversion -Wnon-virtual-dtor -Wcast-align -Wunused-parameter -fdiagnostics-color=always -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
   )
 
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")


### PR DESCRIPTION
We used `-Wall -Wextra -Wno-unused`, tusehe latter disabling warnings
for unused stuff. Removed it to flag unused variables/functions etc