### PR TITLE
feat(evolution): 🔍 attribute the layer build behind monoprop_LAYER_PROFILE

### DIFF
--- a/cpp/monoprop/detail/EnvConfig.h
+++ b/cpp/monoprop/detail/EnvConfig.h
@@ -24,6 +24,7 @@
 //   monoprop_NUM_THREADS    positive int (1..1e6), else ignored                → num_threads
 //   monoprop_PARTITION_PINNING  bool, default ON; 0/false disables per-core pinning → partition_pinning
 //   monoprop_PARTITIONS         int N | "auto" | "off"; parsed where it is used (resolve_partition_count_)
+//   monoprop_LAYER_PROFILE      bool, default OFF; per-partition layer-build attribution to stderr → layer_profile
 
 namespace monoprop::config {
 
@@ -57,6 +58,7 @@ inline auto parse_positive_int(const char *text) -> std::optional<int> {
 struct Settings {
     std::optional<int> num_threads;
     bool partition_pinning = true;
+    bool layer_profile = false;
 };
 
 // Parse the environment once; the Settings are cached and shared across TUs.
@@ -65,6 +67,7 @@ inline auto get() -> const Settings & {
         Settings s;
         s.num_threads = detail::parse_positive_int(std::getenv("monoprop_NUM_THREADS"));
         s.partition_pinning = detail::parse_flag(std::getenv("monoprop_PARTITION_PINNING"), true);
+        s.layer_profile = detail::parse_flag(std::getenv("monoprop_LAYER_PROFILE"), false);
         return s;
     }();
     return settings;

--- a/cpp/monoprop/detail/evolution/LayerProfile.h
+++ b/cpp/monoprop/detail/evolution/LayerProfile.h
@@ -1,0 +1,255 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Per-partition attribution of the layer build, opt-in via monoprop_LAYER_PROFILE.
+//
+// Two instruments with deliberately different costs:
+//   * phase timers and per-gate counters -- O(1) clock reads per gate, and per-term counters that
+//     live in locals and are folded into the slot once per gate, so the emit loop keeps its registers;
+//   * a store population sweep (k/d histograms, paired and overflow fractions) -- O(n), so it runs
+//     only on power-of-two gate indices, which also yields the population's growth curve for free.
+//
+// Slots are heap-allocated per thread and owned by the registry, never freed: a partition master can
+// outlive or predecease the dump, and a dangling slot would be a use-after-free in a diagnostic.
+// Output goes to stderr, like COMMPROF -- pytest's capture is fd-level, so reading it needs `-s`.
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "monoprop/detail/EnvConfig.h"
+
+namespace monoprop::detail::layer_profile {
+
+inline constexpr size_t kHistSlots = 34; // k, d clamped into [0, 33]; slot 33 is the overflow bucket
+
+struct alignas(64) Slot {
+    // Phase wall time. `index_ns` covers inverted-index rebuild/append, which is not a layer phase but
+    // is charged per gate and has never been attributed.
+    uint64_t fold_ns = 0;
+    uint64_t emit_ns = 0;
+    uint64_t index_ns = 0;
+    uint64_t resolve_ns = 0;
+    uint64_t insert_ns = 0;
+    uint64_t contract_ns = 0;
+    // Cross-rank legs. `layer_ns` brackets the whole of build_layer, so layer_ns minus the phases is
+    // the unattributed remainder -- without it a phase split says nothing about the wall time.
+    uint64_t sendbuf_ns = 0;  // packing queries (+values) into the contiguous send stream
+    uint64_t exchange_ns = 0; // inside MPI: both alltoallv legs
+    uint64_t incoming_ns = 0; // resolving other ranks' queries against this store
+    uint64_t layer_ns = 0;
+
+    uint64_t n_gates = 0;
+    uint64_t n_anti = 0;   // terms the fold marked anticommuting
+    uint64_t n_foll = 0;   // of those, followers
+    uint64_t n_emit = 0;   // reached emit_term_products (i.e. passed the dynamic gate)
+    uint64_t n_cutoff = 0; // fell through passes_with_popcount's early-out into cutoff_sums
+    uint64_t n_reject = 0; // dropped by the structural cutoff
+    uint64_t n_push = 0;   // query records pushed
+    uint64_t n_hit = 0;    // self-resolve hits
+    uint64_t n_miss = 0;   // self-resolve misses (deferred inserts)
+    uint64_t query_words = 0;
+
+    // Population sample, overwritten each time the sweep runs (last sample wins; the per-sample line
+    // is emitted at sweep time, so the growth curve is in the log even though only the last is here).
+    uint64_t pop_rows = 0;
+    uint64_t pop_paired = 0;
+    uint64_t pop_overflow = 0;
+    uint64_t k_hist[kHistSlots] = {};
+    uint64_t d_hist[kHistSlots] = {};
+};
+
+class Registry {
+public:
+    static auto add() -> Slot * {
+        auto &r = instance();
+        const std::lock_guard<std::mutex> lock(r.mu_);
+        r.slots_.push_back(std::make_unique<Slot>());
+        return r.slots_.back().get();
+    }
+
+    // Dumping from the destructor rather than a separate atexit object keeps the ordering sound:
+    // slot() evaluates config::get() before Registry::add(), so Settings is constructed first and
+    // therefore destroyed last, and nothing this reads can already be gone.
+    ~Registry() {
+        if (config::get().layer_profile) {
+            dump();
+        }
+    }
+    Registry(const Registry &) = delete;
+    Registry &operator=(const Registry &) = delete;
+    Registry(Registry &&) = delete;
+    Registry &operator=(Registry &&) = delete;
+
+    static auto dump() -> void {
+        auto &r = instance();
+        const std::lock_guard<std::mutex> lock(r.mu_);
+        size_t p = 0;
+        for (const auto &s : r.slots_) {
+            if (s->n_gates == 0) {
+                continue;
+            }
+            std::fprintf(stderr,
+                         "LAYERPROF part=%zu gates=%llu fold_s=%.4f emit_s=%.4f index_s=%.4f "
+                         "resolve_s=%.4f insert_s=%.4f contract_s=%.4f sendbuf_s=%.4f exchange_s=%.4f "
+                         "incoming_s=%.4f layer_s=%.4f anti=%llu foll=%llu emit=%llu "
+                         "cutoff=%llu reject=%llu push=%llu hit=%llu miss=%llu qbytes=%llu\n",
+                         p,
+                         ull(s->n_gates),
+                         to_s(s->fold_ns),
+                         to_s(s->emit_ns),
+                         to_s(s->index_ns),
+                         to_s(s->resolve_ns),
+                         to_s(s->insert_ns),
+                         to_s(s->contract_ns),
+                         to_s(s->sendbuf_ns),
+                         to_s(s->exchange_ns),
+                         to_s(s->incoming_ns),
+                         to_s(s->layer_ns),
+                         ull(s->n_anti),
+                         ull(s->n_foll),
+                         ull(s->n_emit),
+                         ull(s->n_cutoff),
+                         ull(s->n_reject),
+                         ull(s->n_push),
+                         ull(s->n_hit),
+                         ull(s->n_miss),
+                         ull(s->query_words * 8));
+            ++p;
+        }
+        std::fflush(stderr);
+    }
+
+private:
+    Registry() = default;
+    static auto instance() -> Registry & {
+        static Registry r;
+        return r;
+    }
+    static auto to_s(uint64_t ns) -> double { return static_cast<double>(ns) / 1e9; }
+    static auto ull(uint64_t v) -> unsigned long long { return static_cast<unsigned long long>(v); }
+
+    std::mutex mu_;
+    std::vector<std::unique_ptr<Slot>> slots_;
+};
+
+// nullptr when profiling is off, so every call site is one predictable branch and no clock is read.
+inline auto slot() -> Slot * {
+    static thread_local Slot *s = config::get().layer_profile ? Registry::add() : nullptr;
+    return s;
+}
+
+// RAII accumulator; inert when constructed with a null target, so instrumented regions need no #ifdef.
+class ScopedNs {
+public:
+    explicit ScopedNs(uint64_t *target) noexcept
+        : target_(target),
+          start_(target != nullptr ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{}) {}
+    ScopedNs(const ScopedNs &) = delete;
+    ScopedNs &operator=(const ScopedNs &) = delete;
+    ScopedNs(ScopedNs &&) = delete;
+    ScopedNs &operator=(ScopedNs &&) = delete;
+    ~ScopedNs() {
+        if (target_ != nullptr) {
+            const auto end = std::chrono::steady_clock::now();
+            *target_ +=
+                static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(end - start_).count());
+        }
+    }
+
+private:
+    uint64_t *target_;
+    std::chrono::steady_clock::time_point start_;
+};
+
+// O(n) over the store: k and d histograms, the fully-paired fraction and the overflow fraction --
+// the numbers that decide whether the paired-row and digest work is worth landing. Runs only on
+// power-of-two gate indices (see the file comment), so the log carries the growth curve.
+template <size_t NumModes, typename Store>
+auto sample_population(Slot *s, const Store &store, size_t gate_index) -> void {
+    if (s == nullptr) {
+        return;
+    }
+    const uint64_t g = s->n_gates;
+    if (g != 0 && (g & (g - 1)) != 0) {
+        return;
+    }
+    for (auto &v : s->k_hist) {
+        v = 0;
+    }
+    for (auto &v : s->d_hist) {
+        v = 0;
+    }
+    s->pop_rows = 0;
+    s->pop_paired = 0;
+    s->pop_overflow = 0;
+
+    const size_t n = store.size();
+    for (size_t i = 0; i < n; ++i) {
+        // Mode m owns physical bits (2m, 2m+1); d counts modes holding both, so on an ascending
+        // position list a pair is an even entry immediately followed by its successor.
+        size_t k = 0;
+        size_t d = 0;
+        size_t prev = static_cast<size_t>(-2);
+        store.for_each_position(i, [&](size_t pos) {
+            ++k;
+            if (pos == prev + 1 && (prev % 2) == 0) {
+                ++d;
+            }
+            prev = pos;
+        });
+        ++s->pop_rows;
+        s->k_hist[k < kHistSlots ? k : kHistSlots - 1] += 1;
+        s->d_hist[d < kHistSlots ? d : kHistSlots - 1] += 1;
+        if (k == 2 * d) {
+            ++s->pop_paired;
+        }
+    }
+    s->pop_overflow = store.overflow_size();
+
+    // One buffered write: partition masters sample concurrently, and a line assembled by several
+    // fprintf calls interleaves across threads into something no parser can recover.
+    char line[4096];
+    int off = std::snprintf(line,
+                            sizeof(line),
+                            "LAYERPOP gate=%zu rows=%llu paired=%llu overflow=%llu width=%zu k_hist=",
+                            gate_index,
+                            static_cast<unsigned long long>(s->pop_rows),
+                            static_cast<unsigned long long>(s->pop_paired),
+                            static_cast<unsigned long long>(s->pop_overflow),
+                            store.inline_width());
+    const auto append_hist = [&](const uint64_t (&h)[kHistSlots]) {
+        for (size_t j = 0; j < kHistSlots && off > 0 && static_cast<size_t>(off) < sizeof(line); ++j) {
+            off += std::snprintf(line + off,
+                                 sizeof(line) - static_cast<size_t>(off),
+                                 "%llu%s",
+                                 static_cast<unsigned long long>(h[j]),
+                                 j + 1 < kHistSlots ? "," : "");
+        }
+    };
+    append_hist(s->k_hist);
+    if (off > 0 && static_cast<size_t>(off) < sizeof(line)) {
+        off += std::snprintf(line + off, sizeof(line) - static_cast<size_t>(off), " d_hist=");
+    }
+    append_hist(s->d_hist);
+    std::fprintf(stderr, "%s\n", line);
+}
+
+} // namespace monoprop::detail::layer_profile

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -28,6 +28,7 @@
 #include "monoprop/Validation.h"
 #include "monoprop/algebra/Algebra.h"
 #include "monoprop/detail/evolution/CutoffContext.h"
+#include "monoprop/detail/evolution/LayerProfile.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
 #include "monoprop/detail/evolution/layer_build/Resolve.h"
 #include "monoprop/detail/evolution/layer_build/Scan.h"
@@ -347,7 +348,11 @@ struct LayerBuildEngine {
             lv = &src_val_r[my_rank];
         }
         const size_t nq = lq.empty() ? 0 : lq.size() / kQueryWords<NumModes>;
-        resolve_range_(lq, ls, lv, 0, nq, is_leader_pass);
+        {
+            auto *const prof = layer_profile::slot();
+            const layer_profile::ScopedNs t(prof != nullptr ? &prof->resolve_ns : nullptr);
+            resolve_range_(lq, ls, lv, 0, nq, is_leader_pass);
+        }
         lq.clear();
         ls.clear();
         if constexpr (Sink::wants_values) {
@@ -376,13 +381,28 @@ struct LayerBuildEngine {
         if (R <= 1) {
             return;
         }
-        std::vector<VecZ> &send = sink.send_buffer(queries_r, src_val_r, combined_qv_);
+        auto *const prof = layer_profile::slot();
+        std::vector<VecZ> *sendp = nullptr;
+        {
+            const layer_profile::ScopedNs t(prof != nullptr ? &prof->sendbuf_ns : nullptr);
+            sendp = &sink.send_buffer(queries_r, src_val_r, combined_qv_);
+        }
+        std::vector<VecZ> &send = *sendp;
         std::vector<std::vector<size_t>> inc_q;
-        mpi::begin_alltoallv(send, comm).wait_into(inc_q);
-        auto resp = resolve_incoming<NumModes>(inc_q, local_op, R, is_leader_pass, matched, combined_size, sink);
+        {
+            const layer_profile::ScopedNs t(prof != nullptr ? &prof->exchange_ns : nullptr);
+            mpi::begin_alltoallv(send, comm).wait_into(inc_q);
+        }
+        auto resp = [&] {
+            const layer_profile::ScopedNs t(prof != nullptr ? &prof->incoming_ns : nullptr);
+            return resolve_incoming<NumModes>(inc_q, local_op, R, is_leader_pass, matched, combined_size, sink);
+        }();
         std::vector<int> resp_recv = response_recv_counts();
         std::vector<std::vector<typename Sink::Response>> inc_r;
-        mpi::begin_alltoallv(resp, comm, /*skip_self=*/false, &resp_recv).wait_into(inc_r);
+        {
+            const layer_profile::ScopedNs t(prof != nullptr ? &prof->exchange_ns : nullptr);
+            mpi::begin_alltoallv(resp, comm, /*skip_self=*/false, &resp_recv).wait_into(inc_r);
+        }
         process_responses<NumModes>(inc_r, src_idx_r, queries_r, R, my_rank, sink);
     }
 
@@ -435,6 +455,8 @@ struct LayerBuildEngine {
             return;
         }
         auto key_at = [&](size_t k) -> const Monomial<NumModes> & { return deferred_self_misses[k].mono; };
+        auto *const prof = layer_profile::slot();
+        const layer_profile::ScopedNs t(prof != nullptr ? &prof->insert_ns : nullptr);
         sink.prepare_deferred(n_miss);
         insert_absent_terms<NumModes>(local_op, n_miss, key_at, [&](size_t k, size_t base) {
             const auto &m = deferred_self_misses[k];
@@ -493,6 +515,11 @@ private:
                 break;
             }
             local_op.store->find_batch(keys.data(), m, found.data());
+            if (auto *const prof = layer_profile::slot(); prof != nullptr) {
+                for (size_t j = 0; j < m; ++j) {
+                    (found[j] < op_size ? prof->n_hit : prof->n_miss) += 1;
+                }
+            }
             for (size_t j = 0; j < m; ++j) {
                 double v_src = 0.0;
                 if constexpr (Sink::wants_values) {
@@ -537,6 +564,10 @@ auto build_layer(MPOperator<NumModes> &local_op,
                  bool *fused_scale_out = nullptr,
                  Basis basis = Basis::Majorana) -> std::shared_ptr<LayerCore> {
     validate_only_rotate_len_k_(only_rotate_len_k, 2 * NumModes);
+    // Brackets the whole layer so `layer_s` minus the phases is the unattributed remainder. A phase
+    // split without this denominator says nothing about how much of the wall time is reachable.
+    auto *const layer_prof = layer_profile::slot();
+    const layer_profile::ScopedNs layer_timer(layer_prof != nullptr ? &layer_prof->layer_ns : nullptr);
     const size_t my_rank = static_cast<size_t>(mpi::rank(comm));
     const size_t R = static_cast<size_t>(mpi::size(comm));
     // Fused contraction runs at all rank counts (R>1 via the cross-rank half-rotation exchange).

--- a/cpp/monoprop/detail/evolution/layer_build/Resolve.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Resolve.h
@@ -21,6 +21,7 @@
 #include "monoprop/TypeAliases.h"
 #include "monoprop/algebra/Algebra.h"
 #include "monoprop/detail/evolution/CutoffContext.h"
+#include "monoprop/detail/evolution/LayerProfile.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
 #include "monoprop/detail/operator/MPOperator.h"
 
@@ -84,9 +85,18 @@ auto probe_incoming_queries(const std::vector<VecZ> &incoming, // serialized, on
     {
         const size_t op_size = op.store->size();
         op.store->find_batch(pr.mono.data(), pr.nq_total, pr.idx_of.data());
+        // Counted here, not only on the self path: at R = R*S the self stream is 1/R of the traffic,
+        // so a hit rate read off resolve_range_ alone describes almost none of the work.
+        auto *const prof = layer_profile::slot();
         for (size_t g = 0; g < pr.nq_total; ++g) {
             if (pr.idx_of[g] >= op_size) { // kNotFound is size_t max → also lands here
                 pr.idx_of[g] = kMissingIndex;
+                if (prof != nullptr) {
+                    ++prof->n_miss;
+                }
+            }
+            else if (prof != nullptr) {
+                ++prof->n_hit;
             }
         }
     }

--- a/cpp/monoprop/detail/evolution/layer_build/Scan.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Scan.h
@@ -27,6 +27,7 @@
 #include "monoprop/Validation.h"
 #include "monoprop/algebra/Algebra.h"
 #include "monoprop/detail/evolution/CutoffContext.h"
+#include "monoprop/detail/evolution/LayerProfile.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
 #include "monoprop/detail/graph_encoding/MPGraphEncodingTypes.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
@@ -205,6 +206,16 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
     validate_only_rotate_len_k_(only_rotate_len_k, 2 * NumModes);
     const size_t gen_pop = gen.count();
     const auto ectx = A::make_gen_context(gen);
+    auto *const prof = layer_profile::slot();
+    // The popcount below which passes_with_popcount proves keep without reading the bitset. An opaque
+    // cutoff_fn_ has no such bound, and 0 correctly makes every term count as a full evaluation.
+    const size_t prof_fast_cut = (cutoff_eval.length_cutoff() != nullptr)    ? cutoff_eval.length_cutoff()->cutoff
+                                 : (cutoff_eval.support_cutoff() != nullptr) ? cutoff_eval.support_cutoff()->cutoff
+                                                                             : 0;
+    size_t prof_emit = 0;
+    size_t prof_cutoff = 0;
+    size_t prof_reject = 0;
+    size_t prof_push = 0;
 
     FusedScanResult res;
     res.leader_queries.assign(rank_count, VecZ{});
@@ -229,7 +240,12 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
         if (gen_columns.count == 0) {
             return res;
         }
-        const auto &inverted_index = op.inverted_index();
+        // Charged separately: inverted_index() rebuilds the whole transpose whenever rows() has moved,
+        // which is per gate on the build path and has never been attributed.
+        const auto &inverted_index = [&]() -> const InvertedIndex<NumModes> & {
+            const layer_profile::ScopedNs t(prof != nullptr ? &prof->index_ns : nullptr);
+            return op.inverted_index();
+        }();
         const size_t word_count = inverted_index.words();
         if (word_count == 0) {
             return res;
@@ -279,10 +295,16 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
             emit_term_products<NumModes, A>(*op.store, i, ectx, new_mono, overlap, phase_factor);
             // Structural cutoff on the partner M⊕G, unless upper_atol rescues it (CutoffContext::is_above_upper).
             const size_t new_pop = mono_pop + gen_pop - 2 * overlap;
+            // Profile counters are unconditional register increments (~3 ALU ops/term); both A/B arms
+            // carry them, so they cancel in a paired ratio.
+            ++prof_emit;
+            prof_cutoff += static_cast<size_t>(new_pop > prof_fast_cut);
             const bool struct_pass = cutoff_eval.passes_with_popcount(new_mono, new_pop);
             if (!struct_pass && !cut_st.is_above_upper(abs_c)) {
+                ++prof_reject;
                 return;
             }
+            ++prof_push;
             const int phase = A::emit_phase(phase_factor, mono_pop, gen_pop, overlap);
             // Single rank: every partner is self-owned, skip the O(W) hash; multi-rank routes by owner.
             const size_t r_prime = (rank_count == 1) ? my_rank : (monomial_hash<NumModes>(new_mono) % rank_count);
@@ -312,6 +334,7 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
             nz.clear(); // pass 1 clears it on entry; the skip must too (thread_local reuse)
         }
         else {
+            const layer_profile::ScopedNs t(prof != nullptr ? &prof->fold_ns : nullptr);
             even_parity_scan_pass1<NumModes>(inverted_index,
                                              gen_cols,
                                              gen.find_first(),
@@ -340,55 +363,69 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
         };
         const bool word_aligned_cos = !only_rotate_len_k.has_value();
         CosineWordBuilder cos_b;
-        for (const auto &w : nz) {
-            if (word_aligned_cos && fused_scale_coeffs != nullptr) {
-                // Fused cos sweep: scaling in place here is what replaces building a cosine set.
-                for (uint64_t m = w.overlap; m; m &= m - 1) {
-                    const size_t tz = static_cast<size_t>(std::countr_zero(m));
-                    const size_t i = w.base + tz;
-                    const double v_src = fused_scale_coeffs[i];
-                    fused_scale_coeffs[i] = v_src * fused_scale_cos;
-                    const double abs_c = std::abs(v_src);
-                    if (cut_st.is_below_sin(abs_c)) {
-                        continue;
+        { // scoped so emit_ns excludes the profile fold-in and the O(n) population sweep below
+            const layer_profile::ScopedNs emit_timer(prof != nullptr ? &prof->emit_ns : nullptr);
+            for (const auto &w : nz) {
+                if (word_aligned_cos && fused_scale_coeffs != nullptr) {
+                    // Fused cos sweep: scaling in place here is what replaces building a cosine set.
+                    for (uint64_t m = w.overlap; m; m &= m - 1) {
+                        const size_t tz = static_cast<size_t>(std::countr_zero(m));
+                        const size_t i = w.base + tz;
+                        const double v_src = fused_scale_coeffs[i];
+                        fused_scale_coeffs[i] = v_src * fused_scale_cos;
+                        const double abs_c = std::abs(v_src);
+                        if (cut_st.is_below_sin(abs_c)) {
+                            continue;
+                        }
+                        const size_t mono_pop = op.store->popcount(i);
+                        const bool is_follower = (w.foll >> tz) & 1u;
+                        emit(mono_pop, i, abs_c, v_src, is_follower);
                     }
-                    const size_t mono_pop = op.store->popcount(i);
-                    const bool is_follower = (w.foll >> tz) & 1u;
-                    emit(mono_pop, i, abs_c, v_src, is_follower);
+                }
+                else if (word_aligned_cos) {
+                    // No orbital gate: record the whole word in the cosine set, then per bit apply the atol
+                    // gate before the popcount row read — deferring popcount saves random packed-row loads.
+                    cos_b.push_word(w.base, w.overlap);
+                    for (uint64_t m = w.overlap; m; m &= m - 1) {
+                        const size_t tz = static_cast<size_t>(std::countr_zero(m));
+                        const size_t i = w.base + tz;
+                        const auto [v_src, abs_c] = derive_coeff(i);
+                        if (cut_st.is_below_sin(abs_c)) {
+                            continue;
+                        }
+                        const size_t mono_pop = op.store->popcount(i);
+                        const bool is_follower = (w.foll >> tz) & 1u;
+                        emit(mono_pop, i, abs_c, v_src, is_follower);
+                    }
+                }
+                else {
+                    // Orbital gate active: it needs mono_pop, and the per-index cosine push covers only
+                    // orbital-passing terms, so the popcount row read must precede both.
+                    for (uint64_t m = w.overlap; m; m &= m - 1) {
+                        const size_t tz = static_cast<size_t>(std::countr_zero(m));
+                        const size_t i = w.base + tz;
+                        const size_t mono_pop = op.store->popcount(i);
+                        if (mono_pop > static_cast<size_t>(*only_rotate_len_k)) {
+                            continue;
+                        }
+                        cos_b.push_index(i);
+                        const auto [v_src, abs_c] = derive_coeff(i);
+                        const bool is_follower = (w.foll >> tz) & 1u;
+                        emit(mono_pop, i, abs_c, v_src, is_follower);
+                    }
                 }
             }
-            else if (word_aligned_cos) {
-                // No orbital gate: record the whole word in the cosine set, then per bit apply the atol
-                // gate before the popcount row read — deferring popcount saves random packed-row loads.
-                cos_b.push_word(w.base, w.overlap);
-                for (uint64_t m = w.overlap; m; m &= m - 1) {
-                    const size_t tz = static_cast<size_t>(std::countr_zero(m));
-                    const size_t i = w.base + tz;
-                    const auto [v_src, abs_c] = derive_coeff(i);
-                    if (cut_st.is_below_sin(abs_c)) {
-                        continue;
-                    }
-                    const size_t mono_pop = op.store->popcount(i);
-                    const bool is_follower = (w.foll >> tz) & 1u;
-                    emit(mono_pop, i, abs_c, v_src, is_follower);
-                }
-            }
-            else {
-                // Orbital gate active: it needs mono_pop, and the per-index cosine push covers only
-                // orbital-passing terms, so the popcount row read must precede both.
-                for (uint64_t m = w.overlap; m; m &= m - 1) {
-                    const size_t tz = static_cast<size_t>(std::countr_zero(m));
-                    const size_t i = w.base + tz;
-                    const size_t mono_pop = op.store->popcount(i);
-                    if (mono_pop > static_cast<size_t>(*only_rotate_len_k)) {
-                        continue;
-                    }
-                    cos_b.push_index(i);
-                    const auto [v_src, abs_c] = derive_coeff(i);
-                    const bool is_follower = (w.foll >> tz) & 1u;
-                    emit(mono_pop, i, abs_c, v_src, is_follower);
-                }
-            }
+        }
+        if (prof != nullptr) {
+            prof->n_gates += 1;
+            prof->n_anti += n_anti;
+            prof->n_foll += n_foll;
+            prof->n_emit += prof_emit;
+            prof->n_cutoff += prof_cutoff;
+            prof->n_reject += prof_reject;
+            prof->n_push += prof_push;
+            prof->query_words += prof_push * kQueryWords<NumModes>;
+            layer_profile::sample_population<NumModes>(prof, *op.store, prof->n_gates - 1);
         }
         res.cos_blocks.push_back(cos_b.finish());
     }

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -613,6 +613,8 @@ auto MonomialPropagator<NumModes>::evolve_mode_contract_immediately_(const std::
             bool fused_scale = false;
             build_evolve_result_(mono, rot_len, std::cref(*op_coeffs), build_angle, &cos, &fc, op_coeffs, &fused_scale);
             extend_coeffs_from_current_picture_if_needed_(*op_coeffs);
+            auto *const prof = detail::layer_profile::slot();
+            const detail::layer_profile::ScopedNs t(prof != nullptr ? &prof->contract_ns : nullptr);
             detail::apply_fused_contract(fc, *op_coeffs, cos, apply_angle, schrodinger_, fused_scale);
         });
 }

--- a/cpp/monoprop/detail/operator/OperatorIndex.h
+++ b/cpp/monoprop/detail/operator/OperatorIndex.h
@@ -169,6 +169,10 @@ public:
         }
         return overflow_.at(i).count();
     }
+    // Rows whose popcount exceeded inline_width_ and spilled. Diagnostic: every hot-path row read on
+    // one of these is a hash-map lookup, so this fraction is what decides whether the width is right.
+    [[nodiscard]] auto overflow_size() const -> size_t { return overflow_.size(); }
+    [[nodiscard]] auto inline_width() const -> size_t { return inline_width_; }
     [[nodiscard]] auto memory_bytes() const -> size_t {
         size_t total = rows_.capacity() * sizeof(PosT);
         total += overflow_.size() * (sizeof(value_type) + sizeof(size_t) + 24);

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -30,6 +30,7 @@ whose partner lives in another partition are resolved through a per-gate exchang
 | `monoprop_NUM_THREADS` | one partition per physical core | Caps the number of partitions. Set it to run fewer partitions than cores. |
 | `monoprop_PARTITIONS` | `auto` | `auto` = one partition per core (capped by `monoprop_NUM_THREADS`); an integer `N` = exactly `N` partitions; `off` = one partition holding the whole operator. |
 | `monoprop_PARTITION_PINNING` | `on` | `0`/`false`/`no` disables pinning each partition to a core. Supported on platforms where hwloc can bind threads. |
+| `monoprop_LAYER_PROFILE` | `off` | `1` writes a per-partition breakdown of each layer build to **stderr**: phase wall times, per-gate counters, and a periodic population sample. Diagnostic only — it changes no result. Output goes straight to fd 2, so a run under pytest needs `-s` or the capture discards it. |
 
 ```bash
 # Run 8 partitions instead of one-per-core:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds `monoprop_LAYER_PROFILE`: a per-partition attribution of the layer build, off by default.

Before this there was no way to say where a layer build's time went. The instrumented phases summed to ~6% of wall, so a phase split described almost nothing, and every question about the engine had to be answered with the end-to-end wall — an instrument whose observed spread on `build_graph` is **2.86×**, and which needs **~1590 paired repetitions** to resolve a 3% effect. The phase timers resolve the same 3% in about **5**.

This is the instrument the rest of this work is measured with, and it is useful on its own for anyone profiling the engine.

## Changes

Two instruments with deliberately different costs:

- **Phase timers and per-gate counters** — O(1) clock reads per gate, with per-term counters kept in locals and folded into the slot once per gate, so the emit loop keeps its registers.
- **A store population sweep** (k/d histograms, paired and overflow fractions) — O(n), so it runs only on power-of-two gate indices, which also yields the population's growth curve for free.

`layer_ns` brackets the **whole** of `build_layer`, so `layer_ns` minus the phases is the unattributed remainder. Without it the split is not falsifiable: phases that sum to a small fraction of wall can be individually accurate and collectively meaningless. `index_ns` covers the inverted-index rebuild, which is not a layer phase but is charged per gate and had never been attributed to anything.

Slots are heap-allocated per thread and owned by the registry, **never freed**: a partition master can outlive or predecease the dump, and a dangling slot would be a use-after-free in a diagnostic. The registry dumps from its destructor rather than via `atexit` so the ordering is sound — `slot()` evaluates `config::get()` before `Registry::add()`, so `Settings` is constructed first and therefore destroyed last.

## Cost when off

`slot()` returns `nullptr` when the knob is unset, so every call site is one predictable branch and no clock is read. It changes no result.

Output goes to **stderr**, which pytest's fd-level capture discards without `-s`. Documented in `docs/content/docs/features/parallelism.mdx`.

## Verification

`ctest -L serial` — 208/208 green. `pytest tests --with-mpi` green at 1, 2 and 4 ranks.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [x] `CHANGELOG` / release notes updated if applicable — release notes are generated from the PR title

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: Claude Code (claude-opus-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)
