### PR TITLE
docs: 📝 add MDX code-block doctest checks

### DIFF
--- a/docs/content/docs/features/cutoff.mdx
+++ b/docs/content/docs/features/cutoff.mdx
@@ -48,7 +48,7 @@ though its length is 3.
 Both the cutoff value and the cutoff type can be changed at any point during a
 simulation:
 
-```python
+```python notest
 sim.cutoff = 8
 sim.cutoff_type = "length"
 ```
@@ -73,7 +73,7 @@ weight does not track Majorana length — see the Pauli representation in
 entries, one per Majorana operator, each giving its image as a set of Majorana
 indices; `jordan_wigner_basis_change` builds it for Jordan–Wigner:
 
-```python
+```python notest
 from monoprop import MonomialPropagator, jordan_wigner_basis_change
 
 # m_0 -> X_0, m_1 -> Y_0, m_2 -> Z_0 X_1, m_3 -> Z_0 Y_1, ...
@@ -84,7 +84,7 @@ sim = MonomialPropagator(..., cutoff_type="support", basis_change=bc)
 `basis_change` is a read/write attribute, so it can also be set or cleared after
 construction:
 
-```python
+```python notest
 sim.basis_change = jordan_wigner_basis_change(n_qubits=2)
 sim.basis_change = None  # revert to the Majorana basis
 ```
@@ -100,7 +100,7 @@ independently of the structural cutoff:
 - `upper_atol`: accept terms with `|coeff| > upper_atol` regardless of the structural cutoff. Useful for
   keeping a few large terms that would otherwise be discarded by a tight cutoff.
 
-```python
+```python notest
 sim.lower_atol = 1e-9
 sim.upper_atol = 1e-3
 ```

--- a/docs/content/docs/features/evaluation.mdx
+++ b/docs/content/docs/features/evaluation.mdx
@@ -12,7 +12,7 @@ repeatedly at many parameter values.
 
 `expectation_value_functional` returns a callable that accepts a parameter vector:
 
-```python
+```python notest
 expval_fn = sim.expectation_value_functional(param_inds, gen_coeffs)
 expval = expval_fn(parameters)
 ```
@@ -22,7 +22,7 @@ expval = expval_fn(parameters)
 `expectation_value_and_gradient_functional` computes both the expectation value and the full
 parameter gradient in a single backward pass over the graph:
 
-```python
+```python notest
 expval_grad_fn = sim.expectation_value_and_gradient_functional(
     param_inds, gen_coeffs, pare_threshold=1e-7
 )
@@ -42,7 +42,7 @@ during replay. The stored graph itself is unchanged, only the replay skips the
 negligible terms, so this can dramatically speed up replay cost for sparse graphs
 (at the expense of some memory and accuracy):
 
-```python
+```python notest
 pared_expval_fn = sim.expectation_value_functional(param_inds, gen_coeffs, pare_threshold=1e-7)
 ```
 
@@ -54,7 +54,7 @@ replayed. The gates are contracted into the initial operator (Heisenberg picture
 or into the reference state (Schrödinger picture), and by default the simulator's
 internal graph is updated in place:
 
-```python
+```python notest
 # Fold the gates evaluated at these parameters into the operator, in place.
 sim.contract_partially(parameters, param_inds, gen_coeffs)
 ```
@@ -67,7 +67,7 @@ Pass `inplace=False` to leave the stored graph untouched and only return the
 contracted operator coefficients, so the same graph can be reused with different
 parameters:
 
-```python
+```python notest
 coeffs = sim.contract_partially(parameters, param_inds, gen_coeffs, inplace=False)
 ```
 

--- a/docs/content/docs/features/initialisation.mdx
+++ b/docs/content/docs/features/initialisation.mdx
@@ -28,15 +28,16 @@ The coefficients of the initial operator can be patched after construction
 without rebuilding the simulator or the graph:
 
 ```python
->>> from monoprop import MonomialPropagator
->>> from monoprop.fermi_data import MajoranaOperator, FermiCircuit
->>> observable = MajoranaOperator([(0, 1, 2, 3)], [1.0], 4)
->>> circuit = FermiCircuit(initial_state=[0, 1], gates=[])
->>> sim = MonomialPropagator(observable, circuit, cutoff=4)
+from monoprop import MonomialPropagator
+from monoprop.fermi_data import MajoranaOperator, FermiCircuit
+
+observable = MajoranaOperator([(0, 1, 2, 3)], [1.0], 4)
+circuit = FermiCircuit(initial_state=[0, 1], gates=[])
+sim = MonomialPropagator(observable, circuit, cutoff=4)
 # Keys are Majorana monomials (tuples of indices); values are the new
 # coefficients, which must keep each monomial Hermitian (real for length-4
 # terms, imaginary for length-2 — see the Notation page).
->>> sim.update_coeffs({(0, 1, 2, 3): 0.5})
+sim.update_coeffs({(0, 1, 2, 3): 0.5})
 ```
 
 This is particularly useful in the Schrödinger picture: since the state is
@@ -50,9 +51,14 @@ without re-propagating.
   `RuntimeError`:
 
   ```python
-  >>> sim.update_coeffs({(1, 2, 3, 4): 0.5})  # This monomial doesn't exist
-  Traceback (most recent call last):
-     ...
-  RuntimeError: ...
+  import pytest
+  from monoprop import MonomialPropagator
+  from monoprop.fermi_data import MajoranaOperator, FermiCircuit
+
+  observable = MajoranaOperator([(0, 1, 2, 3)], [1.0], 4)
+  circuit = FermiCircuit(initial_state=[0, 1], gates=[])
+  sim = MonomialPropagator(observable, circuit, cutoff=4)
+  with pytest.raises(RuntimeError):
+      sim.update_coeffs({(1, 2, 3, 4): 0.5})  # This monomial doesn't exist
   ```
 </Callout>

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -11,7 +11,7 @@ than would fit in memory on a single node.
 
 ### Single-node (`MPI.COMM_SELF`)
 
-```python
+```python notest
 from mpi4py import MPI
 sim = MonomialPropagator(..., comm=MPI.COMM_SELF)
 ```
@@ -20,7 +20,7 @@ sim = MonomialPropagator(..., comm=MPI.COMM_SELF)
 
 Replace the communicator and launch with `mpiexec`:
 
-```python
+```python notest
 from mpi4py import MPI
 sim = MonomialPropagator(..., comm=MPI.COMM_WORLD)
 ```

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -49,19 +49,19 @@ scaled by $i\sin\theta$). These are the real and imaginary parts of the
 rotation; see more in [Propagation Algorithm](/concepts/algorithm):
 
 ```python
->>> import numpy as np
->>> from monoprop import MonomialPropagator
->>> from monoprop.fermi_data import FermiCircuit, MajoranaOperator, FermiEvGate
->>> observable = MajoranaOperator([(0, 1, 2, 4)], [1.0], 8)  # 8 = number of fermionic modes
->>> generator = MajoranaOperator([(4, 5)], [1j], 8)  # i * m_4 m_5
->>> circuit = FermiCircuit(initial_state=[], gates=[FermiEvGate(generator, 0.5)])
->>> mbs = MonomialPropagator(observable, circuit, cutoff=16)
->>> mbs.propagate(evolve_with_coeffs=True)
->>> result = mbs.evolved_operator_dict()
->>> sorted(result)  # original (cosine) term plus the new (sine) term
-[(0, 1, 2, 4), (0, 1, 2, 5)]
->>> bool(np.isclose(result[(0, 1, 2, 4)].real, np.cos(2 * 0.5)))  # cosine branch
-True
+import numpy as np
+from monoprop import MonomialPropagator
+from monoprop.fermi_data import FermiCircuit, MajoranaOperator, FermiEvGate
+
+observable = MajoranaOperator([(0, 1, 2, 4)], [1.0], 8)  # 8 = number of fermionic modes
+generator = MajoranaOperator([(4, 5)], [1j], 8)  # i * m_4 m_5
+circuit = FermiCircuit(initial_state=[], gates=[FermiEvGate(generator, 0.5)])
+mbs = MonomialPropagator(observable, circuit, cutoff=16)
+mbs.propagate(evolve_with_coeffs=True)
+result = mbs.evolved_operator_dict()
+
+assert sorted(result) == [(0, 1, 2, 4), (0, 1, 2, 5)]  # original (cosine) term plus the new (sine) term
+assert np.isclose(result[(0, 1, 2, 4)].real, np.cos(2 * 0.5))  # cosine branch
 ```
 
 The same simulator works directly with qubit (Pauli) operators. The following
@@ -71,17 +71,17 @@ the Majorana basis (see [Notation](/concepts/notation)), so the gate likewise sp
 $Z \otimes Z$ into two terms — keyed by Majorana indices:
 
 ```python
->>> import numpy as np
->>> from monoprop import MonomialPropagator
->>> from monoprop.pauli_data import PauliOperator, PauliEvGate, PauliEvCircuit
->>> observable = PauliOperator(["ZZ"], [1.0])
->>> gate = PauliEvGate([0], PauliOperator(["X"], [1.0]), 0.5)  # exp(-i * 0.5 * X_0)
->>> circuit = PauliEvCircuit(gates=[gate], initial_state=[], num_qubits=2)
->>> mbs = MonomialPropagator(observable, circuit, cutoff=16)
->>> mbs.propagate(evolve_with_coeffs=True)
->>> result = mbs.evolved_operator_dict()  # WARNING: keys are Majorana indices, not Pauli strings
->>> sorted(result)
-[(0, 1, 2, 3), (1, 2, 3)]
->>> bool(np.isclose(result[(0, 1, 2, 3)].real, -np.cos(2 * 0.5)))  # cosine branch
-True
+import numpy as np
+from monoprop import MonomialPropagator
+from monoprop.pauli_data import PauliOperator, PauliEvGate, PauliEvCircuit
+
+observable = PauliOperator(["ZZ"], [1.0])
+gate = PauliEvGate([0], PauliOperator(["X"], [1.0]), 0.5)  # exp(-i * 0.5 * X_0)
+circuit = PauliEvCircuit(gates=[gate], initial_state=[], num_qubits=2)
+mbs = MonomialPropagator(observable, circuit, cutoff=16)
+mbs.propagate(evolve_with_coeffs=True)
+result = mbs.evolved_operator_dict()  # WARNING: keys are Majorana indices, not Pauli strings
+
+assert sorted(result) == [(0, 1, 2, 3), (1, 2, 3)]
+assert np.isclose(result[(0, 1, 2, 3)].real, -np.cos(2 * 0.5))  # cosine branch
 ```

--- a/justfile
+++ b/justfile
@@ -107,7 +107,7 @@ doctest-py:
     {{ docs_uv }} python -m pytest --doctest-modules src/monoprop
 
 doctest-docs:
-    {{ docs_uv }} python -m pytest --markdown-docs docs/content/docs --ignore=docs/content/docs/tutorials
+    {{ docs_uv }} python -m pytest --markdown-docs docs/content/docs --ignore=docs/content/docs/tutorials --ignore=docs/content/docs/api
 
 # Build the static documentation site into `docs/out`.
 build-docs: docs-install gen-api doctest-py doctest-docs gen-notebooks

--- a/justfile
+++ b/justfile
@@ -106,8 +106,11 @@ gen-api:
 doctest-py:
     {{ docs_uv }} python -m pytest --doctest-modules src/monoprop
 
+doctest-docs:
+    {{ docs_uv }} python -m pytest --markdown-docs docs/content/docs --ignore=docs/content/docs/tutorials
+
 # Build the static documentation site into `docs/out`.
-build-docs: docs-install gen-api doctest-py gen-notebooks
+build-docs: docs-install gen-api doctest-py doctest-docs gen-notebooks
     cd {{ site }} && npm run build
 
 # Serve the documentation locally with hot reloading.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = ["coverage", "prek>=0.4", "ruff==0.14.8", "gcovr"]
 # Python's only roles are converting the tutorial notebooks to Markdown
 # (`nbconvert`) and generating the API reference from docstrings (`griffe`,
 # injected via the `fumadocs-python` npm package in the `gen-api` recipe).
-docs = ["nbconvert", { include-group = "interactive" }]
+docs = ["nbconvert", "pytest-markdown-docs", { include-group = "interactive" }]
 interactive = [
   "ipykernel",
   "matplotlib",

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1075,6 +1075,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1225,6 +1237,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mistune"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1277,6 +1298,7 @@ docs = [
     { name = "monoprop", extra = ["openfermion", "pyscf", "qiskit"] },
     { name = "nbconvert" },
     { name = "pylatexenc" },
+    { name = "pytest-markdown-docs" },
 ]
 interactive = [
     { name = "ipykernel" },
@@ -1326,6 +1348,7 @@ docs = [
     { name = "monoprop", extras = ["qiskit", "openfermion", "pyscf"] },
     { name = "nbconvert" },
     { name = "pylatexenc" },
+    { name = "pytest-markdown-docs" },
 ]
 interactive = [
     { name = "ipykernel" },
@@ -2031,6 +2054,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/46/db060b291999ca048edd06d6fa9ee95945d088edc38b1172c59eeb46ec45/pytest_datadir-1.8.0.tar.gz", hash = "sha256:7a15faed76cebe87cc91941dd1920a9a38eba56a09c11e9ddf1434d28a0f78eb", size = 11848, upload-time = "2025-07-30T13:52:12.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/7a/33895863aec26ac3bb5068a73583f935680d6ab6af2a9567d409430c3ee1/pytest_datadir-1.8.0-py3-none-any.whl", hash = "sha256:5c677bc097d907ac71ca418109adc3abe34cf0bddfe6cf78aecfbabd96a15cf0", size = 6512, upload-time = "2025-07-30T13:52:11.525Z" },
+]
+
+[[package]]
+name = "pytest-markdown-docs"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/c7/6953e9e25d90d038600e65b05265693aef7ae2a2b67e0f170d65f4f16c24/pytest_markdown_docs-0.9.2.tar.gz", hash = "sha256:bf7510fdeec90d3e98ac924561c01de8dbaf4c3ad34f2418ed2b0b12e5a3f4f5", size = 10929, upload-time = "2026-03-23T12:35:04.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/b9/c3df11997d29e69b3f8edae1e903bf44eaf4774ccf4c5b6ddcebde88931c/pytest_markdown_docs-0.9.2-py3-none-any.whl", hash = "sha256:9c05a5bee48214cb36583d4a5131d3a23b327a8d82c92ae860106053fd7d1f9e", size = 13536, upload-time = "2026-03-23T12:35:03.862Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
We need a lightweight doctest-like check for Python snippets in the docs, without adding custom parsing code, and tutorial notebooks are already validated separately.

## What changed
- Added `pytest-markdown-docs` to the docs dependency group and updated `uv.lock`.
- Added `just doctest-docs` to run fenced Python blocks in `docs/content/docs` while excluding `docs/content/docs/tutorials`.
- Wired `doctest-docs` into `just build-docs`.
- Converted docs examples that used `>>>` prompts to plain runnable Python with explicit assertions.
- Marked intentionally illustrative snippet blocks as `python notest` where variables are placeholders (for example `sim`, `parameters`).

## Notes for reviewers
- This keeps notebook validation unchanged (`gen-notebooks` remains the notebook execution path).
- The new docs code-block check is strict for runnable snippets while letting narrative-only examples stay concise via `notest`.

## Validation
- Updated lockfile after dependency change.
- Added and wired the new docs doctest recipe.
- Local execution in this environment is blocked before tests run because CMake cannot find TBB (`TBBConfig.cmake`).