### PR TITLE
fix: env-vars in test-mpi recipe in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,9 +38,9 @@ test:
 # Pass RANKS as either a single integer or a semicolon-separated list (e.g. "1;2;4").
 
 test-mpi RANKS='':
-    export OMPI_MCA_rmaps_base_oversubscribe="1"
     uv sync --all-extras --group test --reinstall-package monoprop --no-cache --config-settings-package="monoprop:cmake.define.monoprop_ENABLE_MPI=ON" -v
-    ranks="${1:-${monoprop_MPI_TEST_PROCS:-2}}"
+    export OMPI_MCA_rmaps_base_oversubscribe="1"; \
+    ranks="${1:-${monoprop_MPI_TEST_PROCS:-2}}"; 
     for r in ${ranks//;/ }; \
     do echo "Running full Python test suite with ${r} MPI rank(s)"; \
     mpiexec -n "$r" uv run --no-sync python -m pytest tests --with-mpi -v; \

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ test:
 test-mpi RANKS='':
     uv sync --all-extras --group test --reinstall-package monoprop --no-cache --config-settings-package="monoprop:cmake.define.monoprop_ENABLE_MPI=ON" -v
     export OMPI_MCA_rmaps_base_oversubscribe="1"; \
-    ranks="${1:-${monoprop_MPI_TEST_PROCS:-2}}"; 
+    ranks="${1:-${monoprop_MPI_TEST_PROCS:-2}}"; \
     for r in ${ranks//;/ }; \
     do echo "Running full Python test suite with ${r} MPI rank(s)"; \
     mpiexec -n "$r" uv run --no-sync python -m pytest tests --with-mpi -v; \


### PR DESCRIPTION
<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

## Summary

<!-- Provide a self-contained description of what this PR does and why.
     Explain the problem being solved and the approach taken. -->

:robot: _AI text below_ :robot:

This pull request makes a minor update to the `test-mpi` task in the `justfile`. The change moves the export of the `OMPI_MCA_rmaps_base_oversubscribe` environment variable to the same line as the other commands for better clarity and ensures it is set before running the test loop.

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
