### PR TITLE
feat: ✨  Method for checking commutativity for operators

### DIFF
--- a/src/monoprop/circuit.py
+++ b/src/monoprop/circuit.py
@@ -51,12 +51,11 @@ circuit, :class:`~monoprop.pauli_propagator.PauliPropagator` a qubit circuit.
 
 from __future__ import annotations
 
-import itertools
 from typing import TYPE_CHECKING, Literal
 
 from .conversion_utils import _extend_pauli_string, _pauli_to_majorana
 from .majorana import MajoranaOperator
-from .pauli import Pauli, PauliOperator
+from .pauli import PauliOperator
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -158,10 +157,10 @@ class ExpGate:
 
         self.generator = self._truncated_term(generator, atol)
 
-        if isinstance(self.generator, PauliOperator):
-            _validate_commuting_pauli_generator(self.generator)
-        elif isinstance(self.generator, MajoranaOperator):
-            _validate_commuting_majorana_generator(self.generator)
+        if not self.generator.all_pairwise_commute():
+            raise ValueError(
+                "The provided generator must be composed of commuting terms."
+            )
 
         self.index = None if index is None else int(index)
         self.family = family
@@ -565,70 +564,6 @@ def _antihermitian_gen_coeff(majorana: Sequence[int], coeff: complex) -> float:
     weight = len(majorana)
     gen = -coeff / (1j) ** (weight * (weight - 1) / 2)
     return _real_generator_coefficient(majorana, gen)
-
-
-def _paulis_commute(p1: Pauli, p2: Pauli) -> bool:
-    """Whether two Pauli terms commute as operators.
-
-    Two Paulis anticommute iff they act with *different* non-identity letters on an odd number
-    of shared qubits (:class:`~monoprop.pauli.Pauli` drops identity letters on
-    construction, so every letter here is non-trivial).
-    """
-    op1 = dict(zip(p1.qubits, p1.string, strict=True))
-    op2 = dict(zip(p2.qubits, p2.string, strict=True))
-    anticommuting = sum(1 for q in op1.keys() & op2.keys() if op1[q] != op2[q])
-    return anticommuting % 2 == 0
-
-
-def _validate_commuting_pauli_generator(generator: PauliOperator) -> None:
-    """Reject a multi-term Pauli generator whose terms do not pairwise commute.
-
-    A gate is a single exponential of its generator, but :func:`_gate_layers` realizes a
-    multi-term generator as a *product* of one rotation per term
-    (``exp(theta*g_1*P_1) * exp(theta*g_2*P_2) * ...``). That product equals
-    ``exp(theta * sum_i g_i*P_i)`` only when the Pauli terms mutually commute; otherwise the
-    evolution would be silently Trotterized. Fail loudly instead (mirroring the check the old
-    ``PauliEvGate`` enforced).
-
-    Raises:
-        ValueError: If any two terms of ``generator`` anticommute.
-    """
-    for p1, p2 in itertools.combinations(generator.terms, 2):
-        if not _paulis_commute(p1, p2):
-            raise ValueError(
-                "A multi-term Pauli gate generator must have mutually commuting terms so the "
-                f"gate is a single exponential of their sum; {p1} and {p2} anticommute."
-            )
-
-
-def _majoranas_commute(m1: Sequence[int], m2: Sequence[int]) -> bool:
-    """Whether two Majorana monomials commute as operators.
-
-    For canonicalized monomials with distinct indices, swapping the products contributes
-    the sign ``(-1)**(len(m1)*len(m2) - |set(m1) & set(m2)|)``.
-    """
-    n_common = len(set(m1) & set(m2))
-    return ((len(m1) * len(m2) - n_common) % 2) == 0
-
-
-def _validate_commuting_majorana_generator(generator: MajoranaOperator) -> None:
-    """Reject a multi-term Majorana generator whose terms do not pairwise commute.
-
-    A gate is a single exponential of its generator, but :func:`_gate_layers` realizes a
-    multi-term generator as a product of one rotation per term. That product equals
-    ``exp(theta * sum_i g_i*M_i)`` only when the Majorana monomials mutually commute;
-    otherwise the evolution would be silently Trotterized.
-
-    Raises:
-        ValueError: If any two terms of ``generator`` anticommute.
-    """
-    for m1, m2 in itertools.combinations(generator.terms, 2):
-        if not _majoranas_commute(m1, m2):
-            raise ValueError(
-                "A multi-term Majorana gate generator must have mutually commuting terms "
-                "so the gate is a single exponential of their sum; "
-                f"{tuple(m1)} and {tuple(m2)} anticommute."
-            )
 
 
 def _gate_layers(

--- a/src/monoprop/majorana.py
+++ b/src/monoprop/majorana.py
@@ -200,8 +200,9 @@ class MajoranaOperator:
         Returns:
             True if all pairs of terms commute, else False.
         """
-        for left, right in itertools.combinations(self.terms, 2):
-            overlap = len(set(left) & set(right))
+        ops_sets = [set(key) for key in self.terms]
+        for left, right in itertools.combinations(ops_sets, 2):
+            overlap = len(left & right)
             if (len(left) * len(right) - overlap) % 2 != 0:
                 return False
         return True

--- a/src/monoprop/majorana.py
+++ b/src/monoprop/majorana.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import itertools
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -189,3 +190,18 @@ class MajoranaOperator:
             )
             for key in self.terms | other.terms
         )
+
+    def all_pairwise_commute(self) -> bool:
+        r"""Whether every pair of Majorana monomials in the operator commutes.
+
+        For Majorana monomials $M_1$ and $M_2$ with supports $S_1$ and $S_2$, they
+        commute if $|S_1||S_2| - |S_1 \cap S_2|$ is even.
+
+        Returns:
+            True if all pairs of terms commute, else False.
+        """
+        for left, right in itertools.combinations(self.terms, 2):
+            overlap = len(set(left) & set(right))
+            if (len(left) * len(right) - overlap) % 2 != 0:
+                return False
+        return True

--- a/src/monoprop/majorana.py
+++ b/src/monoprop/majorana.py
@@ -195,7 +195,7 @@ class MajoranaOperator:
     def all_pairwise_commute(self) -> bool:
         r"""Whether every pair of Majorana monomials in the operator commutes.
 
-        For Majorana monomials $M_1$ and $M_2$ with supports $S_1$ and $S_2$, they
+        For [Majorana monomials][monoprop.majorana.Majorana] $M_1$ and $M_2$ with supports $S_1$ and $S_2$, they
         commute if $|S_1||S_2| - |S_1 \cap S_2|$ is even.
 
         Returns:

--- a/src/monoprop/pauli.py
+++ b/src/monoprop/pauli.py
@@ -239,9 +239,9 @@ class PauliOperator:
     def all_pairwise_commute(self) -> bool:
         r"""Whether every pair of Pauli terms in the operator commutes.
 
-        Returns ``True`` exactly when for every pair of Pauli terms $P_1, P_2$ are commuting
-        Equivalently, the number of qubits for which $P_1$ and $P_2$ have different
-        non-identity letters is even.
+        Returns ``True`` exactly when for every pair of [Pauli][monoprop.pauli.Pauli]
+        terms $P_1, P_2$ are commuting. Equivalently, the number of qubits for which
+        $P_1$ and $P_2$ have different non-identity letters is even.
 
         Returns:
             True if all pairs of terms commute, else False.

--- a/src/monoprop/pauli.py
+++ b/src/monoprop/pauli.py
@@ -246,13 +246,11 @@ class PauliOperator:
         Returns:
             True if all pairs of terms commute, else False.
         """
-        for left, right in itertools.combinations(self.terms, 2):
-            left_ops = dict(zip(left.qubits, left.string, strict=True))
-            right_ops = dict(zip(right.qubits, right.string, strict=True))
+        ops_dicts = [dict(zip(op.qubits, op.string, strict=True)) for op in self.terms]
+        for left_ops, right_ops in itertools.combinations(ops_dicts, 2):
             anticommute_count = sum(
-                1
+                left_ops[qubit] != right_ops[qubit]
                 for qubit in left_ops.keys() & right_ops.keys()
-                if left_ops[qubit] != right_ops[qubit]
             )
             if anticommute_count % 2 != 0:
                 return False

--- a/src/monoprop/pauli.py
+++ b/src/monoprop/pauli.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import itertools
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -234,3 +235,25 @@ class PauliOperator:
             majoranas.append(majorana)
             coefficients.append(jw_coeff * coeff)
         return MajoranaOperator._from_terms(majoranas, coefficients, self.num_qubits)
+
+    def all_pairwise_commute(self) -> bool:
+        r"""Whether every pair of Pauli terms in the operator commutes.
+
+        Returns ``True`` exactly when for every pair of Pauli terms $P_1, P_2$ are commuting
+        Equivalently, the number of qubits for which $P_1$ and $P_2$ have different
+        non-identity letters is even.
+
+        Returns:
+            True if all pairs of terms commute, else False.
+        """
+        for left, right in itertools.combinations(self.terms, 2):
+            left_ops = dict(zip(left.qubits, left.string, strict=True))
+            right_ops = dict(zip(right.qubits, right.string, strict=True))
+            anticommute_count = sum(
+                1
+                for qubit in left_ops.keys() & right_ops.keys()
+                if left_ops[qubit] != right_ops[qubit]
+            )
+            if anticommute_count % 2 != 0:
+                return False
+        return True

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -691,7 +691,9 @@ def test_surplus_parameters_raise_not_truncated() -> None:
 
 def test_non_commuting_pauli_generator_rejected() -> None:
     """A multi-term Pauli gate whose terms anticommute is rejected at construction."""
-    with pytest.raises(ValueError, match="anticommute"):
+    with pytest.raises(
+        ValueError, match=r"The provided generator must be composed of commuting terms."
+    ):
         ExpGate(PauliOperator({Pauli("X", 0): 1.0, Pauli("Z", 0): 1.0}, num_qubits=1))
 
 
@@ -702,35 +704,6 @@ def test_commuting_pauli_generator_accepted() -> None:
             {Pauli("XX", (0, 1)): 1.0, Pauli("ZZ", (0, 1)): 1.0}, num_qubits=2
         )
     )
-
-
-@pytest.mark.parametrize(
-    ("terms", "should_raise"),
-    [
-        pytest.param({(0,): 1.0, (1,): 1.0}, True, id="odd_odd_anticommuting"),
-        pytest.param({(0, 1): 1.0j, (2, 3): 1.0j}, False, id="even_even_commuting"),
-        pytest.param(
-            {(0, 2, 3, 5): 1.0, (0, 2, 4, 6): 1.0},
-            False,
-            id="even_even_commuting_overlap",
-        ),
-        pytest.param(
-            {(0,): 1.0, (0, 1): 1.0}, True, id="mixed_parity_lengths_anticommuting"
-        ),
-        pytest.param(
-            {(0,): 1.0, (1, 2): 1.0}, False, id="mixed_parity_lengths_commuting"
-        ),
-    ],
-)
-def test_majorana_generator_commutation_validation(
-    terms: dict[tuple[int, ...], complex], *, should_raise: bool
-) -> None:
-    """Majorana multi-term gates are accepted iff all terms pairwise commute."""
-    if should_raise:
-        with pytest.raises(ValueError, match="anticommute"):
-            ExpGate(MajoranaOperator(terms, num_modes=10))
-    else:
-        ExpGate(MajoranaOperator(terms, num_modes=10))
 
 
 def test_build_graph_seed_parameters_accepts_numpy() -> None:

--- a/tests/test_majorana.py
+++ b/tests/test_majorana.py
@@ -94,6 +94,24 @@ def test_majorana_operator_from_dict_round_trips():
 
 
 @pytest.mark.parametrize(
+    ("terms", "expected"),
+    [
+        pytest.param({}, True, id="empty"),
+        pytest.param({(0,): 1.0}, True, id="single_term"),
+        pytest.param({(0, 1): 1.0j, (2, 3): 1.0j}, True, id="disjoint_even_even"),
+        pytest.param(
+            {(0, 2, 3, 5): 1.0, (0, 2, 4, 6): 1.0}, True, id="overlap_even_parity"
+        ),
+        pytest.param({(0,): 1.0, (1,): 1.0}, False, id="disjoint_odd_odd"),
+        pytest.param({(0,): 1.0, (0, 1): 1.0}, False, id="overlap_odd_parity"),
+    ],
+)
+def test_majorana_operator_all_pairwise_commute(terms, expected):
+    """Pairwise commutation follows the parity of ``|S_1||S_2| - |S_1 ∩ S_2|``."""
+    assert MajoranaOperator(terms, num_modes=10).all_pairwise_commute() is expected
+
+
+@pytest.mark.parametrize(
     ("left", "right", "expected"),
     [
         pytest.param(

--- a/tests/test_pauli.py
+++ b/tests/test_pauli.py
@@ -229,6 +229,27 @@ class TestPauliOperator:
         assert mon_op.terms == {(0, 1): pytest.approx(-1.0j)}
 
     @pytest.mark.parametrize(
+        ("terms", "expected"),
+        [
+            pytest.param({}, True, id="empty"),
+            pytest.param({Pauli("X", 0): 1.0}, True, id="single_term"),
+            pytest.param(
+                {Pauli("XX", (0, 1)): 1.0, Pauli("ZZ", (0, 1)): 1.0},
+                True,
+                id="different_letters_on_two_shared_qubits",
+            ),
+            pytest.param(
+                {Pauli("X", 0): 1.0, Pauli("Z", 0): 1.0},
+                False,
+                id="different_letters_on_one_shared_qubit",
+            ),
+        ],
+    )
+    def test_all_pairwise_commute(self, terms, expected):
+        """Pairwise commutation follows the parity of differing shared Pauli letters."""
+        assert PauliOperator(terms, num_qubits=2).all_pairwise_commute() is expected
+
+    @pytest.mark.parametrize(
         ("left", "right", "expected"),
         [
             pytest.param(

--- a/tests/test_qiskit_conversion.py
+++ b/tests/test_qiskit_conversion.py
@@ -300,16 +300,6 @@ class TestFromQiskitCircuit:
         with pytest.raises(ValueError, match="Unsupported gate"):
             from_qiskit_circuit(circuit, [])
 
-    def test_non_commuting_generator_rejected(self):
-        """A PauliEvolution gate with non-commuting terms is rejected on conversion."""
-        circuit = QuantumCircuit(1)
-        # X and Z on the same qubit anticommute, so this is not a single exponential.
-        operator = SparsePauliOp.from_list([("X", 0.5), ("Z", 0.5)])
-        circuit.append(PauliEvolutionGate(operator, time=0.7), [0])
-
-        with pytest.raises(ValueError, match="anticommute"):
-            from_qiskit_circuit(circuit, [])
-
 
 @requires_qiskit
 @pytest.mark.qiskit


### PR DESCRIPTION
<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CLA.md).

## Summary

PR provides new methods Majorana and PauliOperator that verifies if the generators is composed of commuting terms. The implementation of the method existed before, but was a private method executed in `ExpGate`

Closes #130 

## Changes

<!-- Bullet-point list of the main changes. -->

- [x] a new public method `all_pairwise_commute` for Pauli/MajoranaOperator
- [x] `ExpGate` and overall refactoring 
- [x] new tests for provided functionality
- [x] some tests for ExpGate removed; this is because it is enough in ExpGate to check if commutativity is verified, but it is not needed to double check if it understand commutativity relations correctly 

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Chat-GPT 5.4

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->
