### PR TITLE
fix: 🐛  magic eq method corrected for operators

### DIFF
--- a/src/monoprop/fermi.py
+++ b/src/monoprop/fermi.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from .conversion_utils import _n_product
 from .majorana import MajoranaOperator
 
@@ -192,9 +194,8 @@ class FermiOperator:
         rhs = other._as_dict()
 
         return all(
-            abs(lhs.get(term, 0) - rhs.get(term, 0))
-            <= atol + rtol * abs(rhs.get(term, 0))
-            for term in lhs.keys() | rhs.keys()
+            np.isclose(lhs.get(term, 0) - rhs.get(term, 0), 0, rtol=rtol, atol=atol)
+            for term in lhs | rhs
         )
 
     def get_majorana_operator(self) -> MajoranaOperator:

--- a/src/monoprop/majorana.py
+++ b/src/monoprop/majorana.py
@@ -177,9 +177,11 @@ class MajoranaOperator:
             raise TypeError(
                 f"Cannot compare MajoranaOperator with {type(other).__name__}."
             )
-        if self.num_modes != other.num_modes or self.terms.keys() != other.terms.keys():
+        if self.num_modes != other.num_modes:
             return False
         return all(
-            np.isclose(coef, other.terms[key], rtol=rtol, atol=atol)
-            for key, coef in self.terms.items()
+            np.isclose(
+                self.terms.get(key, 0), other.terms.get(key, 0), rtol=rtol, atol=atol
+            )
+            for key in self.terms | other.terms
         )

--- a/src/monoprop/pauli.py
+++ b/src/monoprop/pauli.py
@@ -196,14 +196,16 @@ class PauliOperator:
             raise TypeError(
                 f"Cannot compare PauliOperator with {type(other).__name__}."
             )
-        if (
-            self.num_qubits != other.num_qubits
-            or self.terms.keys() != other.terms.keys()
-        ):
+        if self.num_qubits != other.num_qubits:
             return False
         return all(
-            np.isclose(coef, other.terms[pauli], rtol=rtol, atol=atol)
-            for pauli, coef in self.terms.items()
+            np.isclose(
+                self.terms.get(pauli, 0.0),
+                other.terms.get(pauli, 0.0),
+                rtol=rtol,
+                atol=atol,
+            )
+            for pauli in self.terms | other.terms
         )
 
     def get_majorana_operator(self) -> MajoranaOperator:

--- a/src/monoprop/pauli.py
+++ b/src/monoprop/pauli.py
@@ -140,7 +140,7 @@ class PauliOperator:
         self.num_qubits = num_qubits
         if num_qubits is not None:
             for pauli in self.terms:
-                if pauli.qubits and max(pauli.qubits) >= num_qubits:
+                if pauli.qubits and pauli.qubits[-1] >= num_qubits:
                     raise ValueError(
                         f"Pauli term {pauli} acts on a qubit index >= num_qubits="
                         f"{num_qubits}."

--- a/tests/test_fermi.py
+++ b/tests/test_fermi.py
@@ -110,6 +110,74 @@ class TestFermiOperator:
         ):
             FermiOperator([], [])
 
+    @pytest.mark.parametrize(
+        ("left", "right", "expected"),
+        [
+            pytest.param(
+                FermiOperator(
+                    [FermiString([(0, "+")]), FermiString([(1, "-")])],
+                    [1.0, 0.5],
+                    num_modes=2,
+                ),
+                FermiOperator(
+                    [FermiString([(0, "+")]), FermiString([(1, "-")])],
+                    [1.0, 0.5],
+                    num_modes=2,
+                ),
+                True,
+                id="same",
+            ),
+            pytest.param(
+                FermiOperator([FermiString([(0, "+")])], [1.0], num_modes=2),
+                FermiOperator([FermiString([(0, "+")])], [1.0 + 1e-9], num_modes=2),
+                True,
+                id="within_atol",
+            ),
+            pytest.param(
+                FermiOperator([FermiString([(0, "+")])], [1.0], num_modes=2),
+                FermiOperator([FermiString([(0, "+")])], [1.1], num_modes=2),
+                False,
+                id="outside_atol",
+            ),
+            pytest.param(
+                FermiOperator([FermiString([(0, "+")])], [1e-16], num_modes=2),
+                FermiOperator([], [], num_modes=2),
+                True,
+                id="negligible_vs_missing",
+            ),
+            pytest.param(
+                FermiOperator([FermiString([(0, "+")])], [1.0], num_modes=2),
+                FermiOperator([FermiString([(1, "+")])], [1.0], num_modes=2),
+                False,
+                id="different_terms",
+            ),
+            pytest.param(
+                FermiOperator(
+                    [FermiString([(0, "+")]), FermiString([(1, "-")])],
+                    [1.0, 0.5],
+                    num_modes=2,
+                ),
+                FermiOperator([FermiString([(0, "+")])], [1.0], num_modes=2),
+                False,
+                id="different_num_terms",
+            ),
+            pytest.param(
+                FermiOperator([FermiString([(0, "+")])], [1.0], num_modes=2),
+                FermiOperator([FermiString([(0, "+")])], [1.0], num_modes=3),
+                False,
+                id="different_num_modes",
+            ),
+            pytest.param(
+                FermiOperator([FermiString([(0, "+"), (1, "-")])], [1.0], num_modes=2),
+                FermiOperator([FermiString([(1, "-"), (0, "+")])], [1.0], num_modes=3),
+                False,
+                id="same_after_canonicalization",
+            ),
+        ],
+    )
+    def test_is_closely_equal(self, left, right, expected):
+        assert left.isclose(right) is expected
+
 
 class TestMajoranaOperator:
     def test_valid_creation_and_repr(self):
@@ -174,7 +242,7 @@ class TestMajoranaOperator:
                 MajoranaOperator({(0, 1): 1.0}, num_modes=2),
                 MajoranaOperator({(0, 2): 1.0}, num_modes=2),
                 False,
-                id="different_strings",
+                id="different_terms",
             ),
             pytest.param(
                 MajoranaOperator({(0, 1): 1.0, (1, 2): 0.5}, num_modes=2),

--- a/tests/test_fermi.py
+++ b/tests/test_fermi.py
@@ -143,6 +143,56 @@ class TestMajoranaOperator:
 
         assert expected_terms == terms
 
+    @pytest.mark.parametrize(
+        ("left", "right", "expected"),
+        [
+            pytest.param(
+                MajoranaOperator({(0, 1): 1.0j, (1,): 0.5}, num_modes=2),
+                MajoranaOperator({(0, 1): 1.0j, (1,): 0.5}, num_modes=2),
+                True,
+                id="same",
+            ),
+            pytest.param(
+                MajoranaOperator({(0, 1): 1.0}, num_modes=2),
+                MajoranaOperator({(0, 1): 1.0 + 1e-9}, num_modes=2),
+                True,
+                id="within_atol",
+            ),
+            pytest.param(
+                MajoranaOperator({(0, 1): 1.0}, num_modes=2),
+                MajoranaOperator({(0, 1): 1.1}, num_modes=2),
+                False,
+                id="outside_atol",
+            ),
+            pytest.param(
+                MajoranaOperator({(0, 1): 1e-16}, num_modes=2),
+                MajoranaOperator({}, num_modes=2),
+                True,
+                id="negligible_vs_missing",
+            ),
+            pytest.param(
+                MajoranaOperator({(0, 1): 1.0}, num_modes=2),
+                MajoranaOperator({(0, 2): 1.0}, num_modes=2),
+                False,
+                id="different_strings",
+            ),
+            pytest.param(
+                MajoranaOperator({(0, 1): 1.0, (1, 2): 0.5}, num_modes=2),
+                MajoranaOperator({(0, 1): 1.0}, num_modes=2),
+                False,
+                id="different_num_terms",
+            ),
+            pytest.param(
+                MajoranaOperator({(0, 1): 1.0}, num_modes=2),
+                MajoranaOperator({(0, 1): 1.0}, num_modes=3),
+                False,
+                id="different_num_qubits",
+            ),
+        ],
+    )
+    def test_is_closely_equal(self, left, right, expected):
+        assert left.isclose(right) is expected
+
 
 def _number_op(mode: int = 0, num_modes: int = 1) -> FermiOperator:
     """The number operator n = c^+ c on ``mode``: a valid fermionic generator."""

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -221,8 +221,8 @@ class TestPauliOperator:
                 id="different_num_terms",
             ),
             pytest.param(
-                PauliOperator({"X": 1.0}, num_qubits=1),
                 PauliOperator({"XY": 1.0}, num_qubits=2),
+                PauliOperator({"XYI": 1.0}, num_qubits=3),
                 False,
                 id="different_num_qubits",
             ),

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -203,6 +203,12 @@ class TestPauliOperator:
                 id="outside_atol",
             ),
             pytest.param(
+                PauliOperator({"XX": 1e-16}, num_qubits=2),
+                PauliOperator({}, num_qubits=2),
+                True,
+                id="negligible_vs_missing",
+            ),
+            pytest.param(
                 PauliOperator({"XY": 1.0}, num_qubits=2),
                 PauliOperator({"XZ": 1.0}, num_qubits=2),
                 False,


### PR DESCRIPTION
- [x] corrected `__eq__` implementation for Majorana and Pauli operators
- [x] refactored `__eq__` for FermiOperator
- [x] added missing tests for `__eq__` for Fermi and Majorana operators
- [x] added tests for the prior bug for PauliOperator

Closes #73 