### PR TITLE
docs(ci): 🤖 include README snippets in doctest-docs

### DIFF
--- a/justfile
+++ b/justfile
@@ -206,6 +206,7 @@ doctest-py:
 
 doctest-docs:
     {{ docs_uv }} python -m pytest --markdown-docs docs/content/docs --ignore=docs/content/docs/tutorials --ignore=docs/content/docs/api
+    {{ docs_uv }} python -m pytest --markdown-docs README.md
 
 # Build the static documentation site into `docs/out`.
 build-docs: docs-install gen-api doctest-py doctest-docs gen-notebooks


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary
- include `README.md` in the `doctest-docs` just target
- keep existing docs doctest scope/ignores unchanged
- ensure the existing docs CI path (`just build-docs`) also validates README Python snippets

## Notes
- Local run in this environment was blocked by missing Boost CMake package during editable build, before doctests executed.