### PR TITLE
refactor: :recycle: Better error message in from_qiskit_circuit when multiple registers are provided

### DIFF
--- a/src/monoprop/qiskit_conversion.py
+++ b/src/monoprop/qiskit_conversion.py
@@ -126,6 +126,11 @@ def from_qiskit_circuit(
     Returns:
         A :class:`~monoprop.circuit.Circuit` representing the given circuit.
     """
+    if len(circuit.qregs) != 1:
+        raise ValueError(
+            f"from_qiskit_circuit only supports a single quantum register; got {len(circuit.qregs)}."
+        )
+
     gates: list[ExpGate] = []
     parameters: list[float] = []
     qregs = circuit.qregs[0]

--- a/tests/test_qiskit_conversion.py
+++ b/tests/test_qiskit_conversion.py
@@ -24,6 +24,7 @@ from pytest_cases import case, parametrize_with_cases
 
 try:
     from qiskit import QuantumCircuit
+    from qiskit.circuit import QuantumRegister
     from qiskit.circuit.library import PauliEvolutionGate
     from qiskit.quantum_info import SparsePauliOp
 
@@ -296,3 +297,18 @@ def test_to_qiskit_circuit_rejects_unbound() -> None:
     )  # no parameter values
     with pytest.raises(ValueError, match="bound circuit"):
         to_qiskit_circuit(circuit, num_qubits=1)
+
+
+@requires_qiskit
+@pytest.mark.qiskit
+def test_from_qiskit_circuit_rejects_multiple_registers() -> None:
+    """from_qiskit_circuit on a circuit with multiple registers raises a clear error."""
+    qreg1 = QuantumRegister(1)
+    qreg2 = QuantumRegister(1)
+    circuit = QuantumCircuit(qreg1, qreg2)
+
+    with pytest.raises(
+        ValueError,
+        match=r"from_qiskit_circuit only supports a single quantum register; got 2.",
+    ):
+        from_qiskit_circuit(circuit, [0, 1])


### PR DESCRIPTION
- [x] added explicit assertion for multiple quantum registers
- [x] test for the new error raise 

Closes #69 