### PR TITLE
fix: 🐛  LaTeX build

### DIFF
--- a/docs/scripts/generate-api.mjs
+++ b/docs/scripts/generate-api.mjs
@@ -72,6 +72,30 @@ function foldToOneLine(text) {
 }
 
 /**
+ * Unescape braces within LaTeX/KaTeX math expressions.
+ *
+ * Upstream markdown serialization escapes braces (`\{` and `\}`), but KaTeX
+ * requires unescaped braces for proper grouping (subscripts, superscripts, and
+ * command arguments). This function selectively unescapes braces only inside
+ * `$...$` (inline) and `$$...$$` (display) math spans.
+ *
+ * Examples:
+ * - `$r_\{12\}$` -> `$r_{12}$`
+ * - `$$^\{-1\}$$` -> `$$^{-1}$$`
+ * - `$\mathrm\{d\}$` -> `$\mathrm{d}$`
+ */
+function normalizeMathGroupingEscapes(content) {
+  const normalizeMathSegment = (math) =>
+    math
+      .replace(/\\\{/g, '{')
+      .replace(/\\\}/g, '}');
+
+  return content.replace(/\$\$[\s\S]*?\$\$|\$(?:\\.|[^$\\])+\$/g, (math) =>
+    normalizeMathSegment(math),
+  );
+}
+
+/**
  * Extract the raw `Returns:` block from a function source docstring.
  * We prefer source extraction because some upstream parsed `returns.description`
  * values are already truncated to the first wrapped line.
@@ -163,6 +187,10 @@ async function main() {
     // `convert` keeps the package name ("monoprop") in hrefs, but `write`
     // strips that leading segment from file paths. Realign the links.
     file.content = file.content.replaceAll(`${BASE_URL}/monoprop`, BASE_URL);
+
+    // Fumadocs parameter rendering can escape braces in math arguments
+    // (e.g. `\mathrm\{d\}`), which breaks KaTeX grouping.
+    file.content = normalizeMathGroupingEscapes(file.content);
 
     // Add titles to the frontmatter for the modules we documented. The title
     // is used in the sidebar and in the page's <title> tag.

--- a/src/monoprop/circuit.py
+++ b/src/monoprop/circuit.py
@@ -82,7 +82,7 @@ class ExpGate:
     - :class:`~monoprop.majorana.MajoranaOperator` -- a Majorana generator carrying the
       *Hermitian* operator (its coefficients follow the same convention as an observable:
       imaginary for a weight-2 monomial, real for weight-4); it is antihermitian-normalized --
-      the Hermitian phase :math:`i^{\binom{w}{2}}` divided out -- by :func:`_gate_layers` when
+      the Hermitian phase $i^{\binom{w}{2}}$ divided out -- by :func:`_gate_layers` when
       the circuit is ingested. A coefficient that leaves a non-negligible imaginary residue
       after normalization is rejected as non-Hermitian.
     - :class:`~monoprop.pauli.PauliOperator` -- a qubit generator; each Pauli term is
@@ -91,7 +91,7 @@ class ExpGate:
     - :class:`~monoprop.fermi.FermiOperator` -- a fermionic generator; converted to its
       (Hermitian) Majorana form by :meth:`get_majorana_operator` right here in ``__init__``, so
       the gate *is* a ``"majorana"`` gate from then on. The fermionic-to-Majorana mapping already
-      carries the factors of :math:`\tfrac12` and the phases, so the resulting coefficients are
+      carries the factors of 1/2 and the phases, so the resulting coefficients are
       exactly the Hermitian convention above -- no separate fermionic normalization is needed.
 
     All three families thus take the **Hermitian** generator and normalize it identically; the
@@ -555,11 +555,11 @@ def _real_generator_coefficient(majorana: Sequence[int], value: complex) -> floa
 
 
 def _antihermitian_gen_coeff(majorana: Sequence[int], coeff: complex) -> float:
-    """Antihermitian-normalize a raw Majorana-product coefficient to a real ``g``.
+    r"""Antihermitian-normalize a raw Majorana-product coefficient to a real ``g``.
 
-    A physical generator's coefficient on the raw product ``m_{i_1}...m_{i_w}`` is
+    A physical generator's coefficient on the raw product $m_{i_1}...m_{i_w}$ is
     turned into the real structural coefficient of the antihermitian generator the engine
-    rotates by, dividing out the Hermitian phase ``(1j)**(w(w-1)/2)``. Raises ``ValueError``
+    rotates by, dividing out the Hermitian phase $1j^{\binom{w}{2}}$. Raises ``ValueError``
     if the result is not real (i.e. the generator is not Hermitian).
     """
     weight = len(majorana)
@@ -581,12 +581,12 @@ def _paulis_commute(p1: Pauli, p2: Pauli) -> bool:
 
 
 def _validate_commuting_pauli_generator(generator: PauliOperator) -> None:
-    """Reject a multi-term Pauli generator whose terms do not pairwise commute.
+    r"""Reject a multi-term Pauli generator whose terms do not pairwise commute.
 
     A gate is a single exponential of its generator, but :func:`_gate_layers` realizes a
     multi-term generator as a *product* of one rotation per term
-    (``exp(theta*g_1*P_1) * exp(theta*g_2*P_2) * ...``). That product equals
-    ``exp(theta * sum_i g_i*P_i)`` only when the Pauli terms mutually commute; otherwise the
+    $\exp(\theta g_1 P_1) \cdot \exp(\theta g_2 P_2) \cdot ...$. That product equals
+    $\exp(\theta \sum_i g_i P_i)$ only when the Pauli terms mutually commute; otherwise the
     evolution would be silently Trotterized. Fail loudly instead (mirroring the check the old
     ``PauliEvGate`` enforced).
 
@@ -612,11 +612,11 @@ def _majoranas_commute(m1: Sequence[int], m2: Sequence[int]) -> bool:
 
 
 def _validate_commuting_majorana_generator(generator: MajoranaOperator) -> None:
-    """Reject a multi-term Majorana generator whose terms do not pairwise commute.
+    r"""Reject a multi-term Majorana generator whose terms do not pairwise commute.
 
     A gate is a single exponential of its generator, but :func:`_gate_layers` realizes a
     multi-term generator as a product of one rotation per term. That product equals
-    ``exp(theta * sum_i g_i*M_i)`` only when the Majorana monomials mutually commute;
+    $\exp(\theta \sum_i g_i M_i)$ only when the Majorana monomials mutually commute;
     otherwise the evolution would be silently Trotterized.
 
     Raises:
@@ -634,13 +634,13 @@ def _validate_commuting_majorana_generator(generator: MajoranaOperator) -> None:
 def _gate_layers(
     gate: ExpGate, num_qubits: int | None
 ) -> list[tuple[tuple[int, ...], float]]:
-    """Expand one gate into ``(majorana, gen_coeff)`` layers, in application order.
+    r"""Expand one gate into ``(majorana, gen_coeff)`` layers, in application order.
 
     A ``"pauli"``-family :class:`ExpGate` places each :class:`~monoprop.pauli.Pauli` term on
     its qubits within the ``num_qubits``-wide system, Jordan-Wigner maps it, and
     antihermitian-normalizes (one layer per term). A ``"majorana"``-family :class:`ExpGate` carries
     the Hermitian generator, so its :class:`~monoprop.majorana.MajoranaOperator` terms are
-    antihermitian-normalized the same way (the ``i^{binom(w, 2)}`` phase divided out) -- unless
+    antihermitian-normalized the same way (the $i^{\binom{w}{2}}$ phase divided out) -- unless
     the gate is flagged :attr:`ExpGate._structural` (the wire/dense format), whose coefficients are
     already the structural ``g`` and are used directly.
     """

--- a/src/monoprop/majorana.py
+++ b/src/monoprop/majorana.py
@@ -26,12 +26,13 @@ if TYPE_CHECKING:
 
 
 class Majorana:
-    """A single Majorana monomial: the ordered product ``m_{i_1} ... m_{i_w}``.
+    """A single Majorana monomial.
 
-    A term is the atom a :class:`MajoranaOperator` is built from and the generator an
+    Represents an ordered product $m_{i_1} ... m_{i_w}$. A term is the atom a
+    :class:`MajoranaOperator` is built from and the generator an
     :class:`~monoprop.circuit.ExpGate` gate exponentiates. Indices are sorted on construction
     (matching the operator's canonicalization) and must be distinct and non-negative. A
-    repeated index is rejected because ``m_i^2 = 1`` would silently change the monomial's
+    repeated index is rejected because $m_i^2 = 1$ would silently change the monomial's
     weight -- almost always a mistake rather than an intended simplification.
 
     An immutable value object: equal indices compare equal and hash alike, so a term can be

--- a/src/monoprop/majorana_propagator.py
+++ b/src/monoprop/majorana_propagator.py
@@ -77,7 +77,7 @@ class MajoranaPropagator(MonomialPropagator):
                 Majorana monomials retained during evolution; its meaning depends on
                 ``cutoff_type``. Higher values increase accuracy at greater cost. A
                 *fully paired* monomial -- one whose support consists entirely of
-                complete pairs ``(m_{2j-1} m_{2j})`` on a mode -- is always kept
+                complete pairs $(m_{2j-1} m_{2j})$ on a mode -- is always kept
                 regardless of this cutoff, because only paired monomials can contribute
                 to an expectation value against a computational-basis state or Slater
                 determinant; discarding them would throw away signal.


### PR DESCRIPTION
<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CLA.md).

## Summary

This PRs fixes bugged LaTeX expressions rendering.

Closes #111 


## Changes

- [x] undoing unwanted `\` addition before `{` and `}` in math expressions
- [x] in relevant docstrings, math expression are now in $...$
## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Sonnet 4.6

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->
