### PR TITLE
fix(cmake): 🐛 match four-digit binder batches so >=993 modes link

### DIFF
--- a/src/monoprop/bindings/CMakeLists.txt
+++ b/src/monoprop/bindings/CMakeLists.txt
@@ -94,7 +94,7 @@ file(
   # monoprop_MAX_NUM_MODES >= 993 emits four-digit batch ends (bind_up_to_1024.cpp). Match the
   # trailing digits too, or those translation units silently leave the target and the
   # bind_up_to_<end> that bind.h declares fails to link.
-  "${CMAKE_CURRENT_BINARY_DIR}/generated/bind_up_to_[0-9][0-9][0-9]*.cpp"
+  "${CMAKE_CURRENT_BINARY_DIR}/generated/bind_up_to_[0-9]*.cpp"
 )
 set(_bind_cpps_print "")
 foreach(_cpp IN LISTS _bind_cpps)

--- a/src/monoprop/bindings/CMakeLists.txt
+++ b/src/monoprop/bindings/CMakeLists.txt
@@ -90,7 +90,11 @@ file(
   GLOB _bind_cpps
   LIST_DIRECTORIES false
   CONFIGURE_DEPENDS
-  "${CMAKE_CURRENT_BINARY_DIR}/generated/bind_up_to_[0-9][0-9][0-9].cpp"
+  # Three digits is the zero-padded minimum from generate-binders.py ({end:03d}), not a maximum:
+  # monoprop_MAX_NUM_MODES >= 993 emits four-digit batch ends (bind_up_to_1024.cpp). Match the
+  # trailing digits too, or those translation units silently leave the target and the
+  # bind_up_to_<end> that bind.h declares fails to link.
+  "${CMAKE_CURRENT_BINARY_DIR}/generated/bind_up_to_[0-9][0-9][0-9]*.cpp"
 )
 set(_bind_cpps_print "")
 foreach(_cpp IN LISTS _bind_cpps)

--- a/src/monoprop/bindings/CMakeLists.txt
+++ b/src/monoprop/bindings/CMakeLists.txt
@@ -90,10 +90,6 @@ file(
   GLOB _bind_cpps
   LIST_DIRECTORIES false
   CONFIGURE_DEPENDS
-  # Three digits is the zero-padded minimum from generate-binders.py ({end:03d}), not a maximum:
-  # monoprop_MAX_NUM_MODES >= 993 emits four-digit batch ends (bind_up_to_1024.cpp). Match the
-  # trailing digits too, or those translation units silently leave the target and the
-  # bind_up_to_<end> that bind.h declares fails to link.
   "${CMAKE_CURRENT_BINARY_DIR}/generated/bind_up_to_[0-9]*.cpp"
 )
 set(_bind_cpps_print "")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/ed30341adbb0a8aea3aabac02ce329be61b2d92e/CLA.md).

## Summary

Building with `monoprop_MAX_NUM_MODES >= 993` fails to link. `tools/generate-binders.py` names each
generated dispatch translation unit with

```python
(output_dir / f"bind_up_to_{end:03d}.cpp")
```

where `03d` is a zero-padded **minimum** width, not a maximum. The CMake glob that collects those
files, however, is pinned to exactly three digits:

```cmake
"${CMAKE_CURRENT_BINARY_DIR}/generated/bind_up_to_[0-9][0-9][0-9].cpp"
```

So as soon as a batch end reaches four digits, that translation unit is silently dropped from the
target. `bind.h` still declares `bind_up_to_<end>` and `call.txt` still calls it, so the failure
surfaces as an undefined reference at link time rather than as a configuration error — which makes it
look like a toolchain problem rather than a missing source file.

The batch end crosses into four digits at `monoprop_MAX_NUM_MODES >= 993`. The default of 250 is
unaffected, which is why this has not shown up in CI or in normal use; it bites anyone building the
wide-mode configurations (the 1024-qubit end of the single-layer Pauli scaling study, in my case).

### Reproduction

Running the generator the way `src/monoprop/bindings/CMakeLists.txt` invokes it (`--batch-size 8`)
and then applying each glob with real `file(GLOB)` under CMake 3.31.5:

| `monoprop_MAX_NUM_MODES` | generated | matched by current glob | |
| --- | --- | --- | --- |
| 250 (default) | 1 | 1 | ok |
| 512 | 2 | 2 | ok |
| 992 | 4 | 4 | ok |
| **993** | 4 | **3** | **broken** |
| **1024** | 4 | **3** | **broken** |

At 1024 the dropped file is `bind_up_to_1024.cpp`, which is the only definition of mode blocks
800, 832, 864, 896, 928, 960, 992 and 1024.

## Changes

- `src/monoprop/bindings/CMakeLists.txt`: glob `bind_up_to_[0-9]*.cpp`, so any batch-end width is
  picked up rather than exactly three digits. `file(GLOB)` has no regex quantifier, so a bounded
  `[0-9]{1,4}` is not expressible; this also mirrors the generator's own cleanup glob at
  `generate-binders.py:80` (`bind_up_to_*.cpp`), and the generator emits nothing else by that name.

That is the whole change — one pattern, no new comments.

## Checklist

- [ ] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

On tests: the breakage is in build-system wiring, so there is no unit-test seam for it — catching it
automatically would mean a configure-only CI job at a wide `monoprop_MAX_NUM_MODES`, or a generator
assertion that every emitted `bind_up_to_*.cpp` is matched by the glob the build uses. Happy to add
either if you think it is worth the CI minutes; I did not want to bundle that decision into a
one-line fix.

Verified: at `MAX_NUM_MODES=1024` (`--batch-size 8`) the generator emits four translation units and
`file(GLOB)` with `bind_up_to_[0-9]*.cpp` matches all four, `bind_up_to_1024.cpp` — the one the old
pattern dropped — included. I have not run a full wide-mode compile in CI here.

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (claude-opus-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)
