### PR TITLE
refactor: :recycle: qiskit rotation rescaling moved to generator

### DIFF
--- a/src/monoprop/qiskit_conversion.py
+++ b/src/monoprop/qiskit_conversion.py
@@ -145,10 +145,10 @@ def from_qiskit_circuit(
                 from_qiskit_operator(g_op.operator), qubits, num_qubits
             )
         elif gate_name in PAULI_EVOLUTION_EQUIVALENT:
-            parameter = g_op.params[0] * 0.5
+            parameter = g_op.params[0]
             pauli_string = gate_name[1:].upper()  # Remove the leading 'R' and uppercase
             generator = PauliOperator._from_terms(
-                [Pauli(pauli_string, qubits)], [1.0], num_qubits=num_qubits
+                [Pauli(pauli_string, qubits)], [0.5], num_qubits=num_qubits
             )
         else:
             raise ValueError(

--- a/tests/test_qiskit_conversion.py
+++ b/tests/test_qiskit_conversion.py
@@ -237,11 +237,11 @@ class QiskitCircuitsCases:
         circuit.rz(0.7, 0)
         expected = Circuit(
             gates=(
-                ExpGate(PauliOperator({Pauli("X", 0): 1.0}, num_qubits=1)),
-                ExpGate(PauliOperator({Pauli("Y", 0): 1.0}, num_qubits=1)),
-                ExpGate(PauliOperator({Pauli("Z", 0): 1.0}, num_qubits=1)),
+                ExpGate(PauliOperator({Pauli("X", 0): 0.5}, num_qubits=1)),
+                ExpGate(PauliOperator({Pauli("Y", 0): 0.5}, num_qubits=1)),
+                ExpGate(PauliOperator({Pauli("Z", 0): 0.5}, num_qubits=1)),
             ),
-            parameters=(0.25, 0.15, 0.35),
+            parameters=(0.5, 0.3, 0.7),
             initial_state=(),
         )
         return circuit, expected


### PR DESCRIPTION
Moved the 0.5 rescaling as depicted in the file and mentioned in #70. 
The relevant test was updated and enough to test the behaviour

Closes #70 