### PR TITLE
refactor(partition): ♻️ name the node-mask regimes instead of a bare bool

### DIFF
--- a/cpp/monoprop/detail/partition/CpuTopology.cpp
+++ b/cpp/monoprop/detail/partition/CpuTopology.cpp
@@ -278,14 +278,14 @@ auto masks_are_pairwise_disjoint(const uint64_t *masks, size_t n, size_t words) 
 
 /* ── partition_cpusets ─────────────────────────────────────────────────────── */
 
-auto partition_cpusets(size_t n, size_t group_index, size_t group_count, bool mask_is_private) -> std::vector<CpuSet> {
+auto partition_cpusets(size_t n, size_t group_index, size_t group_count, NodeMask mask) -> std::vector<CpuSet> {
     if (!config::get().partition_pinning) {
         return {};
     }
     const auto cores = enumerate_physical_cores();
 
     // A private mask IS this rank's share: the launcher already separated co-located ranks.
-    if (mask_is_private) {
+    if (mask == NodeMask::PerRank) {
         group_index = 0;
         group_count = 1;
     }

--- a/cpp/monoprop/detail/partition/CpuTopology.h
+++ b/cpp/monoprop/detail/partition/CpuTopology.h
@@ -104,6 +104,9 @@ auto affinity_mask_words(uint64_t *out, size_t nwords) -> bool;
  */
 [[nodiscard]] auto masks_are_pairwise_disjoint(const uint64_t *masks, size_t n, size_t words) -> bool;
 
+//! Whether the launcher has already handed this rank a private slice of the node, or the node's CPUs are shared.
+enum class NodeMask { Shared, PerRank };
+
 /*!
  * @brief Build placement tokens for one MPI rank's partitions.
  *
@@ -114,14 +117,14 @@ auto affinity_mask_words(uint64_t *out, size_t nwords) -> bool;
  * @param n            Number of partitions to place.
  * @param group_index  This rank's 0-based index among the co-located ranks on the host.
  * @param group_count  Total number of co-located ranks on the host.
- * @param mask_is_private  True only when the co-located ranks' affinity masks have been measured
+ * @param mask         NodeMask::PerRank only when the co-located ranks' affinity masks have been measured
  *                     pairwise DISJOINT (PartitionGroup::classify_node_masks_), so this mask is our share.
  * @returns Vector of @p n CpuSet tokens, or empty when @c monoprop_PARTITION_PINNING is disabled,
- *          hwloc is unavailable, or fewer than @p group_count x @p n cores are visible (@p n when private).
+ *          hwloc is unavailable, or fewer than @p group_count x @p n cores are visible (@p n under PerRank).
  *
- * @note Under @p mask_is_private the group split is skipped: our share is already this rank's alone.
+ * @note Under NodeMask::PerRank the group split is skipped: our share is already this rank's alone.
  */
-auto partition_cpusets(size_t n, size_t group_index = 0, size_t group_count = 1, bool mask_is_private = false)
+auto partition_cpusets(size_t n, size_t group_index = 0, size_t group_count = 1, NodeMask mask = NodeMask::Shared)
     -> std::vector<CpuSet>;
 
 /*!

--- a/cpp/monoprop/detail/partition/PartitionGroup.h
+++ b/cpp/monoprop/detail/partition/PartitionGroup.h
@@ -61,7 +61,7 @@ public:
           errs_(static_cast<size_t>(n_partitions)) {
         make_transport_();
         discover_node_peers_();
-        cpusets_ = topo_partition_cpusets(n_, node_rank_, node_size_, node_mask_private_);
+        cpusets_ = topo_partition_cpusets(n_, node_rank_, node_size_, node_mask_);
         start_masters_();
         // The masters are already running, so a ctor throw must not escape: ~PartitionGroup would never run,
         // and destroying joinable threads during unwinding calls std::terminate.
@@ -81,11 +81,11 @@ public:
           parent_(src.parent_),
           node_rank_(src.node_rank_),
           node_size_(src.node_size_),
-          node_mask_private_(src.node_mask_private_),
+          node_mask_(src.node_mask_),
           partitions_(static_cast<size_t>(src.n_)),
           errs_(static_cast<size_t>(src.n_)) {
         make_transport_();
-        cpusets_ = topo_partition_cpusets(n_, node_rank_, node_size_, node_mask_private_);
+        cpusets_ = topo_partition_cpusets(n_, node_rank_, node_size_, node_mask_);
         start_masters_();
         try { // see the primary ctor: a throw past live masters would std::terminate
             run_on_all([&](int r) {
@@ -149,12 +149,12 @@ private:
     }
 
     // Free-function wrapper so the header compiles on non-Linux (where partition_cpusets returns {}).
-    static auto topo_partition_cpusets(int n, int group_index, int group_count, bool mask_is_private)
+    static auto topo_partition_cpusets(int n, int group_index, int group_count, NodeMask mask)
         -> std::vector<monoprop::detail::partition::CpuSet> {
         return monoprop::detail::partition::partition_cpusets(static_cast<size_t>(n),
                                                               static_cast<size_t>(group_index),
                                                               static_cast<size_t>(group_count),
-                                                              mask_is_private);
+                                                              mask);
     }
 
     // Under an MPI parent, find how many ranks share this host and which we are, so each co-located rank
@@ -175,7 +175,7 @@ private:
 #ifdef monoprop_ENABLE_MPI
     // A rank seeing 16 of 128 CPUs is equally "my own 16" and "eight of us share these 16": only the masks tell.
     auto classify_node_masks_(MPI_Comm node) -> void {
-        node_mask_private_ = false;
+        node_mask_ = NodeMask::Shared;
         if (node_size_ <= 1) {
             return; // nobody to collide with; the normal split already handles group_count == 1
         }
@@ -185,9 +185,10 @@ private:
         monoprop::detail::partition::affinity_mask_words(mine.data(), kMaskWords);
         std::vector<uint64_t> all(kMaskWords * static_cast<size_t>(node_size_), 0);
         MPI_Allgather(mine.data(), kMaskWords, MPI_UINT64_T, all.data(), kMaskWords, MPI_UINT64_T, node);
-        node_mask_private_ = monoprop::detail::partition::masks_are_pairwise_disjoint(all.data(),
-                                                                                      static_cast<size_t>(node_size_),
-                                                                                      kMaskWords);
+        const bool disjoint = monoprop::detail::partition::masks_are_pairwise_disjoint(all.data(),
+                                                                                       static_cast<size_t>(node_size_),
+                                                                                       kMaskWords);
+        node_mask_ = disjoint ? NodeMask::PerRank : NodeMask::Shared;
     }
 #endif
 
@@ -274,11 +275,11 @@ private:
     }
 
     int n_;
-    mpi::Comm parent_;                  // enclosing communicator (size R) — decides the transport
-    int node_rank_ = 0;                 // this rank's index among the ranks sharing the host
-    int node_size_ = 1;                 // how many parent ranks share the host (1 unless MPI R>1)
-    bool node_mask_private_ = false;    // set by classify_node_masks_; copied, never re-derived, by the copy ctor
-    std::unique_ptr<mpi::ShmComm> shm_; // set iff R == 1
+    mpi::Comm parent_;                      // enclosing communicator (size R) — decides the transport
+    int node_rank_ = 0;                     // this rank's index among the ranks sharing the host
+    int node_size_ = 1;                     // how many parent ranks share the host (1 unless MPI R>1)
+    NodeMask node_mask_ = NodeMask::Shared; // set by classify_node_masks_; copied, never re-derived, by the copy ctor
+    std::unique_ptr<mpi::ShmComm> shm_;     // set iff R == 1
 #ifdef monoprop_ENABLE_MPI
     std::unique_ptr<mpi::HybridComm> hyb_; // set iff R > 1
 #endif

--- a/cpp/tests/cpu_topology_tests.cpp
+++ b/cpp/tests/cpu_topology_tests.cpp
@@ -112,13 +112,13 @@ BOOST_AUTO_TEST_CASE(cpu_topology_place_co_located_ranks) {
     const auto shared_mask = partition::partition_cpusets(/*n=*/cores.size(),
                                                           /*group_index=*/1,
                                                           /*group_count=*/2,
-                                                          /*mask_is_private=*/false);
+                                                          partition::NodeMask::Shared);
     BOOST_CHECK(shared_mask.empty());
 
     const auto private_mask = partition::partition_cpusets(/*n=*/cores.size(),
                                                            /*group_index=*/1,
                                                            /*group_count=*/2,
-                                                           /*mask_is_private=*/true);
+                                                           partition::NodeMask::PerRank);
     if (private_mask.empty() && empty_placement_is_licensed()) {
         return;
     }
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(cpu_topology_policy_per_rank_slice_starves_without_collapse
 
     BOOST_CHECK(placement_order(slice, 2, /*group_index=*/3, /*group_count=*/8).empty());
 
-    // Collapsed to a single group -- what mask_is_private does -- the same slice places fully.
+    // Collapsed to a single group -- what NodeMask::PerRank does -- the same slice places fully.
     const auto collapsed = placement_order(slice, 2, /*group_index=*/0, /*group_count=*/1);
     BOOST_REQUIRE_EQUAL(collapsed.size(), 2u);
     BOOST_CHECK_EQUAL(collapsed[0], 6);
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(cpu_topology_policy_private_mask_collapses_even_when_the_sp
     BOOST_CHECK_EQUAL(split[0], 2);
     BOOST_CHECK_EQUAL(split[1], 6);
 
-    // What mask_is_private now passes: the head of this rank's own interleave over both domains.
+    // What NodeMask::PerRank now passes: the head of this rank's own interleave over both domains.
     const auto collapsed = placement_order(cores, 2, /*group_index=*/0, /*group_count=*/1);
     BOOST_REQUIRE_EQUAL(collapsed.size(), 2u);
     BOOST_CHECK_EQUAL(collapsed[0], 0);
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(cpu_topology_per_rank_mask_still_places) {
 
     // What `srun --cpu-bind=cores` produces: our whole share, told there are eight sibling ranks.
     const auto sets =
-        partition::partition_cpusets(/*n=*/k, /*group_index=*/3, /*group_count=*/8, /*mask_is_private=*/true);
+        partition::partition_cpusets(/*n=*/k, /*group_index=*/3, /*group_count=*/8, partition::NodeMask::PerRank);
     if (sets.empty() && empty_placement_is_licensed()) {
         return;
     }
@@ -401,11 +401,11 @@ BOOST_AUTO_TEST_CASE(cpu_topology_shared_mask_keeps_co_located_ranks_disjoint) {
     const auto rank0 = partition::partition_cpusets(/*n=*/per_rank,
                                                     /*group_index=*/0,
                                                     /*group_count=*/2,
-                                                    /*mask_is_private=*/false);
+                                                    partition::NodeMask::Shared);
     const auto rank1 = partition::partition_cpusets(/*n=*/per_rank,
                                                     /*group_index=*/1,
                                                     /*group_count=*/2,
-                                                    /*mask_is_private=*/false);
+                                                    partition::NodeMask::Shared);
     if (rank0.empty() && rank1.empty() && empty_placement_is_licensed()) {
         return;
     }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Follow-up to #249, which shipped the cgroup placement fix with a `bool mask_is_private` parameter.
This renames that parameter to `enum class NodeMask { Shared, PerRank }`. No behaviour change.

`partition_cpusets(n, gi, gc, true)` does not say at the call site which regime `true` means, and
the safe default is spelled `false`. The enum names both, and a third launcher regime would be a
new enumerator rather than a second bool.

## Changes

- `enum class NodeMask { Shared, PerRank }` in `CpuTopology.h`.
- `partition_cpusets`'s fourth parameter becomes `NodeMask mask = NodeMask::Shared`.
- `PartitionGroup::node_mask_private_` becomes `NodeMask node_mask_`; `classify_node_masks_`
  converts `masks_are_pairwise_disjoint`'s `bool` at the call site. The predicate keeps its `bool`
  return -- it answers a question about masks, not about policy.
- Test call sites lose their `/*mask_is_private=*/` argument comments, which the enum value replaces.

Every assertion and every test-case name is unchanged, and `grep -rn mask_is_private cpp/` is empty.

## Checklist

- [x] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code
- [x] I used the following tool to generate or modify code: Claude Code
