### PR TITLE
fix(docs): 🐛 use static Orama search client for static export

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -8,7 +8,13 @@ export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     <html lang="en" className={gtPlanar.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider
+          // The docs site is exported as static files, so search must load the
+          // prebuilt Orama index instead of calling the dynamic query API.
+          search={{ options: { type: 'static', api: '/api/search' } }}
+        >
+          {children}
+        </RootProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
By opening this PR I confirm that I have read [CONTRIBUTING.md](CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](CLA.md).

## Summary

The docs site is built with `output: 'export'` (static Next.js export) and hosted on Cloudflare Pages. The default Fumadocs search setup uses a runtime fetch client that sends search queries to `/api/search` at query time. On a static host, that path only serves the prebuilt Orama index blob -- it cannot execute dynamic search queries -- so every search silently returned no results.

The fix is to configure `<RootProvider />` with `search.options.type = 'static'`, which tells Fumadocs to load the exported Orama index once client-side and run all searches entirely in-browser, which is the correct approach for static deployments.

## Changes

- Set `search={{ options: { type: 'static', api: '/api/search' } }}` on `<RootProvider />` in `docs/src/app/layout.tsx`

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: GitHub Copilot (claude-sonnet-4.6)