### PR TITLE
build: exclude gcc < 14 and clang < 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -343,7 +343,7 @@ jobs:
             cmake_cxx_compiler: clang++
           - runner: macos-15
             compiler: apple-clang
-            cmake_cxx_compiler: g++
+            cmake_cxx_compiler: clang++
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -365,6 +365,10 @@ jobs:
       - name: Set clang-18/clang++-18 as default compilers
         if: ${{ matrix.compiler == 'clang-18' }}
         run: |
+          if ! command -v clang-18 >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y clang-18
+          fi
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 180
           sudo update-alternatives --set clang /usr/bin/clang-18
           sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-18 180

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,14 +326,24 @@ jobs:
     # skips running the workflow for Draft PRs
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'test-in-draft') }}
 
-    name: Check C++ on ${{ matrix.runner }}
+    name: Check C++ on ${{ matrix.runner }} (${{ matrix.compiler }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - ubuntu-24.04-arm
-          - macos-15
+        include:
+          - runner: ubuntu-24.04-arm
+            compiler: gcc-14
+            cmake_cxx_compiler: g++
+          - runner: ubuntu-24.04-arm
+            compiler: clang-18
+            cmake_cxx_compiler: clang++
+          - runner: ubuntu-latest
+            compiler: clang-18
+            cmake_cxx_compiler: clang++
+          - runner: macos-15
+            compiler: apple-clang
+            cmake_cxx_compiler: g++
 
     steps:
       - uses: actions/checkout@v7
@@ -341,7 +351,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set gcc-14/g++-14 as default compilers
-        if: ${{ matrix.runner != 'macos-15' }}
+        if: ${{ matrix.compiler == 'gcc-14' }}
         run: |
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
           sudo update-alternatives --set gcc /usr/bin/gcc-14
@@ -351,6 +361,18 @@ jobs:
           sudo update-alternatives --set g++ /usr/bin/g++-14
           sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 140
           sudo update-alternatives --set c++ /usr/bin/g++-14
+
+      - name: Set clang-18/clang++-18 as default compilers
+        if: ${{ matrix.compiler == 'clang-18' }}
+        run: |
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 180
+          sudo update-alternatives --set clang /usr/bin/clang-18
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-18 180
+          sudo update-alternatives --set cc /usr/bin/clang-18
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 180
+          sudo update-alternatives --set clang++ /usr/bin/clang++-18
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-18 180
+          sudo update-alternatives --set c++ /usr/bin/clang++-18
 
       - name: Install dependencies
         if: ${{ matrix.runner != 'macos-15' }}
@@ -368,13 +390,13 @@ jobs:
         if: ${{ matrix.runner != 'macos-15' }}
         run: |
           export CMAKE_PREFIX_PATH=/opt/Software
-          cmake -S. -Bbuild -DCMAKE_CXX_COMPILER=g++
+          cmake -S. -Bbuild -DCMAKE_CXX_COMPILER=${{ matrix.cmake_cxx_compiler }}
 
       - name: Configure
         if: ${{ matrix.runner == 'macos-15' }}
         run: |
           export MACOSX_DEPLOYMENT_TARGET=15.0
-          cmake -S. -Bbuild -DCMAKE_CXX_COMPILER=g++
+          cmake -S. -Bbuild -DCMAKE_CXX_COMPILER=${{ matrix.cmake_cxx_compiler }}
 
       - name: Build
         run: cmake --build build
@@ -383,12 +405,12 @@ jobs:
         env:
           OMPI_MCA_rmaps_base_oversubscribe: "1"
         run: |
-          ctest --test-dir build --output-junit ../ctest-${{ matrix.runner }}.xml
+          ctest --test-dir build --output-junit ../ctest-${{ matrix.runner }}-${{ matrix.compiler }}.xml
 
       - name: Upload Test Results as artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: test_results_cpp_${{ matrix.runner }}
+          name: test_results_cpp_${{ matrix.runner }}_${{ matrix.compiler }}
           path: |
             ctest-*.xml
           retention-days: 1

--- a/cmake/compiler_flags/Clang.CXX.cmake
+++ b/cmake/compiler_flags/Clang.CXX.cmake
@@ -1,7 +1,15 @@
 # same flags are used for both Clang and AppleClang
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
   # check version when compiler id is exactly Clang (valid for Linux)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
+  if(
+    CMAKE_CXX_COMPILER_ID
+      STREQUAL
+      Clang
+    AND
+      CMAKE_CXX_COMPILER_VERSION
+        VERSION_LESS
+        18
+  )
     message(
       FATAL_ERROR
       "monoprop requires Clang compiler version >= 18. Detected version: ${CMAKE_CXX_COMPILER_VERSION}"

--- a/cmake/compiler_flags/Clang.CXX.cmake
+++ b/cmake/compiler_flags/Clang.CXX.cmake
@@ -1,5 +1,7 @@
+# same flags are used for both Clang and AppleClang
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
+  # check version when compiler id is exactly Clang (valid for Linux)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
     message(
       FATAL_ERROR
       "monoprop requires Clang compiler version >= 18. Detected version: ${CMAKE_CXX_COMPILER_VERSION}"

--- a/cmake/compiler_flags/Clang.CXX.cmake
+++ b/cmake/compiler_flags/Clang.CXX.cmake
@@ -1,4 +1,11 @@
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
+    message(
+      FATAL_ERROR
+      "monoprop requires Clang compiler version >= 18. Detected version: ${CMAKE_CXX_COMPILER_VERSION}"
+    )
+  endif()
+
   set(
     monoprop_CXX_FLAGS
     "-Wall -Wno-padded -Wno-unknown-pragmas -Woverloaded-virtual -Wwrite-strings -fcolor-diagnostics -Wno-c++98-compat -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"

--- a/cmake/compiler_flags/GNU.CXX.cmake
+++ b/cmake/compiler_flags/GNU.CXX.cmake
@@ -1,4 +1,11 @@
 if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+    message(
+      FATAL_ERROR
+      "monoprop requires GNU compiler version >= 14. Detected version: ${CMAKE_CXX_COMPILER_VERSION}"
+    )
+  endif()
+
   set(
     monoprop_CXX_FLAGS
     "-Wall -Wno-unknown-pragmas -Wno-sign-compare -Woverloaded-virtual -Wwrite-strings -Wno-unused -Wextra -Wconversion -Wnon-virtual-dtor -Wcast-align -Wunused-parameter -fdiagnostics-color=always -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"

--- a/docs/content/docs/building.mdx
+++ b/docs/content/docs/building.mdx
@@ -23,7 +23,7 @@ without MPI, so a from-source build is required for multi-rank runs.
 
 ## Prerequisites
 
-- a C++23 compiler (GCC 13+ or Clang 17+)
+- a C++23-compliant compiler; on Linux the minimum supported versions are **GCC 14** and **Clang 18**
 - CMake and Ninja
 - Python 3.11 or newer and the `uv` package manager (for the bindings)
 - an MPI implementation such as Open MPI (only for MPI builds)


### PR DESCRIPTION
- [X] Test minimum supported GCC and Clang versions on Linux
- [x] Exclude less-than-minimum versions at configuration-time
- [x] close #11 
- [x] close #12 