### PR TITLE
docs: Remove duplicate warning callout in index.mdx

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -9,10 +9,6 @@ Operators and states are expressed in the Majorana basis, with two front-ends:
 `MajoranaPropagator` for native Majorana and fermionic problems, and
 `PauliPropagator` for qubit (Pauli) problems.
 
-<Callout title="Warning" type="warn">
-This package is under active development. This project follows [Semantic Versioning](https://semver.org/). While in `0.x.y`, breaking changes may occur in minor releases.
-Pin your version if you depend on it. If you have feedback, please [open an issue](https://github.com/Algorithmiq/monoprop/issues/new).
-</Callout>
 
 <Callout title="Warning" type="warn">
 This package is under active development. This project follows [Semantic Versioning](https://semver.org/). While in `0.x.y`, breaking changes may occur in minor releases.


### PR DESCRIPTION
Removed duplicate warning callout about package development status.