### PR TITLE
docs: 🔗 add links to API classes in prose docs

### DIFF
--- a/docs/content/docs/concepts/interface.mdx
+++ b/docs/content/docs/concepts/interface.mdx
@@ -18,7 +18,7 @@ accepts operators in three forms, each suited to a different starting point; see
 The natural starting point for quantum chemistry and lattice models. An operator
 is given as a weighted sum of products of fermionic creation and annihilation
 operators on numbered modes (for example $c_0^\dagger c_1$); use
-`MajoranaPropagator`.
+[MajoranaPropagator][].
 
 ```python
 from monoprop import MajoranaPropagator, Circuit, ExpGate
@@ -45,7 +45,7 @@ print(mp.evolved_operator())  # MajoranaOperator
 
 The natural starting point when you already hold a qubit Hamiltonian. An
 operator is given as a real-coefficient sum of Paulis (tensor products of
-$I, X, Y, Z$). For qubit problems, use `PauliPropagator`, which accepts Pauli
+$I, X, Y, Z$). For qubit problems, use [PauliPropagator][], which accepts Pauli
 operators and gates directly and truncates by Pauli weight.
 
 ```python
@@ -114,7 +114,7 @@ A circuit is a sequence of *gates*, each a Majorana rotation described by:
 4. **Evaluate** expectation values or gradients across many parameter values.
 
 Steps 1-2 happen once; step 3 happens once for a fixed circuit, although running it multiple times for a single
-`MajoranaPropagator` instance with new gates is possible. Step 4 can be executed multiple times for various
+[MajoranaPropagator][] instance with new gates is possible. Step 4 can be executed multiple times for various
 parameter inputs, allowing effective variational
 optimisation, covered in [Propagation Algorithm](/concepts/algorithm) with the
 concrete API in [Python API](/api).

--- a/docs/content/docs/concepts/simulation_modes.mdx
+++ b/docs/content/docs/concepts/simulation_modes.mdx
@@ -39,8 +39,8 @@ though matching the Heisenberg-picture result requires a slightly looser cutoff
 on the state (the `schrodinger_cutoff` setting; see
 [Initialisation and updates](/features/initialisation)). The Schrödinger picture
 is less common, but useful for evaluating many observables against the same
-Note that `schrodinger_cutoff` is measured in Pauli weight for PauliPropagator,
-and in number of Majorana operators for MajoranaPropagator, following the natural
+Note that `schrodinger_cutoff` is measured in Pauli weight for [PauliPropagator][],
+and in number of Majorana operators for [MajoranaPropagator][], following the natural
 definitions in each case.
 
 ## See also

--- a/docs/content/docs/features/cutoff.mdx
+++ b/docs/content/docs/features/cutoff.mdx
@@ -9,8 +9,8 @@ mechanisms: a **structural cutoff** on the size of each monomial, and
 changed at any point during a simulation.
 
 The structural cutoff discards monomials that grow "too large". What counts as
-large depends on the simulator: `MajoranaPropagator` offers a choice between two
-measures of a Majorana monomial, while `PauliPropagator` always measures a term
+large depends on the simulator: [MajoranaPropagator][] offers a choice between two
+measures of a Majorana monomial, while [PauliPropagator][] always measures a term
 by its qubit **Pauli weight**.
 
 ## The fully-paired rule
@@ -26,7 +26,7 @@ therefore only ever prunes the remaining, partially paired monomials.
 
 ## Majorana operators: `length` or `support`
 
-`MajoranaPropagator` measures each monomial as a Majorana operator and offers
+[MajoranaPropagator][] measures each monomial as a Majorana operator and offers
 two structural cutoff strategies, selected with `cutoff_type`:
 
 **`length` (default).**
@@ -46,7 +46,7 @@ $M_\nu = m_1 m_2 m_5$ touches only mode 1 (both $m_1$ and $m_2$) and mode 3
 
 ## Qubit operators: Pauli weight
 
-`PauliPropagator` accepts Pauli operators and gates directly and measures each
+[PauliPropagator][] accepts Pauli operators and gates directly and measures each
 term by its **Pauli weight** — the number of qubits it touches. This is the only
 structural measure: `cutoff` bounds the Pauli weight.
 

--- a/docs/content/docs/features/evaluation.mdx
+++ b/docs/content/docs/features/evaluation.mdx
@@ -98,6 +98,6 @@ parameters:
 coeffs = sim.contract_partially(parameters, inplace=False)
 ```
 
-To read the fully evolved operator as a `MajoranaOperator` (or `PauliOperator` for
-`PauliPropagator`) — without modifying the
-simulator — use `evolved_operator`.
+To read the fully evolved operator as a [MajoranaOperator][] (or [PauliOperator][] for
+[PauliPropagator][]) — without modifying the
+simulator — use [MonomialPropagator.evolved_operator][].

--- a/docs/content/docs/features/initialisation.mdx
+++ b/docs/content/docs/features/initialisation.mdx
@@ -19,7 +19,7 @@ picture they are applied to the observable.
 `schrodinger_cutoff` is the truncation applied to the initial state. It must be
 set higher than the regular `cutoff` for the Schrödinger-picture result to
 match the Heisenberg-picture one. A good value of the parameter depends on the circuit
-and observable, although setting `schrodinger_cutoff = cutoff + 2` for MajoranaPropagator and
+and observable, although setting `schrodinger_cutoff = cutoff + 2` for [MajoranaPropagator][] and
 `schrodinger_cutoff = cutoff + 1` for [PauliPropagator][] is usually a good starting point.
 For second-quantized Hamiltonians and usual Fermionic circuits coming from variational
 quantum computing, under length truncation the two pictures agree when
@@ -28,8 +28,8 @@ quantum computing, under length truncation the two pictures agree when
 ## Operator updates
 
 The coefficients of the initial operator can be patched after construction
-without rebuilding the simulator or the graph. For MajoranaPropagator,
-MajoranaOperator is required while PauliPropagator requires PauliOperator.
+without rebuilding the simulator or the graph. For [MajoranaPropagator][],
+[MajoranaOperator][] is required while [PauliPropagator][] requires [PauliOperator][].
 
 ```python
 from monoprop import MajoranaPropagator, MajoranaOperator

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -65,11 +65,11 @@ assert sorted(result.terms) == [(0, 1, 2, 4), (0, 1, 2, 5)]  # original (cosine)
 assert np.isclose(result.terms[(0, 1, 2, 4)].real, np.cos(2 * 0.5))  # cosine branch
 ```
 
-For qubit problems there is a dedicated simulator, `PauliPropagator`, which takes
+For qubit problems there is a dedicated simulator, [PauliPropagator][], which takes
 Pauli operators and gates directly. The following example back-propagates the
 two-qubit observable $Z \otimes Z$ under a single qubit rotation
 $e^{+i\theta X_0}$, which likewise splits it into a cosine and a sine branch.
-Its result is a `PauliOperator` whose `.terms` map each Pauli to its coefficient
+Its result is a [PauliOperator][] whose `.terms` map each Pauli to its coefficient
 (see [Notation](/concepts/notation)):
 
 ```python

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -6,8 +6,8 @@ description: High-performance C++/Python library for Majorana and Pauli propagat
 monoprop is a high-performance C++ library with Python bindings for Majorana and Pauli propagation, for simulating and variationally optimising quantum circuits.
 It supports large-scale simulations through multithreading and multi-node runs on HPC clusters via MPI and shared-memory parallelism.
 Operators and states are expressed in the Majorana basis, with two front-ends:
-`MajoranaPropagator` for native Majorana and fermionic problems, and
-`PauliPropagator` for qubit (Pauli) problems.
+[MajoranaPropagator][] for native Majorana and fermionic problems, and
+[PauliPropagator][] for qubit (Pauli) problems.
 
 
 <Callout title="Warning" type="warn">


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Prose pages in the docs referred to Python API classes (`MajoranaPropagator`, `PauliPropagator`, `MajoranaOperator`, `PauliOperator`, etc.) as plain text or backtick-wrapped names, with no hyperlink to their API reference pages. This replaces those occurrences with mkdocstrings-style `[Symbol][]` references so the rendered site links directly to the API docs.

## Changes

- `index.mdx`: link `MajoranaPropagator` and `PauliPropagator` in the intro paragraph
- `getting-started.mdx`: link `PauliPropagator` and `PauliOperator` in prose
- `concepts/interface.mdx`: link `MajoranaPropagator` (x2) and `PauliPropagator` in prose
- `concepts/simulation_modes.mdx`: link `PauliPropagator` and `MajoranaPropagator` in the note on `schrodinger_cutoff`
- `features/initialisation.mdx`: link `MajoranaPropagator` (x2), `MajoranaOperator`, `PauliPropagator`, and `PauliOperator` in prose
- `features/cutoff.mdx`: link `MajoranaPropagator` (x2) and `PauliPropagator` in prose
- `features/evaluation.mdx`: link `MajoranaOperator`, `PauliOperator`, `PauliPropagator`, and `evolved_operator` in prose

Physics uses of "Majorana" and "Pauli" as adjectives in mathematical context are left as plain text.

## Checklist

- [ ] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: GitHub Copilot (claude-sonnet-4.6)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).