### PR TITLE
docs: :memo: sync AGENTS and README maintenance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ monoprop is a high-performance C++/Python hybrid library implementing Majorana a
 Key files:
 - `src/monoprop/monomial_propagator.py`: Main Python API
 - `include/monoprop/MonomialPropagator.h`: Core C++ simulator (1000+ lines)
-- `src/monoprop/bindings/bindings.cpp.in`: generated template for Python bindings, using the nanobind library.
+- `src/monoprop/bindings/bindings.cpp.in`: template for Python bindings, using the nanobind library. The corresponding source file is generated when configuring the project.
 
 
 ### Environment Management

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,14 @@ monoprop is a high-performance C++/Python hybrid library implementing Majorana a
 ## Architecture Overview
 
 - **Core C++ Engine**: High-performance simulation logic in `src/` and `include/monoprop/`
-- **Python Interface**: User-facing API in `src/monoprop/` with C++ bindings in `src/bindings/`
+- **Python Interface**: User-facing API in `src/monoprop/` with C++ bindings in `src/monoprop/bindings/`
 - **Template-Based Design**: Heavily templated C++ code with compile-time mode limits (`monoprop_MAX_NUM_MODES`)
 - **Generated Code**: Python dispatch and C++ bindings auto-generated via `tools/generate-*.py`
 
 Key files:
 - `src/monoprop/monomial_propagator.py`: Main Python API
 - `include/monoprop/MonomialPropagator.h`: Core C++ simulator (1000+ lines)
-- `src/bindings/bindings.cpp`: auto-generated Python bindings, using the nanobind library.
+- `src/monoprop/bindings/bindings.cpp.in`: generated template for Python bindings, using the nanobind library.
 
 
 ### Environment Management
@@ -81,9 +81,19 @@ mp = MonomialPropagator(operator, num_modes=4, ...)
 4. Use trailing return type syntax in function declarations.
 5. Add Doxygen docstrings.
 6. Implement in corresponding `.cpp` in `src/`
-7. Add Python bindings in `src/bindings/binder.h`
+7. Add Python bindings in `src/monoprop/bindings/binder.h`
 8. Regenerate bindings with `tools/generate-binders.py`
 9. Test with both C++ and Python tests
+
+## Documentation Maintenance Policy
+
+When changing behavior, APIs, build/test workflows, paths, or developer conventions:
+
+1. Update `AGENTS.md` in the same change.
+2. Update `README.md` in the same change.
+3. Update the docs under `docs/` for user-facing or contributor-facing guidance.
+4. Keep commands and paths consistent across all three (`AGENTS.md`, `README.md`, and `docs/`).
+5. If a section no longer reflects the codebase, either fix it immediately or remove it.
 
 ### Debugging Build Issues
 - Check `build/*/compile_commands.json` for compilation flags

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,7 @@ mp = MonomialPropagator(operator, num_modes=4, ...)
 5. Add Doxygen docstrings.
 6. Implement in corresponding `.cpp` in `src/`
 7. Add Python bindings in `src/monoprop/bindings/binder.h`
-8. Regenerate bindings with `tools/generate-binders.py`
-9. Test with both C++ and Python tests
+8. Test with both C++ and Python tests
 
 ## Documentation Maintenance Policy
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ just build-docs   # output: docs/out/
 just serve-docs   # live-reloading dev server
 ```
 
+### Keeping documentation up to date
+
+Any PR that changes behavior, public APIs, build/test commands, or repository paths
+must update the relevant docs in the same change:
+
+1. `AGENTS.md` for agent/developer workflow instructions.
+2. `README.md` for top-level usage and contributor guidance.
+3. `docs/` pages for user-facing and in-depth technical documentation.
+
 ## Citation
 
 If you use `monoprop` in your research, please cite:


### PR DESCRIPTION
By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CLA.md).

## Summary

This updates contributor-facing docs so the documented structure and maintenance expectations match the current repository layout and workflow. The goal is to reduce drift between implementation changes and project documentation.

## Changes

- Fixed stale binding paths in `AGENTS.md` (`src/bindings/...` -> `src/monoprop/bindings/...`) and updated the binding template reference to `src/monoprop/bindings/bindings.cpp.in`.
- Cleaned up duplicated wording in the repository rules section of `AGENTS.md`.
- Added a "Documentation Maintenance Policy" section to `AGENTS.md` requiring coordinated updates to `AGENTS.md`, `README.md`, and `docs/` when behavior, APIs, commands, or paths change.
- Added a matching "Keeping documentation up to date" section in `README.md`.

## Checklist

- [ ] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description:
  - GitHub Copilot CLI (GPT-5.3-Codex)
- [x] I used the following tool to generate or modify code:
  - GitHub Copilot CLI (GPT-5.3-Codex)