### PR TITLE
docs: :memo: simplified technical paragraph

### DIFF
--- a/docs/notebooks/fermi_hubbard/fermi_hubbard.ipynb
+++ b/docs/notebooks/fermi_hubbard/fermi_hubbard.ipynb
@@ -136,13 +136,8 @@
    "id": "b350e43a",
    "metadata": {},
    "source": [
-    "Each local Hamiltonian term is converted to Majorana generators and packed into four parallel arrays required by `propagate`: \n",
-    "- Majorana index tuples (`majoranas`)\n",
-    "- Real prefactors (`gen_coeffs`)\n",
-    "- A group index mapping each generator to its local term (`param_inds`)\n",
-    "- The shared time step per group (`parameters`)\n",
-    "\n",
-    "The real prefactor is obtained by factoring out the imaginary phase $(-i)^{w(w-1)/2}$ from each complex Majorana coefficient, where $w$ is the monomial weight."
+    "Each local Hamiltonian term is converted to Majorana generators and packed into our internal representations of the circuit,\n",
+    "being a list of `ExpGate` objects."
    ]
   },
   {


### PR DESCRIPTION
<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CLA.md).

## Summary

In Fermi-Hubbard tutorial, there was likely a technical leftover of our internal data handling that does not need to be exposed to the user (+ it is probably outdated). I replaced it with something much less technical.

Closes #95 

## Changes
- [x] updated the docstring

## Checklist

- [ ] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [x] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->
