### PR TITLE
perf(mpi): ♻️ lease alltoallv staging buffers instead of allocating per call

### DIFF
--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -388,22 +388,31 @@ struct LayerBuildEngine {
             sendp = &sink.send_buffer(queries_r, src_val_r, combined_qv_);
         }
         std::vector<VecZ> &send = *sendp;
-        std::vector<std::vector<size_t>> inc_q;
-        {
+        // The handle owns the unpacked per-source blocks (leased from the partition master's scratch
+        // pool), so it has to outlive its reader rather than being a temporary: the whole point is that
+        // those blocks keep their capacity from gate to gate. Holding it across resolve_incoming also
+        // keeps the leg's send buffer leased for as long as `send` is meaningful, which is what makes
+        // the pooling invisible to the second-barrier contract in Comm.h.
+        auto qh = [&] {
             const layer_profile::ScopedNs t(prof != nullptr ? &prof->exchange_ns : nullptr);
-            mpi::begin_alltoallv(send, comm).wait_into(inc_q);
-        }
+            auto h = mpi::begin_alltoallv(send, comm);
+            h.wait_into();
+            return h;
+        }();
         auto resp = [&] {
             const layer_profile::ScopedNs t(prof != nullptr ? &prof->incoming_ns : nullptr);
-            return resolve_incoming<NumModes>(inc_q, local_op, R, is_leader_pass, matched, combined_size, sink);
+            return resolve_incoming<NumModes>(qh.received(), local_op, R, is_leader_pass, matched, combined_size, sink);
         }();
         std::vector<int> resp_recv = response_recv_counts();
-        std::vector<std::vector<typename Sink::Response>> inc_r;
-        {
+        // A second live handle, so the response leg leases its own bundle: the query leg's is still held
+        // here, and the two must never be the same buffer even where their element types coincide.
+        auto rh = [&] {
             const layer_profile::ScopedNs t(prof != nullptr ? &prof->exchange_ns : nullptr);
-            mpi::begin_alltoallv(resp, comm, /*skip_self=*/false, &resp_recv).wait_into(inc_r);
-        }
-        process_responses<NumModes>(inc_r, src_idx_r, queries_r, R, my_rank, sink);
+            auto h = mpi::begin_alltoallv(resp, comm, /*skip_self=*/false, &resp_recv);
+            h.wait_into();
+            return h;
+        }();
+        process_responses<NumModes>(rh.received(), src_idx_r, queries_r, R, my_rank, sink);
     }
 
     // Followers a leader already matched must not be re-resolved over the wire, so compact them out.

--- a/cpp/monoprop/detail/mpi/MPICompat.h
+++ b/cpp/monoprop/detail/mpi/MPICompat.h
@@ -112,35 +112,166 @@ auto allreduce_sum_inplace(VecD &values, Comm comm) -> void;
 // `n` is the comm size.
 auto alltoall_counts(const int *send_counts, int *recv_counts, int n, Comm comm) -> void;
 
+namespace detail {
+
+// Every buffer one begin_alltoallv call needs, kept together so a call leases them as a unit rather than
+// heap-allocating each one. Nothing here carries state between calls: every logical size is set exactly
+// by the call that borrows the bundle, only capacity survives.
+template <class T>
+struct AlltoallvScratch {
+    std::vector<int> send_counts;         // [P] elements sent to each destination
+    std::vector<int> send_displs;         // [P] element offsets into `send`
+    std::vector<int> recv_counts;         // [P] elements received from each source
+    std::vector<int> recv_displs;         // [P] element offsets into `recv`
+    std::vector<T> send;                  // flat pack of send_data; peers read it in place (see Comm.h)
+    std::vector<T> recv;                  // flat receive, laid out by recv_displs
+    std::vector<std::vector<T>> unpacked; // wait_into()'s per-source destination
+};
+
+// Free list of scratch bundles for element type T, owned by the calling thread.
+//
+// Ownership scope is the partition master thread, which is exactly the per-partition scope: each
+// partition runs its whole gate sequence on one pinned master (see PartitionGroup), so capacity carries
+// gate to gate and every buffer stays on the NUMA node whose thread first grew it. Same reasoning as
+// Scan.h's `nz` and InvertedIndex.h's fold blocks. Templated on T so the query leg (size_t monomial
+// words) can never be handed a bundle typed for the response leg (TermIndex or double) or the reverse:
+// the transports address payloads as bytes, but these vectors are the typed owners and
+// alltoallv_resolve resizes one of them through a std::vector<T> &.
+//
+// A free list rather than one cached bundle because PendingAlltoallv promises that several exchanges may
+// be in flight at once: concurrent handles each hold a distinct bundle, so no live send buffer is ever
+// handed to a second call. Capacity is a high-water mark held until the thread exits — the same trade
+// HybridComm's stage_send_ / stage_recv_ already make.
+template <class T>
+inline auto scratch_free_list() -> std::vector<AlltoallvScratch<T>> & {
+    static thread_local std::vector<AlltoallvScratch<T>> free_list;
+    return free_list;
+}
+
+// Move-only lease of one scratch bundle, returned to the thread's free list on destruction.
+template <class T>
+class ScratchLease {
+public:
+    ScratchLease() {
+        auto &free_list = scratch_free_list<T>();
+        if (!free_list.empty()) {
+            buf_ = std::move(free_list.back()); // moving a vector keeps its capacity
+            free_list.pop_back();
+        }
+    }
+    ScratchLease(const ScratchLease &) = delete;
+    auto operator=(const ScratchLease &) -> ScratchLease & = delete;
+    ScratchLease(ScratchLease &&other) noexcept
+        : buf_(std::move(other.buf_)),
+          held_(std::exchange(other.held_, false)) {}
+    auto operator=(ScratchLease &&other) noexcept -> ScratchLease & {
+        if (this != &other) {
+            give_back_();
+            buf_ = std::move(other.buf_);
+            held_ = std::exchange(other.held_, false);
+        }
+        return *this;
+    }
+    ~ScratchLease() { give_back_(); }
+
+    auto get() -> AlltoallvScratch<T> & { return buf_; }
+
+private:
+    auto give_back_() noexcept -> void {
+        if (!std::exchange(held_, false)) {
+            return;
+        }
+        // Deliberately no clear(): capacity is the point, and every buffer's logical size is set exactly
+        // by the next borrower before anything reads it (see begin_alltoallv / wait_into).
+        try {
+            scratch_free_list<T>().push_back(std::move(buf_));
+        }
+        catch (...) {
+            // Dropping a bundle only costs its capacity, and this runs in a destructor.
+        }
+    }
+
+    AlltoallvScratch<T> buf_;
+    bool held_ = true;
+};
+
+} // namespace detail
+
 // In-flight variable-size all-to-all owning its buffers + layout, so several can be in flight.
 // recv_counts is valid on return from begin_alltoallv; wait_into completes the payload transfer (a
 // no-op on the synchronous Shm / single-process paths) and unpacks by source.
+//
+// The buffers are leased from a per-thread free list rather than allocated per call, and the handle's
+// lifetime is what makes that safe against the send-buffer contract in Comm.h ("must stay alive and
+// unmodified until the verb's second barrier"):
+//   - Kind::Shm / Kind::Hybrid: begin_alltoallv returns only after the verb's last barrier, past which
+//     no peer reads our send buffer, so the bundle is free the moment the handle dies.
+//   - Kind::Mpi: MPI_Ialltoallv still reads the send buffer until the wait, so the destructor completes
+//     the request before the bundle goes back to the pool. Recycling it under a live request is the
+//     silent-wrong-answer failure this class of change invites, so it is closed here rather than
+//     documented as a caller obligation (same reasoning as Exchange.h's Ticket).
+// Move-only for the same reason: a copied handle would wait on one request twice.
 template <class T>
-struct PendingAlltoallv {
+class PendingAlltoallv {
+public:
+    PendingAlltoallv() = default;
+    PendingAlltoallv(const PendingAlltoallv &) = delete;
+    auto operator=(const PendingAlltoallv &) -> PendingAlltoallv & = delete;
+    PendingAlltoallv(PendingAlltoallv &&other) noexcept { *this = std::move(other); }
+    auto operator=(PendingAlltoallv &&other) noexcept -> PendingAlltoallv & {
+        if (this != &other) {
+            complete_(); // never drop a request this handle already owns
+            num_ranks = std::exchange(other.num_ranks, 0);
+            lease_ = std::move(other.lease_);
+#ifdef monoprop_ENABLE_MPI
+            request = std::exchange(other.request, MPI_REQUEST_NULL);
+#endif
+        }
+        return *this;
+    }
+    ~PendingAlltoallv() { complete_(); }
+
     int num_ranks = 0;
-    std::vector<int> send_counts;
-    std::vector<int> send_displs;
-    std::vector<int> recv_counts;
-    std::vector<int> recv_displs;
-    std::vector<T> send_buffer;
-    std::vector<T> recv_buffer;
 #ifdef monoprop_ENABLE_MPI
     MPI_Request request = MPI_REQUEST_NULL; // set only on the Kind::Mpi async path
 #endif
 
+    // The leased buffers. begin_alltoallv fills them; callers read `unpacked` through wait_into.
+    auto buffers() -> detail::AlltoallvScratch<T> & { return lease_.get(); }
+
     auto wait_into(std::vector<std::vector<T>> &recv_data) -> void {
+        complete_();
+        auto &b = buffers();
+        recv_data.resize(static_cast<size_t>(num_ranks));
+        for (int i = 0; i < num_ranks; ++i) {
+            // assign, not insert: the logical size is set exactly from recv_counts, so a reused
+            // recv_data keeps only capacity and can carry no element of a longer earlier round.
+            const auto lo = b.recv.begin() + b.recv_displs[static_cast<size_t>(i)];
+            recv_data[static_cast<size_t>(i)].assign(lo, lo + b.recv_counts[static_cast<size_t>(i)]);
+        }
+    }
+
+    // Unpack into this handle's own scratch. The result is only valid while the handle lives, which is
+    // what lets the per-source blocks keep their capacity from one call to the next.
+    auto wait_into() -> std::vector<std::vector<T>> & {
+        wait_into(buffers().unpacked);
+        return buffers().unpacked;
+    }
+
+    // The last wait_into() result. Precondition: wait_into() (the no-argument form) has been called.
+    auto received() -> std::vector<std::vector<T>> & { return buffers().unpacked; }
+
+private:
+    auto complete_() noexcept -> void {
 #ifdef monoprop_ENABLE_MPI
         if (request != MPI_REQUEST_NULL) {
             MPI_Wait(&request, MPI_STATUS_IGNORE);
             request = MPI_REQUEST_NULL;
         }
 #endif
-        recv_data.resize(static_cast<size_t>(num_ranks));
-        for (int i = 0; i < num_ranks; ++i) {
-            const auto lo = recv_buffer.begin() + recv_displs[static_cast<size_t>(i)];
-            recv_data[static_cast<size_t>(i)].assign(lo, lo + recv_counts[static_cast<size_t>(i)]);
-        }
     }
+
+    detail::ScratchLease<T> lease_;
 };
 
 // The count exchange runs eagerly (recv_counts known on return); the Kind::Mpi payload is non-blocking
@@ -162,44 +293,52 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
     }
     PendingAlltoallv<T> h;
     h.num_ranks = num_ranks;
-    h.send_counts.resize(static_cast<size_t>(num_ranks));
-    h.send_displs.resize(static_cast<size_t>(num_ranks));
-    h.recv_displs.resize(static_cast<size_t>(num_ranks));
+    auto &b = h.buffers();
+    const auto p = static_cast<size_t>(num_ranks);
+    // resize, not assign: the three loops below write every one of the P entries, so a leased buffer's
+    // stale values are all overwritten before anything reads them.
+    b.send_counts.resize(p);
+    b.send_displs.resize(p);
+    b.recv_displs.resize(p);
 
     const int self = skip_self ? rank(comm) : -1;
-    // Wide accumulator + checked narrowing: a wrapped count would size send_buffer short and then feed
-    // MPI a negative count/displacement.
+    // Wide accumulator + checked narrowing: a wrapped count would size the send buffer short and then
+    // feed MPI a negative count/displacement.
     long long total_send = 0;
     for (int i = 0; i < num_ranks; ++i) {
         const size_t n = (i == self) ? 0 : send_data[static_cast<size_t>(i)].size();
         const int c = checked_mpi_count(n, "Send count");
-        h.send_counts[static_cast<size_t>(i)] = c;
+        b.send_counts[static_cast<size_t>(i)] = c;
         total_send += c;
     }
     long long running_send = 0;
     for (int i = 0; i < num_ranks; ++i) {
-        h.send_displs[static_cast<size_t>(i)] = checked_mpi_count(running_send, "Send displacement");
-        running_send += h.send_counts[static_cast<size_t>(i)];
+        b.send_displs[static_cast<size_t>(i)] = checked_mpi_count(running_send, "Send displacement");
+        running_send += b.send_counts[static_cast<size_t>(i)];
     }
-    h.send_buffer.resize(static_cast<size_t>(checked_mpi_count(total_send, "Total send count")));
+    // The displacements tile [0, total_send) exactly, so the pack loop below rewrites every live element
+    // whatever the previous borrower left behind; resize alone makes the logical size exact.
+    b.send.resize(static_cast<size_t>(checked_mpi_count(total_send, "Total send count")));
     for (int i = 0; i < num_ranks; ++i) {
-        const int c = h.send_counts[static_cast<size_t>(i)];
+        const int c = b.send_counts[static_cast<size_t>(i)];
         if (c == 0) {
             continue;
         }
         std::copy(send_data[static_cast<size_t>(i)].begin(),
                   send_data[static_cast<size_t>(i)].begin() + c,
-                  h.send_buffer.begin() + h.send_displs[static_cast<size_t>(i)]);
+                  b.send.begin() + b.send_displs[static_cast<size_t>(i)]);
     }
 
-    h.recv_counts.resize(static_cast<size_t>(num_ranks));
+    // assign, not resize: the known_recv_counts branch below copies only a prefix when the caller passes
+    // a short vector, and a leased buffer would otherwise keep an earlier round's counts in the tail.
+    b.recv_counts.assign(p, 0);
 
-    const AlltoallvResolveArgs<T> resolve_args{.send = h.send_buffer.data(),
-                                               .send_counts = h.send_counts.data(),
-                                               .send_displs = h.send_displs.data(),
-                                               .recv = h.recv_buffer,
-                                               .recv_counts = h.recv_counts.data(),
-                                               .recv_displs = h.recv_displs.data()};
+    const AlltoallvResolveArgs<T> resolve_args{.send = b.send.data(),
+                                               .send_counts = b.send_counts.data(),
+                                               .send_displs = b.send_displs.data(),
+                                               .recv = b.recv,
+                                               .recv_counts = b.recv_counts.data(),
+                                               .recv_displs = b.recv_displs.data()};
     // Fused fast path (query round, recv layout unknown): resolve recv counts AND move payload in one
     // in-process verb, folding away the count exchange's barriers (Shm 4→2, Hybrid 6→4). It fills
     // recv_counts/recv_displs and resizes recv_buffer; known-layout and pure-MPI paths fall through.
@@ -218,30 +357,30 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
         std::copy(
             known_recv_counts->begin(),
             known_recv_counts->begin() + std::min<size_t>(known_recv_counts->size(), static_cast<size_t>(num_ranks)),
-            h.recv_counts.begin());
+            b.recv_counts.begin());
         if (self >= 0) {
-            h.recv_counts[static_cast<size_t>(self)] = 0;
+            b.recv_counts[static_cast<size_t>(self)] = 0;
         }
     }
     else {
-        alltoall_counts(h.send_counts.data(), h.recv_counts.data(), num_ranks, comm);
+        alltoall_counts(b.send_counts.data(), b.recv_counts.data(), num_ranks, comm);
     }
 
     // Wide accumulator + checked narrowing: see checked_mpi_count.
     long long running = 0;
     for (int i = 0; i < num_ranks; ++i) {
-        h.recv_displs[static_cast<size_t>(i)] = checked_mpi_count(running, "Recv displacement");
-        running += h.recv_counts[static_cast<size_t>(i)];
+        b.recv_displs[static_cast<size_t>(i)] = checked_mpi_count(running, "Recv displacement");
+        running += b.recv_counts[static_cast<size_t>(i)];
     }
-    h.recv_buffer.resize(static_cast<size_t>(checked_mpi_count(running, "Total recv count")));
+    b.recv.resize(static_cast<size_t>(checked_mpi_count(running, "Total recv count")));
 
-    // Taken after the resize above: recv_buffer may have reallocated.
-    const auto flat = FlatAlltoallvArgs<T>{.send = h.send_buffer.data(),
-                                           .send_counts = h.send_counts.data(),
-                                           .send_displs = h.send_displs.data(),
-                                           .recv = h.recv_buffer.data(),
-                                           .recv_counts = h.recv_counts.data(),
-                                           .recv_displs = h.recv_displs.data()}
+    // Taken after the resize above: the recv buffer may have reallocated.
+    const auto flat = FlatAlltoallvArgs<T>{.send = b.send.data(),
+                                           .send_counts = b.send_counts.data(),
+                                           .send_displs = b.send_displs.data(),
+                                           .recv = b.recv.data(),
+                                           .recv_counts = b.recv_counts.data(),
+                                           .recv_displs = b.recv_displs.data()}
                           .bytes();
     if (comm.kind == Comm::Kind::Shm) {
         // ShmComm needs no send counts: its peers pull using the publisher's displacements.
@@ -260,18 +399,18 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
 #endif
     else {
 #ifdef monoprop_ENABLE_MPI
-        MPI_Ialltoallv(h.send_buffer.data(),
-                       h.send_counts.data(),
-                       h.send_displs.data(),
+        MPI_Ialltoallv(b.send.data(),
+                       b.send_counts.data(),
+                       b.send_displs.data(),
                        datatype<T>::get(),
-                       h.recv_buffer.data(),
-                       h.recv_counts.data(),
-                       h.recv_displs.data(),
+                       b.recv.data(),
+                       b.recv_counts.data(),
+                       b.recv_displs.data(),
                        datatype<T>::get(),
                        comm.mpi,
                        &h.request);
 #else
-        h.recv_buffer = h.send_buffer; // single participant: self round-trip (layouts identical)
+        b.recv = b.send; // single participant: self round-trip (layouts identical)
 #endif
     }
     return h;

--- a/cpp/tests/shm_comm_tests.cpp
+++ b/cpp/tests/shm_comm_tests.cpp
@@ -352,3 +352,137 @@ BOOST_AUTO_TEST_CASE(shm_comm_poison_releases_waiters) {
         }
     }
 }
+
+// Buffer reuse across successive exchanges on one thread. begin_alltoallv leases its buffers from a
+// per-thread free list rather than allocating per call, so the round that follows a LARGER round is the
+// one that can go wrong: a logical size left at the high-water mark, or a recv_counts tail never
+// rewritten, both surface as an earlier round's data appearing in a later one. Sizes therefore go
+// large -> small -> large, and every block is checked for exact length and exact contents, not just
+// for the prefix a stale buffer would still get right.
+BOOST_AUTO_TEST_CASE(shm_comm_begin_alltoallv_reuse_leaves_no_stale_data) {
+    for (const int S : {2, 4}) {
+        // Round r of source s sends kPer[r] * (s + 1) elements, tagged so any survivor is traceable to
+        // the round and source that wrote it.
+        const std::vector<int> kPer = {7, 1, 5};
+        std::vector<std::vector<std::vector<std::vector<int>>>> recv(static_cast<size_t>(S));
+        auto errs = run_shm(S, [&](ShmComm &sh, int r) {
+            Comm c = Comm::make_shm(&sh, r);
+            std::vector<std::vector<std::vector<int>>> rounds;
+            for (size_t round = 0; round < kPer.size(); ++round) {
+                std::vector<std::vector<int>> send(static_cast<size_t>(S));
+                const int n = kPer[round] * (r + 1);
+                for (int t = 0; t < S; ++t) {
+                    for (int j = 0; j < n; ++j) {
+                        send[static_cast<size_t>(t)].push_back((static_cast<int>(round) * 1000000) + (r * 1000) + j);
+                    }
+                }
+                auto h = monoprop::mpi::begin_alltoallv(send, c);
+                std::vector<std::vector<int>> got;
+                h.wait_into(got);
+                rounds.push_back(std::move(got));
+            }
+            recv[static_cast<size_t>(r)] = std::move(rounds);
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        for (int r = 0; r < S; ++r) {
+            const auto &rounds = recv[static_cast<size_t>(r)];
+            BOOST_REQUIRE_EQUAL(rounds.size(), kPer.size());
+            for (size_t round = 0; round < kPer.size(); ++round) {
+                const auto &got = rounds[round];
+                BOOST_REQUIRE_EQUAL(static_cast<int>(got.size()), S);
+                for (int s = 0; s < S; ++s) {
+                    const auto &blk = got[static_cast<size_t>(s)];
+                    const int n = kPer[round] * (s + 1);
+                    BOOST_REQUIRE_EQUAL(static_cast<int>(blk.size()), n); // the shrink check
+                    for (int j = 0; j < n; ++j) {
+                        BOOST_REQUIRE_EQUAL(blk[static_cast<size_t>(j)],
+                                            (static_cast<int>(round) * 1000000) + (s * 1000) + j);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// The same hazard on the recv_counts vector specifically. A known_recv_counts shorter than the comm is
+// copied as a prefix, so a leased buffer whose tail still holds a previous round's counts would size
+// the receive from data nobody sent. Round 1 establishes a full set of large counts; round 2 passes a
+// one-element prefix and must see zeros everywhere the prefix does not reach.
+BOOST_AUTO_TEST_CASE(shm_comm_begin_alltoallv_known_counts_tail_is_cleared) {
+    const int S = 4;
+    std::vector<std::vector<std::vector<int>>> recv(static_cast<size_t>(S));
+    auto errs = run_shm(S, [&](ShmComm &sh, int r) {
+        Comm c = Comm::make_shm(&sh, r);
+        std::vector<std::vector<int>> send(static_cast<size_t>(S));
+        for (int t = 0; t < S; ++t) {
+            send[static_cast<size_t>(t)] = {r * 10 + 1, r * 10 + 2, r * 10 + 3};
+        }
+        std::vector<std::vector<int>> first;
+        monoprop::mpi::begin_alltoallv(send, c).wait_into(first);
+
+        const std::vector<int> short_counts = {3}; // source 0 only; sources 1.. must resolve to zero
+        std::vector<std::vector<int>> got;
+        monoprop::mpi::begin_alltoallv(send, c, /*skip_self=*/false, &short_counts).wait_into(got);
+        recv[static_cast<size_t>(r)] = std::move(got);
+    });
+    for (const auto &e : errs) {
+        BOOST_CHECK(e == nullptr);
+    }
+    for (int r = 0; r < S; ++r) {
+        const auto &got = recv[static_cast<size_t>(r)];
+        BOOST_REQUIRE_EQUAL(static_cast<int>(got.size()), S);
+        BOOST_CHECK_EQUAL(got[0].size(), 3U);
+        for (int s = 1; s < S; ++s) {
+            BOOST_CHECK_EQUAL(got[static_cast<size_t>(s)].size(), 0U);
+        }
+    }
+}
+
+// The no-argument wait_into()/received() pair, which is the form the layer build uses: the unpacked
+// per-source blocks live in the leased bundle and therefore survive into whichever call borrows it
+// next, unlike a caller-owned vector that is fresh each round. Sizes again go large -> small -> large,
+// and each round is read through received() exactly as Engine.h reads it.
+BOOST_AUTO_TEST_CASE(shm_comm_alltoallv_received_blocks_do_not_accumulate) {
+    const int S = 4;
+    const std::vector<int> kPer = {6, 1, 4};
+    std::vector<std::vector<std::vector<std::vector<int>>>> recv(static_cast<size_t>(S));
+    auto errs = run_shm(S, [&](ShmComm &sh, int r) {
+        Comm c = Comm::make_shm(&sh, r);
+        std::vector<std::vector<std::vector<int>>> rounds;
+        for (size_t round = 0; round < kPer.size(); ++round) {
+            std::vector<std::vector<int>> send(static_cast<size_t>(S));
+            const int n = kPer[round] * (r + 1);
+            for (int t = 0; t < S; ++t) {
+                for (int j = 0; j < n; ++j) {
+                    send[static_cast<size_t>(t)].push_back((static_cast<int>(round) * 1000000) + (r * 1000) + j);
+                }
+            }
+            auto h = monoprop::mpi::begin_alltoallv(send, c);
+            h.wait_into();
+            rounds.emplace_back(h.received()); // copy out before the lease returns the bundle
+        }
+        recv[static_cast<size_t>(r)] = std::move(rounds);
+    });
+    for (const auto &e : errs) {
+        BOOST_CHECK(e == nullptr);
+    }
+    for (int r = 0; r < S; ++r) {
+        const auto &rounds = recv[static_cast<size_t>(r)];
+        BOOST_REQUIRE_EQUAL(rounds.size(), kPer.size());
+        for (size_t round = 0; round < kPer.size(); ++round) {
+            const auto &got = rounds[round];
+            BOOST_REQUIRE_EQUAL(static_cast<int>(got.size()), S);
+            for (int s = 0; s < S; ++s) {
+                const auto &blk = got[static_cast<size_t>(s)];
+                const int n = kPer[round] * (s + 1);
+                BOOST_REQUIRE_EQUAL(static_cast<int>(blk.size()), n);
+                for (int j = 0; j < n; ++j) {
+                    BOOST_REQUIRE_EQUAL(blk[static_cast<size_t>(j)],
+                                        (static_cast<int>(round) * 1000000) + (s * 1000) + j);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

> **Stacked.** Based on `pr/layer-profile` (#232) so the diff shown here is this change alone. It retargets to `main` when that one merges.

## Summary

`begin_alltoallv` resized a fresh send buffer every call and copied every per-rank vector into it, and `wait_into` allocated each per-source block. Both sit inside the exchange timer, once per gate per partition.

Fitting `exchange = A + B·bytes` across two problem sizes with the collective count held constant isolates a fixed component **A = 9.38 partition-seconds — 21.4% of a leg that is itself 68.2% of layer time**. Per-call heap traffic is what that component is made of.

## Changes

The buffers now come from a per-thread free list. Ownership is the partition master, which is the per-partition scope: each partition runs its whole gate sequence on one pinned master, so capacity carries gate to gate and every buffer stays on the NUMA node whose thread first grew it. The list is typed on the element type, so the query leg can never be handed a bundle belonging to the response leg.

**What makes reuse safe is the handle's lifetime, not a caller obligation.** `Comm.h` requires a buffer be unmodified until the verb's second barrier. `PendingAlltoallv` is now move-only and completes its MPI request **in the destructor**, before the bundle returns to the pool. Recycling a buffer under a live `Ialltoallv` is exactly the silent-wrong-answer failure this class of change invites, so it is closed structurally rather than by convention.

## Tests

Three reuse tests, all in the shape that actually fails — sizes going **large, small, large**, so a logical size left at the high-water mark or a counts tail never rewritten shows up. Verified by mutation: dropping the `recv_counts` clear fails 12 cases; appending instead of assigning in `wait_into` fails 1.

**Not covered:** recycling under a live `MPI_Ialltoallv`, since `ShmComm` never sets a request. That path needs the multi-rank equivalence run, which is green at 1/2/4 ranks here but is not a targeted test of it.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [x] `CHANGELOG` / release notes updated if applicable — release notes are generated from the PR title

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: Claude Code (claude-opus-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)
