### PR TITLE
fix(ci): 🐛 merge duplicate gcovr coverage lines so SonarCloud credits real coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -353,9 +353,13 @@ jobs:
 
       - name: Convert C++ tracefiles to Cobertura XML
         run: |
+          # --merge-lines: collapse gcov's per-instantiation duplicate line
+          # records into one aggregated line each (see the SonarQube step for the
+          # full rationale) so the Codecov report reflects true line coverage.
           for f in cpp-coverage-*.json; do
             pipx run gcovr \
               --root . \
+              --merge-lines \
               --add-tracefile "$f" \
               --cobertura "${f%.json}.xml"
           done
@@ -396,8 +400,17 @@ jobs:
 
       - name: Combine C++ coverage tracefiles into one SonarQube report
         run: |
+          # --merge-lines collapses the multiple per-line coverage records that
+          # gcov emits for template instantiations (and across the native +
+          # python-bindings tracefiles) into a single lineToCover per source
+          # line, marked covered if ANY instantiation covers it. Without it the
+          # SonarQube report contains duplicate lineToCover entries whose
+          # covered= values conflict; SonarCloud keeps only the last, discarding
+          # most real coverage of the heavily-templated headers and sinking
+          # new_coverage far below the true value.
           pipx run gcovr \
             --root . \
+            --merge-lines \
             --add-tracefile 'cpp-coverage-*.json' \
             --sonarqube coverage_cpp.xml
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

SonarCloud's `new_coverage` is badly under-reported for the heavily-templated C++
headers, which fails the quality gate on PRs (e.g. #33 sat at `new_coverage=33.4%`
despite the code being well-tested).

Root cause is **not** a test gap — it's the coverage report. `gcov` emits *multiple*
coverage records per source line for templated headers (one per instantiation), with
hit/miss that differs across instantiations. The gcovr steps didn't aggregate these, so:

- the SonarQube report (`coverage_cpp.xml`) contained **duplicate `<lineToCover>` entries**
  for the same line with conflicting `covered=` values. SonarCloud keeps only one per line
  (~last-wins), discarding most real coverage of the templated headers.
- the Codecov cobertura reports had the same duplication.

## Fix

Add gcovr's `--merge-lines` to the two report-generating steps ("Combine C++ coverage
tracefiles into one SonarQube report" and "Convert C++ tracefiles to Cobertura XML") so each
source line is emitted **once**, marked covered if **any** instantiation covers it.

## Evidence

Reproduced from the **actual CI coverage artifacts**:

| | worst-affected header (`MonomialPropagatorImpl.h`) | C++ new-code |
|---|---|---|
| broken merge (last-wins) | ~11% | ~40% |
| with `--merge-lines` | ~84% | **~84%** |

No source or test changes — this only fixes how existing coverage is reported. `--merge-lines`
is a standard gcovr ≥8.0 flag; CI uses `pipx run gcovr` (unpinned).