### PR TITLE
fix: links in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->
 
-By opening this PR I confirm that I have read [CONTRIBUTING.md](github.com/Algorithmiq/monoprop/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](github.com/Algorithmiq/monoprop/CLA.md).
+By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CLA.md).
 
 ## Summary
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->
 
-By opening this PR I confirm that I have read [CONTRIBUTING.md](CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](CLA.md).
+By opening this PR I confirm that I have read [CONTRIBUTING.md](github.com/Algorithmiq/monoprop/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](github.com/Algorithmiq/monoprop/CLA.md).
 
 ## Summary
 


### PR DESCRIPTION
Updated links in the PR template to point to the correct repository paths.

<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CLA.md).
## Summary

<!-- Provide a self-contained description of what this PR does and why.
     Explain the problem being solved and the approach taken. -->

## Changes

<!-- Bullet-point list of the main changes. -->

-

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [X] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->
