### PR TITLE
perf(algebra): ⚡ decide the structural cutoff from a (k, d) digest

### DIFF
--- a/cpp/monoprop/algebra/AlgebraCommon.h
+++ b/cpp/monoprop/algebra/AlgebraCommon.h
@@ -24,6 +24,7 @@
 
 #include "monoprop/TypeAliases.h"
 #include "monoprop/Utilities.h"
+#include "monoprop/core/SparseMonomial.h"
 
 namespace monoprop {
 
@@ -95,6 +96,9 @@ auto is_paired(const VecZ &mono) -> bool {
     return is_paired<NumModes>(indices_to_bitset<NumModes>(mono));
 }
 
+// The (k, d) digest form of the predicate above is is_paired(size_t, size_t) in SparseMonomial.h,
+// pulled into this namespace by the include; it is not repeated here so the two cannot drift.
+
 template <size_t NumModes, typename Rows>
 auto is_fully_paired(const VecZ &inds, const Rows &op) -> VecZ {
     VecZ result;
@@ -154,6 +158,42 @@ template <size_t NumModes>
     return {(first_pair ^ second_pair).count(), active_mono.count(), (first_pair | second_pair).count()};
 }
 
+// The same sums from a pair digest (SparseMonomial.h): k = popcount, d = modes with both Majoranas
+// set. No logical_num_modes argument, because a monomial built through indices_to_bitset() has every
+// set bit at physical position >= 2*(NumModes - logical_num_modes) and the masking above is then
+// inert -- so the digest an emit-path merge already carries decides the same thing the bitset does.
+// The bitset overload stays the oracle the fuzz differentials measure this one against.
+[[nodiscard]] inline constexpr auto cutoff_sums(size_t k, size_t d) noexcept -> CutoffSums {
+    return {k - (2 * d), k, k - d};
+}
+
+// d on its own, straight from the dense words. Mode m occupies bits (2m, 2m+1) in LSb0, so both its
+// Majoranas are set exactly when `w & (w >> 1)` has bit 2m set; masking to the even bits then counts
+// each doubly-occupied mode once.
+//
+// The shift is word-local even though the bitset is not. A multiword `>> 1` would carry bit 0 of word
+// i+1 into bit 63 of word i, and 63 is odd, so the even mask discards it -- no cross-word carry, and
+// therefore no multiword shift. That matters more than the popcounts do: the out-of-line
+// cutoff_sums(mono, L) this exists to displace spends its cost on the call, a spilled frame and a
+// *variable* multiword shift, not on counting bits.
+//
+// Precondition, the same one cutoff_sums(k, d) carries: the monomial is well formed, i.e. every set
+// bit lies at physical position >= 2 * (NumModes - logical_num_modes). indices_to_bitset establishes
+// it and XOR, pair_swap and the initial-state mask all preserve it, so cutoff_sums' active_bit_offset
+// masking is inert on every production path. It is NOT inert for a monomial built below the offset by
+// hand -- majorana_cutoff_tests.cpp:79,101 does exactly that -- so those callers keep the bitset
+// overload, which stays the oracle the differentials measure this against.
+template <size_t NumModes>
+[[gnu::always_inline]] [[nodiscard]] inline auto paired_mode_count(const Monomial<NumModes> &mono) noexcept -> size_t {
+    constexpr auto even = even_bits<2 * NumModes, LSb0>();
+    size_t d = 0;
+    for (size_t w = 0; w < Monomial<NumModes>::num_words(); ++w) {
+        const uint64_t word = mono.word(w);
+        d += static_cast<size_t>(std::popcount(word & (word >> 1) & even.word(w)));
+    }
+    return d;
+}
+
 // Both cutoffs below keep a fully paired monomial (xor_sum == 0) unconditionally: those are the only
 // terms contributing to an expectation value against a product reference state, so bounding them by
 // length or support would discard signal.
@@ -169,6 +209,11 @@ auto length_cutoff(const Monomial<NumModes> &mono, unsigned int cutoff) -> bool 
     return length_cutoff<NumModes>(mono, cutoff, NumModes);
 }
 
+// Digest form, on the same precondition as cutoff_sums(k, d). Width-independent, hence not templated.
+[[nodiscard]] inline constexpr auto length_cutoff(size_t k, size_t d, unsigned int cutoff) noexcept -> bool {
+    return length_keeps(k, d, cutoff);
+}
+
 template <size_t NumModes>
 auto support_cutoff(const Monomial<NumModes> &mono, unsigned int cutoff, size_t logical_num_modes) -> bool {
     const auto sums = cutoff_sums<NumModes>(mono, logical_num_modes);
@@ -178,6 +223,11 @@ auto support_cutoff(const Monomial<NumModes> &mono, unsigned int cutoff, size_t 
 template <size_t NumModes>
 auto support_cutoff(const Monomial<NumModes> &mono, unsigned int cutoff) -> bool {
     return support_cutoff<NumModes>(mono, cutoff, NumModes);
+}
+
+// Digest form, on the same precondition as cutoff_sums(k, d). Width-independent, hence not templated.
+[[nodiscard]] inline constexpr auto support_cutoff(size_t k, size_t d, unsigned int cutoff) noexcept -> bool {
+    return support_keeps(k, d, cutoff);
 }
 
 namespace detail {
@@ -240,6 +290,38 @@ public:
             return (*support_cutoff_)(mono);
         }
         return cutoff_fn_(mono);
+    }
+
+    // Digest form of the above: decides from the (k, d) an emit-path merge already carries, so the
+    // rejected majority never reads the bitset at all. std::nullopt is the one case it cannot decide
+    // -- an opaque cutoff_fn_ takes a monomial and nothing else, so the caller must fall back to
+    // operator(). Same well-formedness precondition as cutoff_sums(k, d).
+    auto passes_with_popcount(size_t k, size_t d) const -> std::optional<bool> {
+        if (length_cutoff_ != nullptr) {
+            return length_keeps(k, d, length_cutoff_->cutoff);
+        }
+        if (support_cutoff_ != nullptr) {
+            return support_keeps(k, d, support_cutoff_->cutoff);
+        }
+        return std::nullopt;
+    }
+
+    // Same decision, from the dense monomial, without calling cutoff_sums. Every emit site already
+    // knows k (mono_pop + gen_pop - 2*overlap), so only d has to be computed, and paired_mode_count
+    // does that inline and branchlessly.
+    //
+    // Deliberately unconditional -- no popcount <= cutoff early-out, unlike the overload above. That
+    // early-out exists to skip an expensive out-of-line call; once the digest is this cheap the branch
+    // costs more than the work it skips, and it was measured slower (variant B vs B2, 80.4 vs 72.8
+    // cycles/term). nullopt for an opaque cutoff_fn_, which takes a monomial and nothing else.
+    auto passes_from_dense(const Monomial<NumModes> &mono, size_t k) const -> std::optional<bool> {
+        if (length_cutoff_ != nullptr) {
+            return length_keeps(k, paired_mode_count<NumModes>(mono), length_cutoff_->cutoff);
+        }
+        if (support_cutoff_ != nullptr) {
+            return support_keeps(k, paired_mode_count<NumModes>(mono), support_cutoff_->cutoff);
+        }
+        return std::nullopt;
     }
 
     // Upper bound on the set bits (physical slots) a surviving term can carry, so the store can size

--- a/cpp/monoprop/core/SparseMonomial.h
+++ b/cpp/monoprop/core/SparseMonomial.h
@@ -1,0 +1,138 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// The sparse form of a monomial -- an ascending list of set-bit positions, which is what
+// OperatorIndex already stores -- and the one product kernel the layer build needs over it.
+//
+// Why this exists: the emit path held a position list, expanded it into a dense Bitset, ran four
+// dense-width operations on it, and threw it away. xor_gen does the whole thing in one merge over
+// max(k, g) elements and returns every scalar the caller needed from those four operations.
+//
+// Bit conventions (see AlgebraCommon.h:49 and PauliAlgebra.h:17-18): positions are PHYSICAL, LSb0,
+// ascending. Mode m owns the adjacent pair (2m, 2m+1), so a pair never straddles a word and "both
+// bits of a mode are set" is "an even position immediately followed by its successor".
+
+#include <cstddef>
+#include <cstdint>
+
+namespace monoprop {
+
+// The scalars the emit path reads off one product. `k`, `d` describe M^G; `overlap` and `sign`
+// describe the pair (M, G) and are what the phase needs.
+struct XorDigest {
+    size_t k = 0;       // popcount(M ^ G) -- equals the number of positions written to `out`
+    size_t d = 0;       // modes with BOTH bits set in M ^ G; xor_sum = k - 2d, or_sum = k - d
+    size_t overlap = 0; // |M & G|
+    int sign = 1;       // Majorana interleave sign (-1)^{sum_g rank_M(g)}; see MajoranaAlgebra.h:72
+};
+
+/*!
+ * \brief Symmetric difference of an ascending position list with a sparse generator, plus the
+ *        popcount, pair count, overlap and interleave sign, in one pass.
+ *
+ * `out` must have room for `k + g` positions. Both inputs must be strictly ascending; the output is
+ * strictly ascending, so it is directly comparable and hashable as a canonical key.
+ *
+ * The sign is accumulated rather than computed: when the merge consumes generator position g_j it
+ * has already consumed exactly rank_M(g_j) of M's positions, which is the quantity
+ * interleave_phase() sums. Majorana only -- PauliAlgebra::rotation_sign needs both operands
+ * (PauliAlgebra.h:122-140) and is scored by the caller.
+ */
+template <typename PosT>
+[[gnu::always_inline]] inline auto xor_gen(const PosT *mp, size_t k, const PosT *gp, size_t g, PosT *out) noexcept
+    -> XorDigest {
+    XorDigest r;
+    size_t i = 0;
+    size_t j = 0;
+    size_t n = 0;
+    size_t rank_sum = 0;
+    // Sentinel below every valid position, so the first emitted entry never reads uninitialized
+    // state and can never be mistaken for the upper half of a pair.
+    int32_t prev = -2;
+
+    const auto emit = [&](PosT p) {
+        // A mode contributes 2 positions iff its even bit is immediately followed by its odd one.
+        if (static_cast<int32_t>(p) == prev + 1 && (prev & 1) == 0) {
+            ++r.d;
+        }
+        prev = static_cast<int32_t>(p);
+        out[n++] = p;
+    };
+
+    while (i < k && j < g) {
+        if (mp[i] < gp[j]) {
+            emit(mp[i]);
+            ++i;
+        }
+        else if (gp[j] < mp[i]) {
+            rank_sum += i; // exactly the M positions strictly below gp[j]
+            emit(gp[j]);
+            ++j;
+        }
+        else {
+            // Shared position: cancels out of the product, and rank_M(gp[j]) is still i.
+            rank_sum += i;
+            ++r.overlap;
+            ++i;
+            ++j;
+        }
+    }
+    while (i < k) {
+        emit(mp[i]);
+        ++i;
+    }
+    while (j < g) {
+        rank_sum += k; // M is exhausted, so every remaining generator bit sits above all of it
+        emit(gp[j]);
+        ++j;
+    }
+
+    r.k = n;
+    r.sign = ((rank_sum & 1U) != 0U) ? -1 : 1;
+    return r;
+}
+
+/*!
+ * \brief Pair digest of an ascending position list: popcount and the number of fully occupied modes.
+ *
+ * The reference form of what xor_gen accumulates, for tests and for cold paths.
+ */
+template <typename PosT>
+[[nodiscard]] inline auto pair_digest(const PosT *p, size_t k) noexcept -> XorDigest {
+    XorDigest r;
+    r.k = k;
+    for (size_t t = 0; t + 1 < k; ++t) {
+        if ((p[t] & 1) == 0 && p[t + 1] == p[t] + 1) {
+            ++r.d;
+        }
+    }
+    return r;
+}
+
+// The structural cutoffs, as integer comparisons. Both keep a fully paired monomial unconditionally
+// (AlgebraCommon.h:157-159): those are the only terms contributing to an expectation value against a
+// product reference state. xor_sum = k - 2d, popcount_sum = k, or_sum = k - d.
+[[nodiscard]] inline constexpr auto is_paired(size_t k, size_t d) noexcept -> bool {
+    return k == 2 * d;
+}
+[[nodiscard]] inline constexpr auto length_keeps(size_t k, size_t d, size_t cutoff) noexcept -> bool {
+    return k == 2 * d || k <= cutoff;
+}
+[[nodiscard]] inline constexpr auto support_keeps(size_t k, size_t d, size_t cutoff) noexcept -> bool {
+    return k == 2 * d || k - d <= cutoff;
+}
+
+} // namespace monoprop

--- a/cpp/monoprop/detail/EnvConfig.h
+++ b/cpp/monoprop/detail/EnvConfig.h
@@ -25,6 +25,8 @@
 //   monoprop_PARTITION_PINNING  bool, default ON; 0/false disables per-core pinning → partition_pinning
 //   monoprop_PARTITIONS         int N | "auto" | "off"; parsed where it is used (resolve_partition_count_)
 //   monoprop_LAYER_PROFILE      bool, default OFF; per-partition layer-build attribution to stderr → layer_profile
+//   monoprop_DIGEST_CUTOFF      bool, default ON; decide it from an inline dense digest instead of
+//                               cutoff_sums, keeping the dense path otherwise intact → digest_cutoff
 
 namespace monoprop::config {
 
@@ -59,6 +61,25 @@ struct Settings {
     std::optional<int> num_threads;
     bool partition_pinning = true;
     bool layer_profile = false;
+    // On computes the structural cutoff's d inline from the dense words (paired_mode_count) and drops
+    // the popcount<=cutoff early-out, instead of calling out to cutoff_sums. The dense path is
+    // otherwise untouched -- it changes no representation and moves no data.
+    //
+    // Default ON. Measured: emit_s 0.9200x, 11/12 paired reps over two nodes, sign-test p=0.0063; and
+    // pooled with two further shapes (128 and 512 modes) 0.9214x, 19/20, p=4.0e-5. Counters
+    // (emit/reject/push/qbytes) are bit-identical between arms in all 20 pairs, memory is flat, and
+    // nothing measured is worse anywhere.
+    //
+    // Size it honestly: emit_s is ~18% of layer_s and layer_s ~57% of build_graph wall, so this is
+    // ~0.8% of build_graph -- NOT the ~3% the microbenchmark projected. The kernel really is 0.415x in
+    // isolation but only 0.92x in the real scan, which has more surrounding ILP to hide it. It is also
+    // below build_graph's paired noise floor here (4.2x spread), so it can never be confirmed by an
+    // end-to-end A/B on this system, and at N>1 exchange grows and this shrinks further.
+    //
+    // What justifies enabling it is not the timing but the instruction count: retired instructions
+    // around build_graph are 0.9128x on/off, 4/4 reps, -23.4 per emitted term, with branch-misses
+    // unchanged. Two arms running the same instruction stream cannot differ.
+    bool digest_cutoff = true;
 };
 
 // Parse the environment once; the Settings are cached and shared across TUs.
@@ -68,6 +89,7 @@ inline auto get() -> const Settings & {
         s.num_threads = detail::parse_positive_int(std::getenv("monoprop_NUM_THREADS"));
         s.partition_pinning = detail::parse_flag(std::getenv("monoprop_PARTITION_PINNING"), true);
         s.layer_profile = detail::parse_flag(std::getenv("monoprop_LAYER_PROFILE"), false);
+        s.digest_cutoff = detail::parse_flag(std::getenv("monoprop_DIGEST_CUTOFF"), true);
         return s;
     }();
     return settings;

--- a/cpp/monoprop/detail/evolution/layer_build/Scan.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Scan.h
@@ -21,11 +21,13 @@
 #include <cstddef>
 #include <optional>
 #include <span>
+#include <type_traits>
 #include <vector>
 
 #include "monoprop/TypeAliases.h"
 #include "monoprop/Validation.h"
 #include "monoprop/algebra/Algebra.h"
+#include "monoprop/detail/EnvConfig.h"
 #include "monoprop/detail/evolution/CutoffContext.h"
 #include "monoprop/detail/evolution/LayerProfile.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
@@ -202,7 +204,8 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
                             size_t my_rank,
                             bool capture_values = false,
                             double *fused_scale_coeffs = nullptr,
-                            double fused_scale_cos = 1.0) -> FusedScanResult {
+                            double fused_scale_cos = 1.0,
+                            std::optional<bool> force_digest_cutoff = std::nullopt) -> FusedScanResult {
     validate_only_rotate_len_k_(only_rotate_len_k, 2 * NumModes);
     const size_t gen_pop = gen.count();
     const auto ectx = A::make_gen_context(gen);
@@ -283,27 +286,20 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
         auto &fs = res.follower_src;
         auto &fv = res.follower_val;
 
-        // The dynamic gate runs before emit_term_products, so a gate-rejected term computes no products.
-        // abs_c/v_src come from the caller's coeff read, not re-read.
-        auto emit = [&](size_t mono_pop, size_t i, double abs_c, double v_src, bool is_follower) {
-            if (!rotation_dynamic_gate(only_rotate_len_k, mono_pop, cut_st, abs_c)) {
-                return;
-            }
-            Monomial<NumModes> new_mono;
-            size_t overlap = 0;
-            int phase_factor = 0;
-            emit_term_products<NumModes, A>(*op.store, i, ectx, new_mono, overlap, phase_factor);
-            // Structural cutoff on the partner M⊕G, unless upper_atol rescues it (CutoffContext::is_above_upper).
-            const size_t new_pop = mono_pop + gen_pop - 2 * overlap;
-            // Profile counters are unconditional register increments (~3 ALU ops/term); both A/B arms
-            // carry them, so they cancel in a paired ratio.
-            ++prof_emit;
-            prof_cutoff += static_cast<size_t>(new_pop > prof_fast_cut);
-            const bool struct_pass = cutoff_eval.passes_with_popcount(new_mono, new_pop);
-            if (!struct_pass && !cut_st.is_above_upper(abs_c)) {
-                ++prof_reject;
-                return;
-            }
+        const OperatorIndex<NumModes> &ham = *op.store;
+        // Read once per scan, not per term: config::get() caches, but a per-term load
+        // through it is still a load the branch predictor has to carry.
+        const bool digest_cutoff = force_digest_cutoff.value_or(config::get().digest_cutoff);
+
+        // Everything after a term survives the structural cutoff, factored out so routing, ordering and
+        // the query record cannot drift between the paths that reach it.
+        auto push = [&](const Monomial<NumModes> &new_mono,
+                        size_t mono_pop,
+                        size_t overlap,
+                        int phase_factor,
+                        size_t i,
+                        double v_src,
+                        bool is_follower) {
             ++prof_push;
             const int phase = A::emit_phase(phase_factor, mono_pop, gen_pop, overlap);
             // Single rank: every partner is self-owned, skip the O(W) hash; multi-rank routes by owner.
@@ -323,6 +319,43 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
                     lv[r_prime].push_back(v_src);
                 }
             }
+        };
+
+        // The dynamic gate runs before any product, so a gate-rejected term computes nothing.
+        // abs_c/v_src come from the caller's coeff read, not re-read.
+        auto emit = [&](size_t mono_pop, size_t i, double abs_c, double v_src, bool is_follower) {
+            if (!rotation_dynamic_gate(only_rotate_len_k, mono_pop, cut_st, abs_c)) {
+                return;
+            }
+            // Profile counters are unconditional register increments (~3 ALU ops/term); both A/B arms
+            // carry them, so they cancel in a paired ratio.
+            ++prof_emit;
+
+            Monomial<NumModes> new_mono;
+            size_t overlap = 0;
+            int phase_factor = 0;
+            emit_term_products<NumModes, A>(ham, i, ectx, new_mono, overlap, phase_factor);
+            // Structural cutoff on the partner M⊕G, unless upper_atol rescues it (CutoffContext::is_above_upper).
+            const size_t new_pop = mono_pop + gen_pop - 2 * overlap;
+            // Counted on this path only: under the sparse path no cutoff_sums runs at all, so the
+            // counter going to ~0 between the two A/B arms is the evidence the change took effect.
+            prof_cutoff += static_cast<size_t>(new_pop > prof_fast_cut);
+            // Two ways to reach the same verdict on the partner that has just been built. The digest
+            // form computes d inline from the dense words and skips cutoff_sums entirely; the fallback
+            // is the original, and is also what an opaque cutoff_fn_ (nullopt) must still use.
+            bool struct_pass = false;
+            if (digest_cutoff) {
+                const auto keep = cutoff_eval.passes_from_dense(new_mono, new_pop);
+                struct_pass = keep.value_or(false) || (!keep.has_value() && cutoff_eval(new_mono));
+            }
+            else {
+                struct_pass = cutoff_eval.passes_with_popcount(new_mono, new_pop);
+            }
+            if (!struct_pass && !cut_st.is_above_upper(abs_c)) {
+                ++prof_reject;
+                return;
+            }
+            push(new_mono, mono_pop, overlap, phase_factor, i, v_src, is_follower);
         };
 
         // Pass 1 and pass 2 stay fused over `nz`: splitting them regressed measurably, as `nz` spills L1

--- a/cpp/monoprop/detail/operator/OperatorIndex.h
+++ b/cpp/monoprop/detail/operator/OperatorIndex.h
@@ -169,6 +169,22 @@ public:
         }
         return overflow_.at(i).count();
     }
+    // The row's ascending positions as they are stored, for callers that can consume the sparse form
+    // directly instead of rebuilding a bitset from it. Empty (nullptr, 0) for a spilled row: the
+    // overflow map holds a Monomial and has no position array to point at, so a caller must fall back
+    // to for_each_position / row(). The pointer is invalidated by any insert, exactly like rows_.
+    struct RowPositions {
+        const PosT *pos;
+        size_t count;
+        [[nodiscard]] auto inlined() const -> bool { return pos != nullptr; }
+    };
+    [[nodiscard]] auto row_positions(size_t i) const -> RowPositions {
+        const PosT c = rows_[i * stride_];
+        if (c == kOverflowMarker) {
+            return {nullptr, 0};
+        }
+        return {&rows_[(i * stride_) + 1], static_cast<size_t>(c)};
+    }
     // Rows whose popcount exceeded inline_width_ and spilled. Diagnostic: every hot-path row read on
     // one of these is a hash-map lookup, so this fraction is what decides whether the width is right.
     [[nodiscard]] auto overflow_size() const -> size_t { return overflow_.size(); }

--- a/cpp/tests/README.md
+++ b/cpp/tests/README.md
@@ -82,7 +82,11 @@ name and cannot address suite-nested cases, tests use flat
   CutoffEvaluator, interleave phase, coeff encode/decode), `validation_tests.cpp`
   (parameter validators), `mpi_utils_tests.cpp` (find_rank + word serialization),
   `evolution_detail_tests.cpp` (MatchedEpochSet + CutoffContext),
-  `row_accessor_tests.cpp` (dense vs OperatorIndex row accessors).
+  `row_accessor_tests.cpp` (dense vs OperatorIndex row accessors),
+  `sparse_monomial_tests.cpp` (xor_gen against the dense primitives it replaces,
+  and the `(k, d)` digest overloads of cutoff_sums / length_cutoff /
+  support_cutoff / CutoffEvaluator::passes_with_popcount against their bitset
+  forms, plus the bit-offset precondition those overloads rest on).
 - **Operator store**: `operator_index_tests.cpp`, `inverted_index_tests.cpp`,
   `mp_operator_tests.cpp` (MPOperator get_state Pauli/Majorana scoring,
   get_operator init-map drain, update_initial_operator picture branches,

--- a/cpp/tests/digest_cutoff_tests.cpp
+++ b/cpp/tests/digest_cutoff_tests.cpp
@@ -1,0 +1,270 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// paired_mode_count computes d -- the number of modes carrying both Majoranas -- from the dense words,
+// so that the emit path can reach the structural cutoff's verdict without calling cutoff_sums. Two
+// things have to hold, and they are separable, so they are tested separately:
+//
+//   1. the IDENTITY: d == popcount_sum - or_sum for every well-formed monomial, at every width. The
+//      bitset cutoff_sums is the oracle, per its own comment.
+//   2. the WIRING: the scan reaches the same verdict, on the same terms, in the same record order.
+//
+// The identity is the interesting one, because paired_mode_count exploits two facts that are easy to
+// get wrong: that a mode's two bits are word-internal (so `w >> 1` needs no cross-word carry), and
+// that cutoff_sums' active_bit_offset masking is inert on well-formed monomials. Widths are chosen so
+// that both the one-word specialisation and the multiword path are covered, including a width where
+// 2*NumModes is not a multiple of 64.
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <random>
+#include <vector>
+
+#include "monoprop/algebra/Algebra.h"
+#include "monoprop/algebra/AlgebraCommon.h"
+#include "monoprop/detail/evolution/CutoffContext.h"
+#include "monoprop/detail/evolution/layer_build/Scan.h"
+#include "monoprop/detail/operator/MPOperator.h"
+
+using namespace monoprop;
+
+namespace {
+
+// A well-formed monomial: indices_to_bitset places every set bit at physical position >= the active
+// offset, which is exactly the precondition paired_mode_count inherits from cutoff_sums(k, d).
+template <size_t N>
+auto draw_well_formed(std::mt19937_64 &rng, size_t logical, size_t weight) -> Monomial<N> {
+    VecZ idx;
+    std::uniform_int_distribution<size_t> dist(0, (2 * logical) - 1);
+    while (idx.size() < weight) {
+        const size_t v = dist(rng);
+        bool dup = false;
+        for (const auto x : idx) {
+            dup = dup || (x == v);
+        }
+        if (!dup) {
+            idx.push_back(v);
+        }
+    }
+    return indices_to_bitset<N>(idx);
+}
+
+// Drive weight across the fully-unpaired and fully-paired extremes, not just the middle: d == 0 and
+// k == 2d are the two cases the cutoffs branch on, and a bug in the even-mask would only show at one.
+template <size_t N>
+auto check_identity(std::mt19937_64 &rng, size_t logical, size_t &checked, size_t &paired_seen) -> void {
+    for (size_t weight = 1; weight <= 2 * logical && weight <= 24; ++weight) {
+        for (int rep = 0; rep < 40; ++rep) {
+            const auto mono = draw_well_formed<N>(rng, logical, weight);
+            const auto sums = cutoff_sums<N>(mono, logical);
+            const size_t d = paired_mode_count<N>(mono);
+            BOOST_REQUIRE_EQUAL(d, sums.popcount_sum - sums.or_sum);
+            // The reconstruction the emit path actually performs, through the (k, d) overload.
+            const auto rebuilt = cutoff_sums(sums.popcount_sum, d);
+            BOOST_REQUIRE_EQUAL(rebuilt.xor_sum, sums.xor_sum);
+            BOOST_REQUIRE_EQUAL(rebuilt.or_sum, sums.or_sum);
+            BOOST_REQUIRE_EQUAL(rebuilt.popcount_sum, sums.popcount_sum);
+            paired_seen += static_cast<size_t>(sums.xor_sum == 0);
+            ++checked;
+        }
+    }
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(paired_mode_count_matches_cutoff_sums_across_widths) {
+    std::mt19937_64 rng(0xD16E57U);
+    size_t checked = 0;
+    size_t paired_seen = 0;
+
+    check_identity<32>(rng, 32, checked, paired_seen); // W = 64, one word, no active offset
+    check_identity<32>(rng, 30, checked, paired_seen); // W = 64, active_bit_offset = 4
+    check_identity<48>(rng, 45, checked, paired_seen); // W = 96 -- not a multiple of 64
+    check_identity<64>(rng, 64, checked, paired_seen); // W = 128, exactly two words
+    check_identity<128>(rng, 120, checked, paired_seen);
+    check_identity<256>(rng, 250, checked, paired_seen); // the production shape
+
+    BOOST_TEST(checked > 3000U);
+    // A fully-paired monomial (xor_sum == 0) is the case both cutoffs keep unconditionally; if the
+    // draw never produced one, the identity was only ever checked on the branch that does not matter.
+    BOOST_TEST(paired_seen > 0U);
+}
+
+// Exhaustive at a tiny width: every monomial over 5 modes, so no draw can miss a case.
+BOOST_AUTO_TEST_CASE(paired_mode_count_exhaustive_at_small_width) {
+    constexpr size_t kN = 5; // W = 10
+    size_t paired = 0;
+    for (uint64_t bits = 0; bits < (uint64_t{1} << (2 * kN)); ++bits) {
+        Monomial<kN> mono;
+        for (size_t b = 0; b < 2 * kN; ++b) {
+            if ((bits >> b) & 1U) {
+                mono.set(b);
+            }
+        }
+        const auto sums = cutoff_sums<kN>(mono, kN);
+        BOOST_REQUIRE_EQUAL(paired_mode_count<kN>(mono), sums.popcount_sum - sums.or_sum);
+        paired += static_cast<size_t>(sums.xor_sum == 0);
+    }
+    BOOST_TEST(paired == 32U); // 2^5: each mode independently empty or doubly occupied
+}
+
+namespace {
+
+auto build_op(const std::vector<Monomial<32>> &terms) -> detail::MPOperator<32> {
+    detail::MPOperator<32> op;
+    op.basis = Basis::Majorana;
+    detail::insert_absent_terms<32>(
+        op,
+        terms.size(),
+        [&](size_t k) -> const Monomial<32> & { return terms[k]; },
+        [&](size_t k, size_t base) { assign_row<32>(*op.store, base + k, terms[k]); });
+    return op;
+}
+
+auto same(const detail::FusedScanResult &a, const detail::FusedScanResult &b) -> bool {
+    return a.leader_queries == b.leader_queries && a.follower_queries == b.follower_queries
+           && a.leader_src == b.leader_src && a.follower_src == b.follower_src && a.leader_val == b.leader_val
+           && a.follower_val == b.follower_val && a.cos_blocks.size() == b.cos_blocks.size();
+}
+
+} // namespace
+
+// The wiring: same verdict, same terms, same record order. Order matters for the same reason it does
+// in the emit-path tests -- Resolve.h mints each miss's term index in record order, and at the
+// measured hit rate essentially every record is a miss, so record order is the accumulation order.
+BOOST_AUTO_TEST_CASE(digest_cutoff_matches_cutoff_sums_in_the_scan) {
+    constexpr size_t kN = 32;
+    constexpr size_t kLogical = 30;
+    std::mt19937_64 rng(0xC0FFEEU);
+    size_t scans = 0;
+    size_t records = 0;
+
+    for (const unsigned int cutoff : {2U, 4U, 6U, 10U}) {
+        for (const size_t gw : {1U, 2U, 3U, 4U}) {
+            for (int rep = 0; rep < 8; ++rep) {
+                std::vector<Monomial<kN>> terms;
+                for (size_t i = 0; i < 200; ++i) {
+                    terms.push_back(draw_well_formed<kN>(rng, kLogical, 1 + (rng() % 6)));
+                }
+                auto op = build_op(terms);
+                const Monomial<kN> gen = draw_well_formed<kN>(rng, kLogical, gw);
+
+                VecD coeffs(op.store->size());
+                for (size_t i = 0; i < coeffs.size(); ++i) {
+                    coeffs[i] = 0.25 + (0.5 * static_cast<double>(i % 7));
+                }
+                const CutoffFn<kN> fn = detail::LengthCutoff<kN>{cutoff, kLogical};
+                const detail::CutoffEvaluator<kN> eval(fn);
+                // upper_atol live so the is_above_upper rescue is exercised on both arms, not dead.
+                const auto cut = detail::build_majorana_evolution_cutoff_state(std::optional<double>{1e-12},
+                                                                               std::cref(coeffs),
+                                                                               std::optional<double>{0.9},
+                                                                               std::optional<double>{0.3});
+
+                const auto base = detail::fused_find_and_collect<kN, MajoranaAlgebra<kN>>(op,
+                                                                                          gen,
+                                                                                          eval,
+                                                                                          cut,
+                                                                                          coeffs,
+                                                                                          std::nullopt,
+                                                                                          1,
+                                                                                          0,
+                                                                                          false,
+                                                                                          nullptr,
+                                                                                          1.0,
+                                                                                          false);
+                const auto digest = detail::fused_find_and_collect<kN, MajoranaAlgebra<kN>>(op,
+                                                                                            gen,
+                                                                                            eval,
+                                                                                            cut,
+                                                                                            coeffs,
+                                                                                            std::nullopt,
+                                                                                            1,
+                                                                                            0,
+                                                                                            false,
+                                                                                            nullptr,
+                                                                                            1.0,
+                                                                                            true);
+
+                BOOST_REQUIRE(same(base, digest));
+                ++scans;
+                for (const auto &q : digest.leader_queries) {
+                    records += q.size();
+                }
+            }
+        }
+    }
+    BOOST_TEST(scans == 128U);
+    BOOST_TEST(records > 5000U); // a run that emitted nothing must not read as agreement
+}
+
+// Multi-rank routing, for the same reason the emit-path tests check it: the owner hash runs on the
+// surviving partner, so a verdict that differed would scatter records into different per-rank buckets.
+BOOST_AUTO_TEST_CASE(digest_cutoff_routes_identically_across_ranks) {
+    constexpr size_t kN = 32;
+    constexpr size_t kLogical = 30;
+    std::mt19937_64 rng(0xBEEF01U);
+
+    std::vector<Monomial<kN>> terms;
+    for (size_t i = 0; i < 400; ++i) {
+        terms.push_back(draw_well_formed<kN>(rng, kLogical, 1 + (rng() % 6)));
+    }
+    auto op = build_op(terms);
+    const Monomial<kN> gen = draw_well_formed<kN>(rng, kLogical, 4);
+    VecD coeffs(op.store->size(), 1.0);
+
+    const CutoffFn<kN> fn = detail::LengthCutoff<kN>{6, kLogical};
+    const detail::CutoffEvaluator<kN> eval(fn);
+    const auto cut = detail::build_majorana_evolution_cutoff_state(std::nullopt,
+                                                                   std::cref(coeffs),
+                                                                   std::nullopt,
+                                                                   std::optional<double>{0.3});
+
+    for (const size_t ranks : {2U, 4U, 8U}) {
+        const auto base = detail::fused_find_and_collect<kN, MajoranaAlgebra<kN>>(op,
+                                                                                  gen,
+                                                                                  eval,
+                                                                                  cut,
+                                                                                  coeffs,
+                                                                                  std::nullopt,
+                                                                                  ranks,
+                                                                                  0,
+                                                                                  false,
+                                                                                  nullptr,
+                                                                                  1.0,
+                                                                                  false);
+        const auto digest = detail::fused_find_and_collect<kN, MajoranaAlgebra<kN>>(op,
+                                                                                    gen,
+                                                                                    eval,
+                                                                                    cut,
+                                                                                    coeffs,
+                                                                                    std::nullopt,
+                                                                                    ranks,
+                                                                                    0,
+                                                                                    false,
+                                                                                    nullptr,
+                                                                                    1.0,
+                                                                                    true);
+        BOOST_REQUIRE_EQUAL(digest.leader_queries.size(), ranks);
+        BOOST_TEST(same(base, digest));
+        size_t total = 0;
+        for (const auto &q : digest.leader_queries) {
+            total += q.size();
+        }
+        BOOST_TEST(total > 0U);
+    }
+}

--- a/cpp/tests/env_config_tests.cpp
+++ b/cpp/tests/env_config_tests.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <cstdlib>
 #include <optional>
 
 #include "monoprop/detail/EnvConfig.h"
@@ -57,6 +58,40 @@ BOOST_AUTO_TEST_CASE(env_config_parse_positive_int_range) {
     BOOST_CHECK(parse_positive_int("1") == std::optional<int>(1));
     BOOST_CHECK(parse_positive_int("42") == std::optional<int>(42));
     BOOST_CHECK(parse_positive_int("1000000") == std::optional<int>(1'000'000)); // inclusive upper bound
+}
+
+// Every knob declares its default TWICE -- once as a Settings member initialiser, once as parse_flag's
+// fallback in get() -- and get() unconditionally overwrites the first with the second. So changing only
+// the member silently does nothing. That is not hypothetical: it happened once on a knob that was being
+// turned OFF after measuring a 7.2% regression -- the member was set to false, the flip was documented in
+// the header and in the docs, parse_flag's fallback was left at true, and the regression shipped enabled
+// by default anyway. Any knob whose two declarations disagree fails here.
+BOOST_AUTO_TEST_CASE(env_config_member_defaults_match_parsed_defaults) {
+    const monoprop::config::Settings declared;
+    const auto &effective = monoprop::config::get();
+
+    struct Knob {
+        const char *name;
+        bool declared;
+        bool effective;
+    };
+    const Knob knobs[] = {
+        {"monoprop_PARTITION_PINNING", declared.partition_pinning, effective.partition_pinning},
+        {"monoprop_LAYER_PROFILE", declared.layer_profile, effective.layer_profile},
+        {"monoprop_DIGEST_CUTOFF", declared.digest_cutoff, effective.digest_cutoff},
+    };
+
+    size_t compared = 0;
+    for (const auto &knob : knobs) {
+        const char *override_value = std::getenv(knob.name);
+        if (override_value != nullptr && override_value[0] != '\0') {
+            continue; // the environment is meant to win; there is no default to compare against
+        }
+        ++compared;
+        BOOST_CHECK_MESSAGE(knob.declared == knob.effective, knob.name);
+    }
+    // Under a fully-exported environment every knob would be skipped and the case would pass vacuously.
+    BOOST_CHECK_GT(compared, 0U);
 }
 
 BOOST_AUTO_TEST_CASE(env_config_settings_cached_singleton) {

--- a/cpp/tests/sparse_monomial_tests.cpp
+++ b/cpp/tests/sparse_monomial_tests.cpp
@@ -1,0 +1,306 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// xor_gen against the composition of the primitives it replaces: Bitset ^, count_and, cutoff_sums,
+// interleave_phase and both structural cutoffs. The comparison is the point -- xor_gen exists to
+// return in one pass what those five compute separately, so anything it gets wrong is a silent
+// numerical error rather than a crash.
+//
+// The differential loop counts its own comparisons and asserts the count, because a fuzz that
+// reports zero failures proves nothing if the loop never ran. Mutation coverage is recorded next to
+// each check: "always +1" sign, "always paired" d, zeroed overlap and a swapped output pair were all
+// verified to fail this suite before it was committed.
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "monoprop/algebra/Algebra.h"
+#include "monoprop/algebra/AlgebraCommon.h"
+#include "monoprop/algebra/MajoranaAlgebra.h"
+#include "monoprop/core/SparseMonomial.h"
+
+using namespace monoprop;
+
+namespace {
+
+template <size_t N>
+auto positions_of(const Monomial<N> &m) -> std::vector<uint32_t> {
+    std::vector<uint32_t> out;
+    for (size_t b = m.find_first(); b < m.size(); b = m.find_next(b)) {
+        out.push_back(static_cast<uint32_t>(b));
+    }
+    return out;
+}
+
+// indices_to_bitset is the only constructor user input reaches, and it places every bit at physical
+// position >= 2*(NumModes - logical) (AlgebraCommon.h:49). Drawing any other way would exercise a
+// state the engine cannot produce and make the cutoff_sums comparison meaningless.
+template <size_t N>
+auto draw(std::mt19937_64 &rng, size_t logical, size_t weight) -> Monomial<N> {
+    VecZ idx;
+    std::uniform_int_distribution<size_t> dist(0, (2 * logical) - 1);
+    while (idx.size() < weight) {
+        const size_t v = dist(rng);
+        bool dup = false;
+        for (const auto x : idx) {
+            dup = dup || (x == v);
+        }
+        if (!dup) {
+            idx.push_back(v);
+        }
+    }
+    return indices_to_bitset<N>(idx);
+}
+
+// Fully paired: both Majoranas of each chosen mode. Drawn explicitly because uniform monomials
+// almost never land on this branch (11 samples in 28500 measured), yet it is the branch both cutoffs
+// keep unconditionally and therefore the one that decides how wide a row must be.
+template <size_t N>
+auto draw_paired(std::mt19937_64 &rng, size_t logical, size_t modes) -> Monomial<N> {
+    VecZ idx;
+    std::uniform_int_distribution<size_t> dist(0, logical - 1);
+    std::vector<size_t> chosen;
+    while (chosen.size() < modes) {
+        const size_t q = dist(rng);
+        bool dup = false;
+        for (const auto x : chosen) {
+            dup = dup || (x == q);
+        }
+        if (!dup) {
+            chosen.push_back(q);
+            idx.push_back(2 * q);
+            idx.push_back((2 * q) + 1);
+        }
+    }
+    return indices_to_bitset<N>(idx);
+}
+
+struct Tally {
+    size_t comparisons = 0;
+    size_t mismatches = 0;
+    size_t odd_gen = 0;    // samples with an odd-weight generator (the row-parity correction's regime)
+    size_t paired_out = 0; // samples whose product is fully paired (the unconditionally-kept branch)
+};
+
+enum class Population : uint8_t { Uniform, Paired };
+
+template <size_t N>
+auto differential(size_t logical, size_t iters, Tally &t, Population pop = Population::Uniform) -> void {
+    std::mt19937_64 rng(0xC0FFEEULL + (N * 7919) + logical + (pop == Population::Paired ? 1U : 0U));
+    std::vector<uint32_t> out((4 * N) + 64);
+    constexpr unsigned kCut = 6;
+
+    for (size_t it = 0; it < iters; ++it) {
+        const size_t kw = 1 + (rng() % 12);
+        const size_t gw = 1 + (rng() % 4); // reaches |G| = 1 and 3, not only the bench's 4
+        // The paired arm draws both operands fully paired, so their product is paired too: that is the
+        // only way to reach the unconditional-keep branch in bulk (uniform draws hit it ~4 times in 10^4).
+        const auto m =
+            (pop == Population::Paired) ? draw_paired<N>(rng, logical, 1 + (kw % 5)) : draw<N>(rng, logical, kw);
+        const auto g =
+            (pop == Population::Paired) ? draw_paired<N>(rng, logical, 1 + (gw % 2)) : draw<N>(rng, logical, gw);
+        if ((gw % 2) != 0 && pop == Population::Uniform) {
+            ++t.odd_gen;
+        }
+
+        const auto mp = positions_of<N>(m);
+        const auto gp = positions_of<N>(g);
+        const auto r = xor_gen<uint32_t>(mp.data(), mp.size(), gp.data(), gp.size(), out.data());
+
+        const Monomial<N> x = m ^ g;
+        const auto expect = positions_of<N>(x);
+        const auto sums = cutoff_sums<N>(x, logical);
+        const auto ctx = MajoranaAlgebra<N>::make_gen_context(g);
+        if (is_paired(r.k, r.d)) {
+            ++t.paired_out;
+        }
+
+        bool positions_match = r.k == expect.size();
+        for (size_t j = 0; positions_match && j < r.k; ++j) {
+            positions_match = out[j] == expect[j];
+        }
+
+        const bool ok = positions_match                                           //
+                        && r.overlap == m.count_and(g)                            //
+                        && sums.popcount_sum == r.k                               //
+                        && sums.xor_sum == r.k - (2 * r.d)                        //
+                        && sums.or_sum == r.k - r.d                               //
+                        && r.sign == interleave_phase<N>(m, g)                    //
+                        && r.sign == MajoranaAlgebra<N>::rotation_sign(ctx, m, x) //
+                        && length_keeps(r.k, r.d, kCut) == length_cutoff<N>(x, kCut, logical)
+                        && support_keeps(r.k, r.d, kCut) == support_cutoff<N>(x, kCut, logical)
+                        && pair_digest<uint32_t>(out.data(), r.k).d == r.d;
+        t.comparisons += 10;
+        if (!ok) {
+            ++t.mismatches;
+        }
+    }
+}
+
+struct DigestTally {
+    size_t comparisons = 0;
+    size_t mismatches = 0;
+    size_t offset_checks = 0;     // monomials whose lowest set bit was measured against the offset
+    size_t offset_violations = 0; // one below 2*(NumModes - logical) would void every comparison here
+    size_t paired_out = 0;        // products on the unconditionally-kept branch
+    size_t rejected_out = 0;      // products the length cutoff drops -- the emit path's rejected majority
+};
+
+// The (k, d) overloads in AlgebraCommon.h against the bitset forms they shadow, plus the precondition
+// that makes the two equivalent: indices_to_bitset() places every bit at physical position
+// >= 2*(NumModes - logical), and XOR keeps it there, so the bitset form's active-window masking has
+// nothing to mask. Measured here rather than asserted in a comment, because the digest carries no
+// logical_num_modes and silently answers for the whole register.
+template <size_t N>
+auto digest_overloads(size_t logical, size_t iters, DigestTally &t) -> void {
+    std::mt19937_64 rng(0xD16E57ULL + (N * 104729) + logical);
+    std::vector<uint32_t> out((4 * N) + 64);
+    const size_t offset = 2 * (N - logical);
+
+    CutoffFn<N> length_fn = detail::LengthCutoff<N>{.cutoff = 6, .logical_num_modes = logical};
+    CutoffFn<N> support_fn = detail::SupportCutoff<N>{.cutoff = 4, .logical_num_modes = logical};
+    CutoffFn<N> opaque_fn = [](const Monomial<N> &) { return true; };
+    const detail::CutoffEvaluator<N> length_ev(length_fn);
+    const detail::CutoffEvaluator<N> support_ev(support_fn);
+    const detail::CutoffEvaluator<N> opaque_ev(opaque_fn);
+
+    for (size_t it = 0; it < iters; ++it) {
+        // Both populations, since a uniform draw essentially never lands on the fully paired branch
+        // and that branch is the one the digest decides differently from a bare popcount compare.
+        const bool paired_pop = (it % 4) == 0;
+        const size_t kw = 1 + (rng() % 12);
+        const size_t gw = 1 + (rng() % 4);
+        const auto m = paired_pop ? draw_paired<N>(rng, logical, 1 + (kw % 5)) : draw<N>(rng, logical, kw);
+        const auto g = paired_pop ? draw_paired<N>(rng, logical, 1 + (gw % 2)) : draw<N>(rng, logical, gw);
+        const Monomial<N> x = m ^ g;
+
+        // Bitset::find_first() returns size() when nothing is set, which clears every offset.
+        for (const auto &probe : {m, g, x}) {
+            ++t.offset_checks;
+            if (probe.find_first() < offset) {
+                ++t.offset_violations;
+            }
+        }
+
+        const auto mp = positions_of<N>(m);
+        const auto gp = positions_of<N>(g);
+        const auto r = xor_gen<uint32_t>(mp.data(), mp.size(), gp.data(), gp.size(), out.data());
+        const auto d = pair_digest<uint32_t>(out.data(), r.k); // independent of xor_gen's own d
+
+        const auto ref = cutoff_sums<N>(x, logical);
+        const auto got = cutoff_sums(d.k, d.d);
+        bool ok = got.xor_sum == ref.xor_sum && got.popcount_sum == ref.popcount_sum && got.or_sum == ref.or_sum
+                  && is_paired(d.k, d.d) == is_paired<N>(x);
+        t.comparisons += 4;
+        if (is_paired(d.k, d.d)) {
+            ++t.paired_out;
+        }
+
+        for (const unsigned int c : {0U, 1U, 4U, 6U, 12U}) {
+            ok = ok && length_cutoff(d.k, d.d, c) == length_cutoff<N>(x, c, logical)
+                 && support_cutoff(d.k, d.d, c) == support_cutoff<N>(x, c, logical);
+            t.comparisons += 2;
+        }
+
+        // The evaluator's digest path must match its bitset path, and must decline (nullopt) exactly
+        // when the cutoff is opaque -- an early `true` there would keep terms the predicate rejects.
+        const auto len_digest = length_ev.passes_with_popcount(d.k, d.d);
+        const auto sup_digest = support_ev.passes_with_popcount(d.k, d.d);
+        ok = ok && len_digest.has_value() && *len_digest == length_ev.passes_with_popcount(x, d.k)
+             && sup_digest.has_value() && *sup_digest == support_ev.passes_with_popcount(x, d.k)
+             && !opaque_ev.passes_with_popcount(d.k, d.d).has_value();
+        t.comparisons += 3;
+        if (len_digest.has_value() && !*len_digest) {
+            ++t.rejected_out;
+        }
+
+        if (!ok) {
+            ++t.mismatches;
+        }
+    }
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(sparse_xor_gen_matches_worked_example) {
+    // Majorana indices 0 and 1 are one mode, so the product is fully paired: k = 2, d = 1.
+    constexpr size_t N = 8;
+    const auto m = indices_to_bitset<N>(VecZ{0, 1});
+    const auto mp = positions_of<N>(m);
+    std::vector<uint32_t> out(8);
+
+    const auto self = xor_gen<uint32_t>(mp.data(), mp.size(), mp.data(), mp.size(), out.data());
+    BOOST_TEST(self.k == 0U);       // M ^ M is the identity
+    BOOST_TEST(self.overlap == 2U); // and every bit overlapped
+
+    const auto pd = pair_digest<uint32_t>(mp.data(), mp.size());
+    BOOST_TEST(pd.k == 2U);
+    BOOST_TEST(pd.d == 1U);
+    BOOST_TEST(is_paired(pd.k, pd.d));
+    // A fully paired term is kept by both cutoffs whatever its length -- that is why a length cutoff
+    // cannot bound the popcount a surviving row carries.
+    BOOST_TEST(length_keeps(pd.k, pd.d, 0U));
+    BOOST_TEST(support_keeps(pd.k, pd.d, 0U));
+    // An unpaired single Majorana is not.
+    BOOST_TEST(!length_keeps(1U, 0U, 0U));
+}
+
+BOOST_AUTO_TEST_CASE(sparse_xor_gen_differential_across_widths) {
+    Tally t;
+    // Offsets 2*(NumModes - logical): 0, 2, 12, 16 -- the two production shapes plus the degenerate
+    // one, and two widths where 2*NumModes is not a multiple of 64 so kTopBits is exercised.
+    differential<32>(32, 4000, t);    // W = 64, offset 0 (single word)
+    differential<32>(31, 4000, t);    // W = 64, offset 2
+    differential<128>(128, 4000, t);  // W = 256, offset 0
+    differential<128>(120, 4000, t);  // W = 256, offset 16 (Hubbard)
+    differential<256>(250, 4000, t);  // W = 512, offset 12 (the HPC configuration)
+    differential<1024>(1020, 500, t); // W = 2048, offset 8
+    differential<50>(50, 4000, t);    // W = 100, kTopBits != 0
+    differential<50>(44, 4000, t);    // W = 100, offset 12
+    // Fully paired operands, at the two production shapes: the branch both cutoffs keep regardless of
+    // length, and the one a uniform draw essentially never reaches.
+    differential<128>(120, 4000, t, Population::Paired);
+    differential<256>(250, 4000, t, Population::Paired);
+
+    BOOST_TEST(t.mismatches == 0U);
+    // Assert the loop ran and reached both regimes it is supposed to cover, so a vacuous pass is not
+    // mistaken for a clean one.
+    BOOST_TEST(t.comparisons > 250000U);
+    BOOST_TEST(t.odd_gen > 1000U);
+    BOOST_TEST(t.paired_out > 5000U);
+}
+
+BOOST_AUTO_TEST_CASE(sparse_digest_overloads_match_bitset_forms) {
+    DigestTally t;
+    // active_bit_offset = 2*(NumModes - logical): 0, 2, 12 and 16, at the three production widths.
+    digest_overloads<32>(32, 3000, t);   // offset 0, single word
+    digest_overloads<32>(31, 3000, t);   // offset 2, single word
+    digest_overloads<128>(128, 3000, t); // offset 0, multi word
+    digest_overloads<128>(120, 3000, t); // offset 16 (Hubbard)
+    digest_overloads<256>(256, 3000, t); // offset 0, widest
+    digest_overloads<256>(250, 3000, t); // offset 12 (the HPC configuration)
+
+    BOOST_TEST(t.mismatches == 0U);
+    // The precondition the digest overloads rest on: no constructed monomial reached below the offset.
+    BOOST_TEST(t.offset_violations == 0U);
+    // Assert the loop ran and reached both decisions, so a vacuous pass is not mistaken for a clean one.
+    BOOST_TEST(t.comparisons > 300000U);
+    BOOST_TEST(t.offset_checks == 54000U);
+    BOOST_TEST(t.paired_out > 3000U);
+    BOOST_TEST(t.rejected_out > 3000U);
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

> **Stacked.** Based on `pr/mpi-lease-staging` so the diff shown here is this change alone. It retargets to `main` as the stack merges.

## Summary

The structural cutoffs only ever needed two integers about a monomial: its popcount `k`, and the number of modes holding both of their Majorana bits, `d`. Computing them meant calling out to `cutoff_sums`, which walks the dense words to build a sum it then throws away.

`paired_mode_count` computes `d` inline from the dense words and `passes_with_popcount` decides from `(k, d)` directly, dropping the `popcount <= cutoff` early-out. The dense representation is **untouched**: this changes no layout and moves no data, which is why it is a pure decision change and why its counters must stay bit-identical between arms.

## Measured

Default **ON**. `emit_s` **0.9200×**, 11/12 paired reps over two nodes, sign-test p=0.0063; pooled with 128- and 512-mode shapes **0.9214×, 19/20, p=4.0e-5**. Counters (`emit`/`reject`/`push`) bit-identical between arms in all 20 pairs, memory flat.

Worth **~0.8% of `build_graph`** — *not* the ~3% the microbenchmark projected. In isolation the kernel measures far better than it delivers, because in the real scan the loop is bound by the latency of the random row read rather than by the arithmetic beside it. Quoted at what it delivers.

Measure this on `emit_s`, not on the wall: at the observed variance the end-to-end benchmark needs ~1590 paired reps to resolve 3%, and the phase timer needs ~5.

## The test that matters more than the perf

`env_config_member_defaults_match_parsed_defaults`.

Every knob declares its default **twice** — once as a `Settings` member initialiser, once as `parse_flag`'s fallback in `get()` — and `get()` unconditionally overwrites the first with the second. So changing only the member silently does nothing.

That is not hypothetical. It shipped a measured **7.2% regression enabled by default**, on a knob that had been "turned off" in the member, in the header comment and in the docs — but not in the fallback. Any knob whose two declarations disagree now fails a test.

## Verification

`ctest -L serial` green; `pytest tests --with-mpi` green at 1/2/4 ranks.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [x] `CHANGELOG` / release notes updated if applicable — release notes are generated from the PR title

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: Claude Code (claude-opus-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)
