### PR TITLE
Fix Python API reference URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you are contributing on behalf of your employer, contact
 ## Documentation
 
 The documentation is built with [Fumadocs](https://fumadocs.dev/) and hosted at
-<https://docs.algorithmiq.fi/monoprop>. The Python API reference is generated from
+<https://docs.monoprop.algorithmiq.tech>. The Python API reference is generated from
 docstrings ([griffe](https://mkdocstrings.github.io/griffe/)) and the tutorials are
 executed from the notebooks in `docs/notebooks/`.  Building the documentation locally requires [npm](https://docs.npmjs.com/), the Node.js package manager. Once that is available, you can run:
 


### PR DESCRIPTION
Corrected the URL for the Python API reference in the documentation.

<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

## Summary

<!-- Provide a self-contained description of what this PR does and why.
     Explain the problem being solved and the approach taken. -->

## Changes

<!-- Bullet-point list of the main changes. -->

-

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [x] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
