### PR TITLE
docs(concepts): 📝 fix notation table rendering

### DIFF
--- a/docs/content/docs/concepts/notation.mdx
+++ b/docs/content/docs/concepts/notation.mdx
@@ -57,7 +57,7 @@ $(m_{i_1}\cdots m_{i_n})^\dagger = (-1)^{n(n-1)/2}\,m_{i_1}\cdots m_{i_n}$.
 The compensating factor $i^{\binom{|\nu|}{2}}$ cancels this sign and
 restores $M_\nu^\dagger = M_\nu$:
 
-| Length $|\nu|$ | Phase $i^{\binom{|\nu|}{2}}$ | Example |
+| Length $\lvert \nu \rvert$ | Phase $i^{\binom{\lvert \nu \rvert}{2}}$ | Example |
 | --- | --- | --- |
 | 1 | $1$ | $m_j$ |
 | 2 | $i$ | $i\,m_j m_k$ |


### PR DESCRIPTION
## Why
The Notation page table in `concepts/notation` did not render correctly because the header used unescaped `|` characters inside inline math, which conflicted with Markdown table parsing.

## What changed
The table header now uses `\lvert \nu \rvert` instead of `$|\nu|$` in both affected math expressions. This preserves the intended notation while avoiding accidental column splits in MDX/Markdown parsing.

## Notes for reviewers
This is a docs-only, single-line fix with no behavior changes outside page rendering.