### PR TITLE
fix: missing num_modes argument in hubbard bench

### DIFF
--- a/benches/_builders.py
+++ b/benches/_builders.py
@@ -242,6 +242,7 @@ def _hubbard_fermion_terms(config: HubbardConfig) -> list[FermiOperator]:
                 FermiOperator(
                     terms=op_terms,
                     coefficients=[-config.hopping, -config.hopping],
+                    num_modes=config.num_qubits,
                 )
             )
 
@@ -251,6 +252,7 @@ def _hubbard_fermion_terms(config: HubbardConfig) -> list[FermiOperator]:
             FermiOperator(
                 terms=[((up, "+"), (up, "-"), (down, "+"), (down, "-"))],
                 coefficients=[config.interaction],
+                num_modes=config.num_qubits,
             )
         )
 
@@ -261,6 +263,7 @@ def _hubbard_fermion_terms(config: HubbardConfig) -> list[FermiOperator]:
                 FermiOperator(
                     terms=[((m, "+"), (m, "-"))],
                     coefficients=[-config.chemical_potential],
+                    num_modes=config.num_qubits,
                 )
             )
 


### PR DESCRIPTION
<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

## Summary

<!-- Provide a self-contained description of what this PR does and why.
     Explain the problem being solved and the approach taken. -->

## Changes

<!-- Bullet-point list of the main changes. -->

-

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
