### PR TITLE
refactor(docs): own the Python API-docs pipeline, drop fumadocs-python

### DIFF
--- a/docs/content/docs/documenting.mdx
+++ b/docs/content/docs/documenting.mdx
@@ -18,7 +18,7 @@ docs/
       concepts/    # conceptual reference pages
       features/    # feature guides
   notebooks/       # Jupyter tutorial notebooks (converted to .md at build time)
-  scripts/         # tooling: API generation, notebook conversion
+  scripts/         # tooling: API generation, cross-references, notebook conversion
 ```
 
 The navigation order is controlled by `docs/content/docs/meta.json`.
@@ -125,11 +125,17 @@ just doctest-docs
 
 ## Python API reference
 
-The API reference is **auto-generated** from Python docstrings using
-[`griffe`](https://mkdocstrings.github.io/griffe/) and
-[`fumadocs-python`](https://fumadocs.dev/docs/ui/python).
-Do not edit files under `docs/content/docs/api/` directly — they are overwritten
-every time the generator runs.
+The API reference is **auto-generated** from Python docstrings in two stages,
+both living in `docs/scripts/`: `gen_api_dump.py` reads the package with
+[`griffe`](https://mkdocstrings.github.io/griffe/) and writes the API surface to
+`docs/monoprop.json`, then `generate-api.mjs` (with the MDX emitter in
+`api-mdx.mjs`) renders that to the pages under `docs/content/docs/api/`.
+Do not edit those pages directly — they are overwritten every time the generator
+runs. The components they are written in terms of (`PyFunction`, `PyParameter`, …)
+live in `docs/src/components/py.tsx`.
+
+`docs/monoprop.json` is also what the cross-reference index is built from, so a
+stale dump means stale links: regenerate it whenever docstrings move.
 
 To update the API reference after changing docstrings, regenerate it:
 
@@ -192,8 +198,9 @@ sudo apt update
 sudo apt install -y npm
 ```
 
-The fastest way to preview changes is the live-reloading dev server. It
-regenerates the API reference and notebooks once, then watches for file changes:
+The fastest way to preview changes is the live-reloading dev server. It serves
+whatever is already generated and watches for file changes, so run `just gen-api`
+(and `just gen-notebooks`) first if either is stale:
 
 ```bash
 just serve-docs

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,7 +12,6 @@
         "cnfast": "^0.1.0",
         "fumadocs-core": "16.14.5",
         "fumadocs-mdx": "15.3.0",
-        "fumadocs-python": "^0.1.1",
         "fumadocs-ui": "16.14.5",
         "katex": "^0.18.4",
         "lucide-react": "^1.33.0",
@@ -22,7 +21,8 @@
         "rehype-citation": "^2.3.2",
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
-        "remark-math": "^6.0.0"
+        "remark-math": "^6.0.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.3",
@@ -46,75 +46,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@base-ui/react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
-      "integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.2",
-        "@floating-ui/react-dom": "^2.1.9",
-        "@floating-ui/utils": "^0.2.12",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@base-ui/utils": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
-      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@floating-ui/utils": "^0.2.12",
-        "reselect": "^5.2.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@citation-js/core": {
@@ -4075,39 +4006,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/fumadocs-python": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/fumadocs-python/-/fumadocs-python-0.1.1.tgz",
-      "integrity": "sha512-5JNGj+dS6T+/ATDMygwBNi4P/LlkN52hArg2d6df8h2QZFxpXRhcxNDLOdu8EGCAF29fxMcGJ9lRETRhTxhbig==",
-      "license": "MIT",
-      "dependencies": {
-        "@base-ui/react": "^1.6.0",
-        "class-variance-authority": "^0.7.1",
-        "cnfast": "^0.0.8",
-        "lucide-react": "^1.24.0",
-        "yaml": "^2.9.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "fumadocs-core": "15.x.x || 16.x.x",
-        "fumadocs-ui": "15.x.x || 16.x.x",
-        "react": "19.x.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fumadocs-python/node_modules/cnfast": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/cnfast/-/cnfast-0.0.8.tgz",
-      "integrity": "sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==",
-      "license": "MIT",
-      "bin": {
-        "cnfast": "bin/cli.js"
-      }
-    },
     "node_modules/fumadocs-ui": {
       "version": "16.14.5",
       "resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-16.14.5.tgz",
@@ -6710,12 +6608,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/reselect": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
-      "license": "MIT"
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7198,15 +7090,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vfile": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -21,8 +21,7 @@
         "rehype-citation": "^2.3.2",
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
-        "remark-math": "^6.0.0",
-        "yaml": "^2.9.0"
+        "remark-math": "^6.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.3",
@@ -32,7 +31,8 @@
         "@types/react-dom": "^19.2.4",
         "postcss": "^8.5.26",
         "tailwindcss": "^4.3.3",
-        "typescript": "^7.0.2"
+        "typescript": "^7.0.2",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,6 @@
     "cnfast": "^0.1.0",
     "fumadocs-core": "16.14.5",
     "fumadocs-mdx": "15.3.0",
-    "fumadocs-python": "^0.1.1",
     "fumadocs-ui": "16.14.5",
     "katex": "^0.18.4",
     "lucide-react": "^1.33.0",
@@ -23,7 +22,8 @@
     "rehype-citation": "^2.3.2",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,8 +22,7 @@
     "rehype-citation": "^2.3.2",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
-    "remark-math": "^6.0.0",
-    "yaml": "^2.9.0"
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",
@@ -33,6 +32,7 @@
     "@types/react-dom": "^19.2.4",
     "postcss": "^8.5.26",
     "tailwindcss": "^4.3.3",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "yaml": "^2.9.0"
   }
 }

--- a/docs/scripts/api-mdx.mjs
+++ b/docs/scripts/api-mdx.mjs
@@ -17,8 +17,9 @@ import { stringify } from 'yaml';
 /**
  * Render a module tree to a flat list of `{path, frontmatter, content}` files.
  *
- * Hrefs keep the package's own leading segment (`/api/monoprop/...`), which
- * `write` then strips from file paths; `generate-api.mjs` realigns the two.
+ * `path` stays package-qualified (`monoprop/circuit/ExpGate.mdx`) -- callers key
+ * off that leading segment to derive a page's scope and source file -- while
+ * `write` strips it on the way to disk, matching the hrefs `getHref` mints.
  */
 export function convert(mod, options = {}) {
   const files = [];
@@ -179,10 +180,14 @@ function element(name, props = {}, children) {
   return `<${name} ${propsStr.join(' ')} />`;
 }
 
+// Mints the URL of the page documenting `ele`, dropping the package's own
+// leading segment so it lines up with where `write` puts the file. `pageUrl` in
+// `xref.mjs` has to agree with this, since prose links are resolved from there.
 function getHref(ele, options) {
   const { baseUrl = '/' } = options;
   return (
-    '/' + [...baseUrl.split('/'), ...ele.path.split('.')].filter((v) => v.length > 0).join('/')
+    '/' +
+    [...baseUrl.split('/'), ...ele.path.split('.').slice(1)].filter((v) => v.length > 0).join('/')
   );
 }
 
@@ -214,6 +219,6 @@ export async function write(output, options = {}) {
   );
 }
 
-export function frontmatter(obj) {
+function frontmatter(obj) {
   return `---\n${stringify(obj, { compat: 'yaml-1.1', singleQuote: true }).trim()}\n---`;
 }

--- a/docs/scripts/api-mdx.mjs
+++ b/docs/scripts/api-mdx.mjs
@@ -1,0 +1,219 @@
+// Render the griffe API dump (`gen_api_dump.py`) to Fumadocs MDX.
+//
+// Derived from the Node half of fumadocs-python (MIT, (c) 2023 Fuma); see
+// `gen_api_dump.py` for the full notice. Kept deliberately close to that
+// original so the emitted MDX -- and therefore the `/api/...` URL scheme the
+// cross-reference index in `xref.mjs` mirrors -- stays unchanged.
+//
+// Page granularity is the contract: one page per module (`<module>/index.mdx`)
+// and one per class (`<module>/<Class>.mdx`), with functions and attributes
+// rendered inline on their parent's page and addressed by a `#<name>` fragment.
+// `xref.mjs` encodes the same rule, so the two must move together.
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { stringify } from 'yaml';
+
+/**
+ * Render a module tree to a flat list of `{path, frontmatter, content}` files.
+ *
+ * Hrefs keep the package's own leading segment (`/api/monoprop/...`), which
+ * `write` then strips from file paths; `generate-api.mjs` realigns the two.
+ */
+export function convert(mod, options = {}) {
+  const files = [];
+  const content = [];
+  const tabs = [];
+  const tabContents = [];
+
+  if (mod.description) content.push(encodeText(mod.description));
+  for (const attr of mod.attributes) content.push(convertAttribute(attr));
+
+  if (Object.keys(mod.classes).length > 0) {
+    tabs.push('Class');
+    const lines = [];
+    for (const cls of Object.values(mod.classes)) {
+      files.push(...convertClass(cls));
+      lines.push(element('Card', { title: cls.name, href: getHref(cls, options) }));
+    }
+    tabContents.push(element('Cards', undefined, lines.join('\n')));
+  }
+
+  if (Object.keys(mod.functions).length > 0) {
+    tabs.push('Functions');
+    const lines = [];
+    for (const func of Object.values(mod.functions)) lines.push(convertFunction(func));
+    tabContents.push(lines.join('\n'));
+  }
+
+  if (Object.keys(mod.modules).length > 0) {
+    tabs.push('Modules');
+    const lines = [];
+    for (const submod of Object.values(mod.modules)) {
+      files.push(...convert(submod, options));
+      lines.push(element('Card', { href: getHref(submod, options), title: submod.name }));
+    }
+    tabContents.push(element('Cards', undefined, lines.join('\n')));
+  }
+
+  if (tabs.length > 0) {
+    content.push(
+      element(
+        'Tabs',
+        { items: tabs },
+        tabContents.map((tab, i) => element('Tab', { value: tabs[i] }, tab)).join('\n'),
+      ),
+    );
+  }
+
+  files.push({
+    path: [...mod.path.split('.'), 'index.mdx'].join('/'),
+    frontmatter: { title: mod.name },
+    content: content.join('\n\n'),
+  });
+  return files;
+}
+
+function convertClass(cls) {
+  const content = [];
+
+  if (cls.description) content.push(encodeText(cls.description));
+  if (cls.attributes.length > 0) content.push(heading(2, 'Attributes'));
+  for (const attr of cls.attributes) content.push(convertAttribute(attr));
+  if (Object.keys(cls.functions).length > 0) {
+    content.push(heading(2, 'Functions'));
+    for (const func of Object.values(cls.functions)) content.push(convertFunction(func));
+  }
+
+  return [
+    {
+      path: cls.path.replaceAll('.', '/') + '.mdx',
+      frontmatter: { title: cls.name },
+      content: content.join('\n\n'),
+    },
+  ];
+}
+
+function convertFunction(func) {
+  return element(
+    'PyFunction',
+    { name: func.name, type: func.signature },
+    [
+      func.description ? encodeText(func.description) : null,
+      convertDoc(func.docstring ?? []),
+      func.source.length > 0
+        ? element('PySourceCode', undefined, codeblock('python', func.source))
+        : null,
+      func.parameters.length > 0
+        ? element('div', undefined, func.parameters.map(convertParameter).join('\n'))
+        : null,
+      element(
+        'PyFunctionReturn',
+        { type: func.returns.annotation },
+        [func.returns.description ? encodeText(func.returns.description) : null]
+          .filter(Boolean)
+          .join('\n'),
+      ),
+    ]
+      .filter(Boolean)
+      .join('\n\n'),
+  );
+}
+
+function convertParameter(param) {
+  const lines = [];
+  if (param.description) {
+    lines.push(
+      typeof param.description === 'string' ? param.description : convertDoc(param.description),
+    );
+  }
+  return element(
+    'PyParameter',
+    { name: param.name, type: param.annotation, value: param.value },
+    lines.join('\n'),
+  );
+}
+
+function convertAttribute(attribute) {
+  return element(
+    'PyAttribute',
+    { name: attribute.name, type: attribute.annotation, value: attribute.value },
+    [attribute.description ? convertDoc(attribute.description) : null].filter(Boolean).join('\n'),
+  );
+}
+
+/** Render the docstring sections `simplify_docstring` left in `remainder`. */
+function convertDoc(docstring) {
+  const lines = [];
+  for (const item of docstring) {
+    if (item.kind === 'text') lines.push(encodeText(item.value));
+    if (item.kind === 'admonition') {
+      lines.push(
+        element(
+          'Callout',
+          { title: item.title, type: item.value.annotation },
+          encodeText(item.value.description),
+        ),
+      );
+    }
+  }
+  return lines.join('\n\n');
+}
+
+function heading(depth, content) {
+  return ['#'.repeat(depth), content].join(' ');
+}
+
+function codeblock(meta, code) {
+  const delimit = '```';
+  return `${delimit}${meta}\n${code.replaceAll(delimit, '\\```')}\n${delimit}`;
+}
+
+/** Emit an MDX element, passing every prop as an expression (`name={"x"}`). */
+function element(name, props = {}, children) {
+  const propsStr = [];
+  for (const key in props) propsStr.push(`${key}={${JSON.stringify(props[key])}}`);
+  if (children) {
+    return `<${name} ${propsStr.join(' ')}>\n\n${children}\n\n</${name}>`;
+  }
+  return `<${name} ${propsStr.join(' ')} />`;
+}
+
+function getHref(ele, options) {
+  const { baseUrl = '/' } = options;
+  return (
+    '/' + [...baseUrl.split('/'), ...ele.path.split('.')].filter((v) => v.length > 0).join('/')
+  );
+}
+
+// MDX parses `<` as JSX and `{` as an expression, so docstring prose has to
+// escape both.
+function encodeText(v) {
+  return v.replaceAll('<', '\\<').replaceAll('{', '\\{').replaceAll('}', '\\}');
+}
+
+/**
+ * Write the rendered files under `outDir`, dropping the leading path segment
+ * (the package name) so `monoprop/circuit/...` lands at `<outDir>/circuit/...`.
+ */
+export async function write(output, options = {}) {
+  await Promise.all(
+    output.map(async (file) => {
+      const filePath = path.resolve(
+        options.outDir ?? './',
+        file.path.split('/').slice(1).join('/'),
+      );
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(
+        filePath,
+        Object.keys(file.frontmatter).length > 0
+          ? `${frontmatter(file.frontmatter)}\n\n${file.content}`
+          : file.content,
+      );
+    }),
+  );
+}
+
+export function frontmatter(obj) {
+  return `---\n${stringify(obj, { compat: 'yaml-1.1', singleQuote: true }).trim()}\n---`;
+}

--- a/docs/scripts/gen_api_dump.py
+++ b/docs/scripts/gen_api_dump.py
@@ -469,7 +469,7 @@ def parse_module(m: griffe.Object | griffe.Alias) -> Module:
     if m.is_package:
         try:
             res["version"] = version(m.name)
-        except AttributeError:
+        except Exception:
             res["version"] = "unknown"
 
     return t.cast("Module", res)

--- a/docs/scripts/gen_api_dump.py
+++ b/docs/scripts/gen_api_dump.py
@@ -469,7 +469,7 @@ def parse_module(m: griffe.Object | griffe.Alias) -> Module:
     if m.is_package:
         try:
             res["version"] = version(m.name)
-        except Exception:
+        except AttributeError:
             res["version"] = "unknown"
 
     return t.cast("Module", res)

--- a/docs/scripts/gen_api_dump.py
+++ b/docs/scripts/gen_api_dump.py
@@ -57,7 +57,7 @@ import argparse
 import json
 import typing as t
 from importlib.metadata import version
-from pathlib import Path, PosixPath, WindowsPath
+from pathlib import Path
 
 import griffe
 from griffe_typingdoc import TypingDocExtension
@@ -213,14 +213,8 @@ def _parse_nested(description: str) -> object:
     """Re-parse a docstring entry's description as a Google-style docstring.
 
     Parameter and attribute descriptions can themselves carry sections; the
-    renderer expects the parsed form. Non-string descriptions are already
-    parsed, and `AttributeError` is how that shows up.
-
-    Args:
-        description: The entry's description, parsed or not.
-
-    Returns:
-        The parsed sections, or `description` unchanged if it was not raw text.
+    renderer expects the parsed form. A description that is already parsed is
+    returned unchanged -- `AttributeError` is how that shows up.
     """
     try:
         return griffe.parse_google(griffe.Docstring(description))
@@ -233,12 +227,8 @@ def _merge_parameters(
 ) -> list[object]:
     """Order a docstring's parameter entries by the real signature.
 
-    Args:
-        documented: The entries from the docstring's parameters section.
-        parent: The object whose signature fixes the order.
-
-    Returns:
-        One entry per signature parameter, documented or not.
+    Yields one entry per signature parameter, documented or not, so the renderer
+    can lay out a full parameter list from a partial docstring.
     """
     by_name = {entry.name: entry for entry in documented}
     merged: list[object] = []
@@ -267,12 +257,7 @@ def _merge_attributes(
 ) -> list[object]:
     """Order a docstring's attribute entries by the real attributes.
 
-    Args:
-        documented: The entries from the docstring's attributes section.
-        parent: The object whose attributes fix the order.
-
-    Returns:
-        One entry per non-aliased attribute, documented or not.
+    Yields one entry per non-aliased attribute, documented or not.
     """
     by_name = {entry.name: entry for entry in documented}
     merged: list[object] = []
@@ -383,14 +368,7 @@ def simplify_docstring(
 
 
 def _render_parameter(p: griffe.Parameter) -> str:
-    """Render one parameter, with its `*`/`**` prefix and default if it has one.
-
-    Args:
-        p: The parameter to render.
-
-    Returns:
-        The parameter as it appears in the signature.
-    """
+    """Render one parameter, with its `*`/`**` prefix and default if it has one."""
     if p.kind == griffe.ParameterKind.var_keyword:
         return f"**{p.name}"
     if p.kind == griffe.ParameterKind.var_positional:
@@ -535,14 +513,7 @@ def parse_class(c: griffe.Class) -> Class:
 
 
 def parse_function(f: griffe.Function) -> Function:
-    """Walk a function or method.
-
-    Args:
-        f: The function to walk.
-
-    Returns:
-        The function's documented surface.
-    """
+    """Walk a function or method."""
     out = simplify_docstring(f.docstring, f)
     return t.cast(
         "Function",
@@ -563,35 +534,21 @@ def parse_function(f: griffe.Function) -> Function:
 # Serialisation
 # ---------------------------------------------------------------------------
 
-_ENCODERS: dict[type, t.Callable[[t.Any], t.Any]] = {
-    Path: str,
-    PosixPath: str,
-    WindowsPath: str,
-    set: sorted,
-}
-
 
 class Encoder(griffe.JSONEncoder):
-    """Serialise the griffe objects left in the tree by `simplify_docstring`."""
+    """Serialise the griffe objects `simplify_docstring` leaves in the tree.
+
+    The base class already handles every griffe model (via `as_dict`) plus the
+    `Path`/`set` values they carry; the one thing it gets wrong for us is
+    `Expr`, which *has* an `as_dict` and so would serialise as a nested tree
+    where the consumers want the annotation as written.
+    """
 
     def default(self, obj: object) -> object:
-        """Return a serialisable representation of `obj`.
-
-        Args:
-            obj: The object to serialise.
-
-        Returns:
-            A serialisable representation.
-        """
+        """Return a serialisable representation of `obj`."""
         if isinstance(obj, griffe.Expr):
             return str(obj)
-        # Every griffe model serialises itself; anything else is one of the
-        # plain Python types the dump also carries.
-        as_dict = getattr(obj, "as_dict", None)
-        if as_dict is not None:
-            return as_dict(full=self.full)
-        encode = _ENCODERS.get(type(obj))
-        return encode(obj) if encode is not None else super().default(obj)
+        return super().default(obj)
 
 
 def main() -> None:

--- a/docs/scripts/gen_api_dump.py
+++ b/docs/scripts/gen_api_dump.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+# Copyright 2026 Algorithmiq
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ---------------------------------------------------------------------------
+# Portions of this file are derived from `fumapy`, the Python half of the
+# fumadocs-python package (https://github.com/fuma-nama/fumadocs):
+#
+#   MIT License. Copyright (c) 2023 Fuma
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+# ---------------------------------------------------------------------------
+"""Dump a Python package's documented API surface to JSON, via griffe.
+
+The JSON is the input to two consumers, which is why its schema is a contract
+rather than an implementation detail:
+
+- `scripts/generate-api.mjs`, which renders it to the MDX under
+  `content/docs/api/`, and
+- `scripts/remark-xref.mjs`, which builds the `[Symbol][]` cross-reference index
+  for prose pages and docstrings from it.
+
+Run it through the `gen-api` recipe rather than directly; it needs `monoprop`
+importable, which means the compiled extension has to be built first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import typing as t
+from importlib.metadata import version
+from pathlib import Path, PosixPath, WindowsPath
+
+import griffe
+from griffe_typingdoc import TypingDocExtension
+
+# ---------------------------------------------------------------------------
+# The JSON schema
+#
+# These describe the *serialised* shape, which is what the two JS consumers
+# read. In flight, the same fields hold griffe model objects (a
+# `DocstringParameter` where a `Parameter` is declared, an `Expr` where a `str`
+# is); `Encoder` flattens them at dump time. The `t.cast` calls in the `parse_*`
+# functions are where that gap is crossed deliberately.
+# ---------------------------------------------------------------------------
+
+
+class Module(t.TypedDict):
+    """A documented module or package."""
+
+    name: str
+    path: str
+    filepath: str
+    description: str | None
+    docstring: Docstring
+    attributes: list[Attribute]
+    modules: dict[str, Module]
+    classes: dict[str, Class]
+    functions: dict[str, Function]
+    version: str | None
+
+
+class Class(t.TypedDict):
+    """A documented class."""
+
+    name: str
+    path: str
+    description: str | None
+    parameters: list[Parameter]
+    attributes: list[Attribute]
+    docstring: Docstring
+    functions: dict[str, Function]
+    source: str
+    inherited_members: dict[str, list[dict[str, str]]]
+
+
+class Function(t.TypedDict):
+    """A documented function or method."""
+
+    name: str
+    path: str
+    signature: str
+    description: str | None
+    parameters: list[Parameter]
+    returns: dict[str, str | None]
+    docstring: Docstring
+    source: str
+
+
+class DocstringSection(t.TypedDict):
+    """A docstring section that `simplify_docstring` did not consume."""
+
+    kind: str
+    value: str | list[Parameter]
+
+
+Docstring = list[DocstringSection]
+
+
+class Parameter(t.TypedDict):
+    """A signature parameter, merged with its docstring entry if it has one."""
+
+    name: str
+    annotation: str
+    description: str
+    value: str
+
+
+class Attribute(t.TypedDict):
+    """A module- or class-level attribute."""
+
+    name: str
+    annotation: str
+    description: str
+    value: str
+
+
+# ---------------------------------------------------------------------------
+# Docstring simplification
+# ---------------------------------------------------------------------------
+
+
+class SimplifiedDocstring(t.NamedTuple):
+    """A docstring split into the parts the renderer treats specially.
+
+    Entries are either plain dicts built from the signature or the griffe
+    docstring elements they were parsed from; `Encoder` serialises both, so the
+    two are interchangeable downstream. A field is `None` when the parent cannot
+    have it at all (a module has no parameters), as opposed to an empty list for
+    a parent that has none.
+    """
+
+    description: str | None
+    parameters: list[object] | None
+    returns: object | None
+    attributes: list[object] | None
+    remainder: list[griffe.DocstringSection]
+
+
+def _parameters_from_signature(
+    parent: griffe.Class | griffe.Function,
+) -> list[object]:
+    return [
+        {
+            "name": p.name,
+            "annotation": p.annotation,
+            "description": None,
+            "value": p.default,
+        }
+        for p in parent.parameters
+    ]
+
+
+def _returns_from_signature(parent: griffe.Function) -> object:
+    return {
+        "name": "",
+        "annotation": (
+            parent.returns
+            if isinstance(parent.returns, (str, type(None)))
+            else "".join(
+                elem if isinstance(elem, str) else elem.canonical_path
+                for elem in parent.returns.iterate(flat=True)
+            )
+        ),
+        "description": None,
+    }
+
+
+def _attributes_from_signature(
+    parent: griffe.Module | griffe.Class,
+) -> list[object]:
+    return [
+        {
+            "name": attr.name,
+            "annotation": attr.annotation,
+            "description": attr.docstring.parsed if attr.docstring else None,
+            "value": attr.value,
+        }
+        for attr in parent.attributes.values()
+        if (not attr.is_alias and not attr.is_private)
+    ]
+
+
+def _parse_nested(description: str) -> object:
+    """Re-parse a docstring entry's description as a Google-style docstring.
+
+    Parameter and attribute descriptions can themselves carry sections; the
+    renderer expects the parsed form. Non-string descriptions are already
+    parsed, and `AttributeError` is how that shows up.
+
+    Args:
+        description: The entry's description, parsed or not.
+
+    Returns:
+        The parsed sections, or `description` unchanged if it was not raw text.
+    """
+    try:
+        return griffe.parse_google(griffe.Docstring(description))
+    except AttributeError:
+        return description
+
+
+def _merge_parameters(
+    documented: list[griffe.DocstringParameter], parent: griffe.Class | griffe.Function
+) -> list[object]:
+    """Order a docstring's parameter entries by the real signature.
+
+    Args:
+        documented: The entries from the docstring's parameters section.
+        parent: The object whose signature fixes the order.
+
+    Returns:
+        One entry per signature parameter, documented or not.
+    """
+    by_name = {entry.name: entry for entry in documented}
+    merged: list[object] = []
+    for param in parent.parameters:
+        entry = by_name.get(param.name)
+        if entry is not None:
+            # Replaces the raw text with its parsed sections in place, which the
+            # renderer reads back -- griffe declares `description` as `str`, so
+            # this widening is deliberate.
+            entry.description = t.cast("str", _parse_nested(entry.description))
+            merged.append(entry)
+        else:
+            merged.append(
+                {
+                    "name": param.name,
+                    "annotation": param.annotation,
+                    "description": None,
+                    "value": param.default,
+                }
+            )
+    return merged
+
+
+def _merge_attributes(
+    documented: list[griffe.DocstringAttribute], parent: griffe.Module | griffe.Class
+) -> list[object]:
+    """Order a docstring's attribute entries by the real attributes.
+
+    Args:
+        documented: The entries from the docstring's attributes section.
+        parent: The object whose attributes fix the order.
+
+    Returns:
+        One entry per non-aliased attribute, documented or not.
+    """
+    by_name = {entry.name: entry for entry in documented}
+    merged: list[object] = []
+    for attr in parent.attributes.values():
+        if attr.is_alias:
+            continue
+        entry = by_name.get(attr.name)
+        if entry is not None:
+            merged.append(
+                {
+                    "name": entry.name,
+                    "description": _parse_nested(entry.description),
+                    # The declared annotation wins over the inferred one, but
+                    # the value only exists on the real attribute.
+                    "annotation": entry.annotation,
+                    "value": attr.value,
+                }
+            )
+        else:
+            merged.append(
+                {
+                    "name": attr.name,
+                    "annotation": attr.annotation,
+                    "description": (attr.docstring.parsed if attr.docstring else None),
+                    "value": attr.value,
+                }
+            )
+    return merged
+
+
+def simplify_docstring(
+    doc: griffe.Docstring | None,
+    parent: griffe.Module | griffe.Class | griffe.Function | None = None,
+) -> SimplifiedDocstring:
+    """Split a docstring into description, parameters, returns and the rest.
+
+    The `parameters` and `attributes` sections are re-ordered to follow the real
+    signature, and entries the docstring omits are filled in from it, so the
+    renderer can lay out every parameter whether or not it is documented.
+
+    Args:
+        doc: The docstring to simplify; may be `None`.
+        parent: The object the docstring belongs to, used for the signature.
+
+    Returns:
+        The docstring's parts, with anything not recognised in `remainder`.
+    """
+    description = None
+    parameters = (
+        _parameters_from_signature(parent)
+        if isinstance(parent, (griffe.Class, griffe.Function))
+        else None
+    )
+    attributes = (
+        _attributes_from_signature(parent)
+        if isinstance(parent, (griffe.Module, griffe.Class))
+        else None
+    )
+    returns = (
+        _returns_from_signature(parent) if isinstance(parent, griffe.Function) else None
+    )
+    remainder: list[griffe.DocstringSection] = []
+
+    if not doc:
+        return SimplifiedDocstring(
+            description, parameters, returns, attributes, remainder
+        )
+
+    for i, sec in enumerate(doc.parsed):
+        # The leading prose is the summary; later text sections stay in the
+        # remainder so the renderer can place them after the signature.
+        if sec.kind == "text" and i == 0:
+            description = sec.value
+            continue
+
+        # Each branch is gated on the parent kind that can actually have the
+        # section, so a misplaced section (`Args:` on a module) lands in the
+        # remainder instead of failing on a missing signature.
+        if sec.kind == "parameters" and isinstance(
+            parent, (griffe.Class, griffe.Function)
+        ):
+            parameters = _merge_parameters(sec.value, parent)
+            continue
+
+        if sec.kind == "returns" and isinstance(parent, griffe.Function):
+            returns = sec.value[0]
+            returns.annotation = (
+                returns.annotation.canonical_path
+                if isinstance(returns.annotation, griffe.Expr)
+                else returns.annotation
+            )
+            continue
+
+        if sec.kind == "attributes" and isinstance(
+            parent, (griffe.Module, griffe.Class)
+        ):
+            attributes = _merge_attributes(sec.value, parent)
+            continue
+
+        remainder.append(sec)
+
+    return SimplifiedDocstring(description, parameters, returns, attributes, remainder)
+
+
+# ---------------------------------------------------------------------------
+# Signatures
+# ---------------------------------------------------------------------------
+
+
+def _render_parameter(p: griffe.Parameter) -> str:
+    """Render one parameter, with its `*`/`**` prefix and default if it has one.
+
+    Args:
+        p: The parameter to render.
+
+    Returns:
+        The parameter as it appears in the signature.
+    """
+    if p.kind == griffe.ParameterKind.var_keyword:
+        return f"**{p.name}"
+    if p.kind == griffe.ParameterKind.var_positional:
+        return f"*{p.name}"
+    if p.default is not None:
+        return f"{p.name}={p.default}"
+    return p.name
+
+
+def build_signature(func: griffe.Function) -> str:
+    """Render a function's signature, including the `/` and `*` separators.
+
+    griffe stores parameter kinds rather than the separators, so the markers are
+    reconstructed: `/` closes the positional-only run at the first parameter
+    that is not positional-only, and `*` opens the keyword-only run.
+
+    Args:
+        func: The function to render.
+
+    Returns:
+        The signature, from the opening parenthesis to the return annotation.
+    """
+    tokens: list[str] = []
+    positional_only = True
+    keyword_only = False
+    for i, p in enumerate(func.parameters):
+        if p.kind in (
+            griffe.ParameterKind.positional_or_keyword,
+            griffe.ParameterKind.keyword_only,
+        ):
+            # The first parameter that is not positional-only closes the run,
+            # unless it is also the first parameter overall (nothing to close).
+            if positional_only and i != 0:
+                tokens.append("/")
+            positional_only = False
+
+            if p.kind == griffe.ParameterKind.keyword_only and not keyword_only:
+                tokens.append("*")
+                keyword_only = True
+
+        tokens.append(_render_parameter(p))
+
+    signature = f"({', '.join(tokens)})"
+    if func.returns:
+        signature += f" -> {func.returns}"
+
+    return signature
+
+
+# ---------------------------------------------------------------------------
+# Walking the package
+# ---------------------------------------------------------------------------
+
+
+def parse_module(m: griffe.Object | griffe.Alias) -> Module:
+    """Walk a module recursively, dropping re-exported (aliased) members.
+
+    Aliases are skipped so a symbol is documented once, on the page for the
+    module that defines it -- which is also what makes the cross-reference index
+    single-valued.
+
+    Args:
+        m: The module to walk.
+
+    Returns:
+        The module's documented surface.
+
+    Raises:
+        TypeError: If `m` is not a module.
+    """
+    if not isinstance(m, griffe.Module):
+        raise TypeError("Module must be a module")
+
+    out = simplify_docstring(m.docstring, m)
+    res: dict[str, object] = {
+        "name": m.name,
+        "path": m.path,
+        "filepath": m.filepath,
+        "description": out.description,
+        "docstring": out.remainder,
+        "attributes": out.attributes,
+        "modules": {
+            name: parse_module(value)
+            for name, value in m.modules.items()
+            if not value.is_alias
+        },
+        "classes": {
+            name: parse_class(value)
+            for name, value in m.classes.items()
+            if not value.is_alias
+        },
+        "functions": {
+            name: parse_function(value)
+            for name, value in m.functions.items()
+            if not value.is_alias
+        },
+    }
+    if m.is_package:
+        try:
+            res["version"] = version(m.name)
+        except AttributeError:
+            res["version"] = "unknown"
+
+    return t.cast("Module", res)
+
+
+def parse_class(c: griffe.Class) -> Class:
+    """Walk a class.
+
+    Inherited members are recorded by canonical path and grouped by the class
+    that defines them, so the renderer can point at the base class rather than
+    duplicating the documentation.
+
+    Args:
+        c: The class to walk.
+
+    Returns:
+        The class's documented surface.
+    """
+    out = simplify_docstring(c.docstring, c)
+    inherited: dict[str, list[dict[str, str]]] = {}
+    res: dict[str, object] = {
+        "name": c.name,
+        "path": c.path,
+        "description": out.description,
+        "parameters": out.parameters,
+        "attributes": out.attributes,
+        "docstring": out.remainder,
+        "functions": {
+            name: parse_function(value)
+            for name, value in c.functions.items()
+            if not value.is_alias
+        },
+        "source": c.source,
+        "inherited_members": inherited,
+    }
+    for member in c.inherited_members.values():
+        parent_path = ".".join(member.canonical_path.split(".")[:-1])
+        entry = {"kind": member.kind, "path": member.canonical_path}
+        inherited.setdefault(parent_path, []).append(entry)
+    return t.cast("Class", res)
+
+
+def parse_function(f: griffe.Function) -> Function:
+    """Walk a function or method.
+
+    Args:
+        f: The function to walk.
+
+    Returns:
+        The function's documented surface.
+    """
+    out = simplify_docstring(f.docstring, f)
+    return t.cast(
+        "Function",
+        {
+            "name": f.name,
+            "path": f.path,
+            "signature": build_signature(f),
+            "description": out.description,
+            "parameters": out.parameters,
+            "returns": out.returns,
+            "docstring": out.remainder,
+            "source": f.source,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+_ENCODERS: dict[type, t.Callable[[t.Any], t.Any]] = {
+    Path: str,
+    PosixPath: str,
+    WindowsPath: str,
+    set: sorted,
+}
+
+
+class Encoder(griffe.JSONEncoder):
+    """Serialise the griffe objects left in the tree by `simplify_docstring`."""
+
+    def default(self, obj: object) -> object:
+        """Return a serialisable representation of `obj`.
+
+        Args:
+            obj: The object to serialise.
+
+        Returns:
+            A serialisable representation.
+        """
+        if isinstance(obj, griffe.Expr):
+            return str(obj)
+        # Every griffe model serialises itself; anything else is one of the
+        # plain Python types the dump also carries.
+        as_dict = getattr(obj, "as_dict", None)
+        if as_dict is not None:
+            return as_dict(full=self.full)
+        encode = _ENCODERS.get(type(obj))
+        return encode(obj) if encode is not None else super().default(obj)
+
+
+def main() -> None:
+    """Dump the API surface of the module named on the command line."""
+    parser = argparse.ArgumentParser(description="Dump a Python API surface to JSON")
+    parser.add_argument("module", type=str, help="The module to document")
+    parser.add_argument(
+        "--dir",
+        "-d",
+        type=Path,
+        default=Path(),
+        help="The directory to write `<module>.json` into",
+    )
+    args = parser.parse_args()
+
+    pkg = parse_module(
+        griffe.load(
+            args.module,
+            docstring_parser="auto",
+            # The renderer shows each function's source in a collapsible block.
+            store_source=True,
+            # Reads `Doc[...]` annotations (PEP 727) as descriptions.
+            extensions=griffe.load_extensions(TypingDocExtension),
+        )
+    )
+
+    out_path = args.dir / f"{args.module}.json"
+    with out_path.open("w") as file:
+        json.dump(pkg, file, cls=Encoder, indent=2, full=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/generate-api.mjs
+++ b/docs/scripts/generate-api.mjs
@@ -3,7 +3,8 @@
 //
 // `api-mdx.mjs`'s `convert`/`write` do the heavy lifting; this script only
 //  1. prunes the griffe dump to the public surface (minus private `_`-prefixed members),
-//  2. resolves cross-references inside the rendered pages, and
+//  2. fixes the package-name segment that `convert` puts in cross-links but
+//     `write` strips from file paths, and
 //  3. emits a `meta.json` so the API section is ordered like the old reference.
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';

--- a/docs/scripts/generate-api.mjs
+++ b/docs/scripts/generate-api.mjs
@@ -132,31 +132,22 @@ function extractReturnsFromSource(source) {
 }
 
 /**
- * griffe preserves wrapped descriptions in parsed docstring sections, and the
- * dump's `returns` entry truncates multi-line Returns text in some cases, so we
- * re-read it from the function source and fold it to one line before
- * conversion. Fixing this in `gen_api_dump.py` would retire this whole path.
+ * Recover a multi-line `Returns:` description that the dump truncated, by
+ * re-reading it from the function source.
+ *
+ * This is a bandaid over the dump, not a fix. griffe's Google parser defaults to
+ * `returns_multiple_items`, which splits the block one item per physical line
+ * and distributes a tuple annotation element-wise across them, so the dump's
+ * `sec.value[0]` keeps only the first line *and* the wrong annotation
+ * (`graph_size` is documented as `int`, not `tuple[int, int]`). Passing
+ * `docstring_options={"returns_multiple_items": False}` to `griffe.load` in
+ * `gen_api_dump.py` fixes both and retires this whole path -- deferred only
+ * because it changes the generated pages.
  */
 function normalizeFunctionReturnsSection(funcNode) {
   const fromSource = extractReturnsFromSource(funcNode?.source);
   if (fromSource && funcNode?.returns && typeof funcNode.returns === 'object') {
     funcNode.returns.description = foldToOneLine(fromSource);
-  }
-
-  const parsed = funcNode?.docstring?.parsed;
-  if (!Array.isArray(parsed)) return;
-
-  for (const section of parsed) {
-    if (section?.kind !== 'returns') continue;
-
-    // Depending on parser shape, `value` can be a list of return entries or a
-    // single entry-like object.
-    const values = Array.isArray(section.value) ? section.value : [section.value];
-    for (const item of values) {
-      if (item && typeof item.description === 'string') {
-        item.description = foldToOneLine(item.description);
-      }
-    }
   }
 }
 
@@ -196,10 +187,6 @@ async function main() {
 
   for (const file of files) {
     file.content = resolveXrefs(file.content, xref, unresolved, scopeFromPath(file.path));
-
-    // `convert` keeps the package name ("monoprop") in hrefs, but `write`
-    // strips that leading segment from file paths. Realign the links.
-    file.content = file.content.replaceAll(`${API_BASE_URL}/monoprop`, API_BASE_URL);
 
     // Attach source paths to frontmatter so docs can build GitHub links
     // without duplicating the module list in app code.

--- a/docs/scripts/generate-api.mjs
+++ b/docs/scripts/generate-api.mjs
@@ -1,15 +1,15 @@
 // Generate the Python API reference MDX from the griffe JSON produced by
-// `fumapy-generate monoprop` (see the `gen-api` recipe in the justfile).
+// `gen_api_dump.py` (see the `gen-api` recipe in the justfile).
 //
-// fumadocs-python's `convert`/`write` do the heavy lifting; this script only
+// `api-mdx.mjs`'s `convert`/`write` do the heavy lifting; this script only
 //  1. prunes the griffe dump to the public surface (minus private `_`-prefixed members),
 //  2. fixes the package-name segment that `convert` puts in cross-links but
 //     `write` strips from file paths, and
 //  3. emits a `meta.json` so the API section is ordered like the old reference.
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { convert, write, frontmatter } from 'fumadocs-python';
-import { API_BASE_URL, buildXrefMap, pageUrl, resolve } from './xref.mjs';
+import { convert, write } from './api-mdx.mjs';
+import { API_BASE_URL, buildXrefMap, resolve } from './xref.mjs';
 
 const JSON_PATH = path.resolve('monoprop.json');
 const OUT_DIR = path.resolve('content/docs/api');
@@ -132,10 +132,10 @@ function extractReturnsFromSource(source) {
 }
 
 /**
- * griffe preserves wrapped descriptions in parsed docstring sections. The
- * fumadocs-python renderer currently truncates multi-line Returns text in some
- * cases, so we normalize function Returns descriptions to one line before
- * conversion.
+ * griffe preserves wrapped descriptions in parsed docstring sections, and the
+ * dump's `returns` entry truncates multi-line Returns text in some cases, so we
+ * re-read it from the function source and fold it to one line before
+ * conversion. Fixing this in `gen_api_dump.py` would retire this whole path.
  */
 function normalizeFunctionReturnsSection(funcNode) {
   const fromSource = extractReturnsFromSource(funcNode?.source);

--- a/docs/scripts/generate-api.mjs
+++ b/docs/scripts/generate-api.mjs
@@ -3,8 +3,7 @@
 //
 // `api-mdx.mjs`'s `convert`/`write` do the heavy lifting; this script only
 //  1. prunes the griffe dump to the public surface (minus private `_`-prefixed members),
-//  2. fixes the package-name segment that `convert` puts in cross-links but
-//     `write` strips from file paths, and
+//  2. resolves cross-references inside the rendered pages, and
 //  3. emits a `meta.json` so the API section is ordered like the old reference.
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';

--- a/docs/scripts/xref.mjs
+++ b/docs/scripts/xref.mjs
@@ -7,7 +7,7 @@ export const API_BASE_URL = '/api';
 
 /**
  * Turn a fully-qualified symbol path into the URL of the page that documents
- * it. Mirrors fumadocs-python's `getHref`, then drops the leading `monoprop`
+ * it. Mirrors `getHref` in `api-mdx.mjs`, then drops the leading `monoprop`
  * segment that `write` strips from file paths (the same realignment applied to
  * the rendered content).
  */

--- a/docs/scripts/xref.mjs
+++ b/docs/scripts/xref.mjs
@@ -7,25 +7,27 @@ export const API_BASE_URL = '/api';
 
 /**
  * Turn a fully-qualified symbol path into the URL of the page that documents
- * it. Mirrors `getHref` in `api-mdx.mjs`, then drops the leading `monoprop`
- * segment that `write` strips from file paths (the same realignment applied to
- * the rendered content).
+ * it. Must agree with `getHref` in `api-mdx.mjs`, which mints the same URLs for
+ * the links inside the generated pages: both drop the leading package segment,
+ * because that is what `write` strips from the file paths.
  */
 export function pageUrl(dottedPath) {
-  const url =
+  return (
     '/' +
-    [...API_BASE_URL.split('/'), ...dottedPath.split('.')].filter((v) => v.length > 0).join('/');
-  return url.replace(`${API_BASE_URL}/monoprop`, API_BASE_URL);
+    [...API_BASE_URL.split('/'), ...dottedPath.split('.').slice(1)]
+      .filter((v) => v.length > 0)
+      .join('/')
+  );
 }
 
 /**
  * Build a map from fully-qualified symbol path to the doc URL that documents it.
  *
  * Classes and modules get their own page. Functions, methods and attributes are
- * rendered inline on their parent's page; the `getMDXComponents` wrappers give
- * each `PyFunction`/`PyAttribute` card an `id` equal to its member name, so those
- * members resolve to their parent page with a `#<name>` fragment that jumps to
- * the definition.
+ * rendered inline on their parent's page; `PyFunction`/`PyAttribute` (in
+ * `src/components/py.tsx`) give each card an `id` equal to its member name, so
+ * those members resolve to their parent page with a `#<name>` fragment that
+ * jumps to the definition.
  */
 export function buildXrefMap(pkg) {
   const map = new Map();

--- a/docs/src/app/global.css
+++ b/docs/src/app/global.css
@@ -1,8 +1,16 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
-/* Styling for the generated Python API reference components (PyFunction, …). */
-@import 'fumadocs-python/preset.css';
+
+/*
+ * Kind badges on the generated Python API reference cards (see
+ * `src/components/py.tsx`). The `fdpy-` prefix and these two hues are inherited
+ * from fumadocs-python's stylesheet, which the components used to come from.
+ */
+@theme inline {
+  --color-fdpy-func: oklch(79.2% 0.209 151.711);
+  --color-fdpy-attribute: oklch(74% 0.238 322.16);
+}
 
 /*
  * Algorithmiq brand accents (algorithmiq.fi).

--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -1,15 +1,7 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
-import * as Py from 'fumadocs-python/components';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from 'fumadocs-ui/components/ui/collapsible';
-import { buttonVariants } from 'fumadocs-ui/components/ui/button';
-import { ChevronRight } from 'lucide-react';
-import { cn } from '@/lib/cn';
+import * as Py from '@/components/py';
 import type { MDXComponents } from 'mdx/types';
-import type { ComponentProps, ImgHTMLAttributes, ReactElement, ReactNode } from 'react';
+import type { ImgHTMLAttributes } from 'react';
 
 // The tutorial pages embed matplotlib figures as raw `<img src="data:…">` tags
 // with no intrinsic dimensions. fumadocs' default `img` wraps Next.js' `Image`,
@@ -25,47 +17,11 @@ function Img({ src, ...props }: ImgHTMLAttributes<HTMLImageElement>) {
   return <DefaultImg src={src} {...props} />;
 }
 
-// Wrap the generated Py{Function,Attribute} cards in an anchor so cross-references
-// to a specific member (e.g. `monoprop.circuit.ExpGate.__init__`) can jump to its
-// definition: the `id` must stay equal to the member `name`, which is the `#<name>`
-// fragment `buildXrefMap` (docs/scripts/xref.mjs) appends. `scroll-mt` keeps the
-// target clear of the sticky header.
-function anchored<P extends { name?: string }>(Component: (props: P) => ReactElement) {
-  return function Anchored(props: P) {
-    return (
-      <div id={props.name} className="scroll-mt-24">
-        <Component {...props} />
-      </div>
-    );
-  };
-}
-
-const PyFunction = anchored(Py.PyFunction as (props: ComponentProps<typeof Py.PyFunction>) => ReactElement);
-const PyAttribute = anchored(Py.PyAttribute as (props: ComponentProps<typeof Py.PyAttribute>) => ReactElement);
-
-// Replaces `Py.PySourceCode` from fumadocs-python which is bugged.
-function PySourceCode({ children }: { children?: ReactNode }) {
-  return (
-    <Collapsible className="my-6">
-      <CollapsibleTrigger
-        className={cn(buttonVariants({ color: 'secondary', size: 'sm', className: 'group' }))}
-      >
-        Source Code
-        <ChevronRight className="size-3.5 text-fd-muted-foreground group-data-[state=open]:rotate-90" />
-      </CollapsibleTrigger>
-      <CollapsibleContent className="prose-no-margin">{children}</CollapsibleContent>
-    </Collapsible>
-  );
-}
-
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
     // Py* components (plus Tab/Tabs) used by the generated Python API pages.
     ...Py,
-    PyFunction,
-    PyAttribute,
-    PySourceCode,
     img: Img,
     ...components,
   } satisfies MDXComponents;

--- a/docs/src/components/py.tsx
+++ b/docs/src/components/py.tsx
@@ -1,0 +1,159 @@
+// The component vocabulary of the generated Python API reference: the MDX under
+// `content/docs/api/` is written in terms of these, by `scripts/api-mdx.mjs`.
+//
+// Derived from the React half of fumadocs-python (MIT, (c) 2023 Fuma); see
+// `scripts/gen_api_dump.py` for the full notice.
+//
+// `PyFunction` and `PyAttribute` carry `id={name}`: that is the `#<member>`
+// fragment `buildXrefMap` (scripts/xref.mjs) appends for members, which are
+// documented inline on their parent's page rather than on one of their own.
+// `scroll-mt` keeps the target clear of the sticky header.
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from 'fumadocs-ui/components/ui/collapsible';
+import { buttonVariants } from 'fumadocs-ui/components/ui/button';
+import { highlight } from 'fumadocs-core/highlight';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import type { ComponentProps, ReactNode } from 'react';
+
+export { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+const card = 'bg-fd-card rounded-lg text-sm my-6 p-3 border';
+
+/** The kind badge in a card's header; the colours come from `global.css`. */
+function Badge({ kind }: { kind: 'func' | 'attribute' | 'param' }) {
+  const color = {
+    func: 'bg-fdpy-func/10 text-fdpy-func border-fdpy-func/50',
+    attribute: 'bg-fdpy-attribute/10 text-fdpy-attribute border-fdpy-attribute/50',
+    param: 'bg-fd-primary/10 text-fd-primary border-fd-primary/10',
+  }[kind];
+  return (
+    <code className={cn('text-xs font-medium border p-1 rounded-lg not-prose', color)}>
+      {kind === 'param' ? 'param' : kind}
+    </code>
+  );
+}
+
+/**
+ * A syntax-highlighted code span. Async (it awaits shiki), so it only ever
+ * renders on the server -- which is fine, every caller here is a server
+ * component.
+ */
+async function InlineCode({ lang, code, ...rest }: { lang: string; code: string } & ComponentProps<'span'>) {
+  return highlight(code, {
+    lang,
+    components: {
+      pre: (props) => <span {...props} {...rest} className={cn(rest.className, props.className)} />,
+    },
+  });
+}
+
+export function PyFunction(props: { name: string; type: string; children?: ReactNode }) {
+  return (
+    <figure id={props.name} className={cn(card, 'scroll-mt-24')}>
+      <div className="flex gap-2 items-center font-mono flex-wrap mb-4">
+        <Badge kind="func" />
+        {props.name}
+        <InlineCode
+          lang="python"
+          className="not-prose text-xs text-fd-muted-foreground"
+          code={props.type}
+        />
+      </div>
+      <div className="text-fd-muted-foreground prose-no-margin">{props.children}</div>
+    </figure>
+  );
+}
+
+export function PyAttribute(props: {
+  name: string;
+  type?: string;
+  value?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <figure id={props.name} className={cn(card, 'scroll-mt-24')}>
+      <div className="flex gap-2 items-center flex-wrap font-mono mb-4">
+        <Badge kind="attribute" />
+        {props.name}
+        {props.type && (
+          <InlineCode
+            lang="python"
+            className="not-prose text-fd-muted-foreground text-xs"
+            code={props.type}
+          />
+        )}
+      </div>
+      <div className="text-fd-muted-foreground prose-no-margin">
+        {props.value && (
+          <InlineCode lang="python" className="not-prose text-xs" code={`= ${props.value}`} />
+        )}
+        {props.children}
+      </div>
+    </figure>
+  );
+}
+
+export function PyParameter(props: {
+  name: string;
+  type?: string;
+  value?: string;
+  children?: ReactNode;
+}) {
+  return (
+    // The square middle corners plus `first:`/`last:` rounding stack the
+    // parameters of one function into a single seamless list.
+    <div
+      data-parameter=""
+      className="bg-fd-secondary rounded-lg text-sm p-3 border shadow-md rounded-none first:rounded-t-lg last:rounded-b-lg"
+    >
+      <div className="flex flex-wrap gap-2 items-center font-mono text-fd-foreground">
+        <Badge kind="param" />
+        {props.name}
+        {props.type && (
+          <InlineCode
+            lang="python"
+            className="ms-auto text-fd-muted-foreground not-prose text-xs"
+            code={props.type}
+          />
+        )}
+      </div>
+      <div className="text-fd-muted-foreground prose-no-margin mt-4 empty:hidden">
+        {props.value ? (
+          <InlineCode lang="python" code={`= ${props.value}`} className="not-prose text-xs" />
+        ) : null}
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+export function PyFunctionReturn({ type, children }: { type?: string; children?: ReactNode }) {
+  return (
+    <div className="border bg-fd-secondary rounded-lg p-3 mt-2">
+      <div className="flex flex-wrap gap-2 not-prose">
+        <p className="font-medium me-auto">Returns</p>
+        <InlineCode lang="python" code={type ?? 'None'} className="text-xs" />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function PySourceCode({ children }: { children?: ReactNode }) {
+  return (
+    <Collapsible className="my-6">
+      <CollapsibleTrigger
+        className={cn(buttonVariants({ color: 'secondary', size: 'sm', className: 'group' }))}
+      >
+        Source Code
+        <ChevronRight className="size-3.5 text-fd-muted-foreground group-data-[state=open]:rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="prose-no-margin">{children}</CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/docs/src/components/py.tsx
+++ b/docs/src/components/py.tsx
@@ -7,7 +7,6 @@
 // `PyFunction` and `PyAttribute` carry `id={name}`: that is the `#<member>`
 // fragment `buildXrefMap` (scripts/xref.mjs) appends for members, which are
 // documented inline on their parent's page rather than on one of their own.
-// `scroll-mt` keeps the target clear of the sticky header.
 
 import {
   Collapsible,
@@ -22,7 +21,9 @@ import type { ComponentProps, ReactNode } from 'react';
 
 export { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
-const card = 'bg-fd-card rounded-lg text-sm my-6 p-3 border';
+// The `scroll-mt` keeps a card clear of the sticky header when an anchor jumps
+// to it, so it belongs with the card surface itself, not the anchored members.
+const card = 'bg-fd-card rounded-lg text-sm my-6 p-3 border scroll-mt-24';
 
 /** The kind badge in a card's header; the colours come from `global.css`. */
 function Badge({ kind }: { kind: 'func' | 'attribute' | 'param' }) {
@@ -32,20 +33,18 @@ function Badge({ kind }: { kind: 'func' | 'attribute' | 'param' }) {
     param: 'bg-fd-primary/10 text-fd-primary border-fd-primary/10',
   }[kind];
   return (
-    <code className={cn('text-xs font-medium border p-1 rounded-lg not-prose', color)}>
-      {kind === 'param' ? 'param' : kind}
-    </code>
+    <code className={cn('text-xs font-medium border p-1 rounded-lg not-prose', color)}>{kind}</code>
   );
 }
 
 /**
  * A syntax-highlighted code span. Async (it awaits shiki), so it only ever
  * renders on the server -- which is fine, every caller here is a server
- * component.
+ * component. Everything rendered here is Python, so the language is not a prop.
  */
-async function InlineCode({ lang, code, ...rest }: { lang: string; code: string } & ComponentProps<'span'>) {
+async function InlineCode({ code, ...rest }: { code: string } & ComponentProps<'span'>) {
   return highlight(code, {
-    lang,
+    lang: 'python',
     components: {
       pre: (props) => <span {...props} {...rest} className={cn(rest.className, props.className)} />,
     },
@@ -54,12 +53,11 @@ async function InlineCode({ lang, code, ...rest }: { lang: string; code: string 
 
 export function PyFunction(props: { name: string; type: string; children?: ReactNode }) {
   return (
-    <figure id={props.name} className={cn(card, 'scroll-mt-24')}>
+    <figure id={props.name} className={card}>
       <div className="flex gap-2 items-center font-mono flex-wrap mb-4">
         <Badge kind="func" />
         {props.name}
         <InlineCode
-          lang="python"
           className="not-prose text-xs text-fd-muted-foreground"
           code={props.type}
         />
@@ -76,13 +74,12 @@ export function PyAttribute(props: {
   children?: ReactNode;
 }) {
   return (
-    <figure id={props.name} className={cn(card, 'scroll-mt-24')}>
+    <figure id={props.name} className={card}>
       <div className="flex gap-2 items-center flex-wrap font-mono mb-4">
         <Badge kind="attribute" />
         {props.name}
         {props.type && (
           <InlineCode
-            lang="python"
             className="not-prose text-fd-muted-foreground text-xs"
             code={props.type}
           />
@@ -90,7 +87,7 @@ export function PyAttribute(props: {
       </div>
       <div className="text-fd-muted-foreground prose-no-margin">
         {props.value && (
-          <InlineCode lang="python" className="not-prose text-xs" code={`= ${props.value}`} />
+          <InlineCode className="not-prose text-xs" code={`= ${props.value}`} />
         )}
         {props.children}
       </div>
@@ -105,18 +102,17 @@ export function PyParameter(props: {
   children?: ReactNode;
 }) {
   return (
-    // The square middle corners plus `first:`/`last:` rounding stack the
-    // parameters of one function into a single seamless list.
+    // Square middle corners, rounded only at the ends, so the parameters of one
+    // function stack into a single seamless list.
     <div
       data-parameter=""
-      className="bg-fd-secondary rounded-lg text-sm p-3 border shadow-md rounded-none first:rounded-t-lg last:rounded-b-lg"
+      className="bg-fd-secondary text-sm p-3 border shadow-md rounded-none first:rounded-t-lg last:rounded-b-lg"
     >
       <div className="flex flex-wrap gap-2 items-center font-mono text-fd-foreground">
         <Badge kind="param" />
         {props.name}
         {props.type && (
           <InlineCode
-            lang="python"
             className="ms-auto text-fd-muted-foreground not-prose text-xs"
             code={props.type}
           />
@@ -124,7 +120,7 @@ export function PyParameter(props: {
       </div>
       <div className="text-fd-muted-foreground prose-no-margin mt-4 empty:hidden">
         {props.value ? (
-          <InlineCode lang="python" code={`= ${props.value}`} className="not-prose text-xs" />
+          <InlineCode code={`= ${props.value}`} className="not-prose text-xs" />
         ) : null}
         {props.children}
       </div>
@@ -137,7 +133,7 @@ export function PyFunctionReturn({ type, children }: { type?: string; children?:
     <div className="border bg-fd-secondary rounded-lg p-3 mt-2">
       <div className="flex flex-wrap gap-2 not-prose">
         <p className="font-medium me-auto">Returns</p>
-        <InlineCode lang="python" code={type ?? 'None'} className="text-xs" />
+        <InlineCode code={type ?? 'None'} className="text-xs" />
       </div>
       {children}
     </div>

--- a/justfile
+++ b/justfile
@@ -21,12 +21,6 @@ site := "docs"
 
 docs_uv := "uv run --group docs --group test --no-dev --all-extras"
 
-# `fumapy` (the fumadocs Python docgen) ships inside the npm package; inject it
-# ephemerally and pin griffe to the 1.x line it targets (its newer
-# griffe-typingdoc dependency otherwise pulls an incompatible griffe).
-
-fumapy := "--with " + site + "/node_modules/fumadocs-python --with 'griffe<2' --with 'griffe-typingdoc==0.2.8'"
-
 default: build-docs
 
 test:
@@ -197,7 +191,7 @@ gen-notebooks:
 
 # Generate the Python API reference MDX from docstrings (griffe -> JSON -> MDX).
 gen-api:
-    {{ docs_uv }} {{ fumapy }} fumapy-generate monoprop -d {{ site }}
+    {{ docs_uv }} python {{ site }}/scripts/gen_api_dump.py monoprop -d {{ site }}
     cd {{ site }} && node scripts/generate-api.mjs
 
 # Run the runnable docstring examples (the docstring-level doctest check).

--- a/prek.toml
+++ b/prek.toml
@@ -38,8 +38,8 @@ hooks = [
 repo = "https://github.com/astral-sh/ruff-pre-commit"
 rev = "v0.15.20"
 hooks = [
-    { id = "ruff-check", exclude = "(docs/)" },
-    { id = "ruff-format", exclude = "(docs/)", args = [
+    { id = "ruff-check" },
+    { id = "ruff-format", args = [
         "--check",
     ] },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,10 @@ dev = ["prek>=0.4", "ruff==0.15.20"]
 # (`nbconvert`) and dumping the API surface from docstrings (`griffe`, driven by
 # `docs/scripts/gen_api_dump.py` in the `gen-api` recipe). griffe is held to the
 # 1.x line: `griffe-typingdoc` 0.2.x, which reads the `Doc[...]` annotations,
-# does not support 2.x.
+# does not support 2.x. The floor is 1.15 because earlier 1.x releases infer
+# different return annotations, which changes the generated pages.
 docs = [
-  "griffe>=1.13,<2",
+  "griffe>=1.15,<2",
   "griffe-typingdoc>=0.2.8,<1",
   "nbconvert",
   "pytest-markdown-docs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ dev = ["prek>=0.4", "ruff==0.15.20"]
 # Python's only roles are converting the tutorial notebooks to Markdown
 # (`nbconvert`) and dumping the API surface from docstrings (`griffe`, driven by
 # `docs/scripts/gen_api_dump.py` in the `gen-api` recipe). griffe is held to the
-# 1.x line: `griffe-typingdoc` 0.2.x, which reads the `Doc[...]` annotations,
-# does not support 2.x. The floor is 1.15 because earlier 1.x releases infer
+# 1.x line because `griffe-typingdoc` (<1), which reads the `Doc[...]` annotations,
+# does not support griffe 2.x. The floor is 1.15 because earlier 1.x releases infer
 # different return annotations, which changes the generated pages.
 docs = [
   "griffe>=1.15,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,17 @@ qiskit = ["qiskit>=2.0.0"]
 dev = ["prek>=0.4", "ruff==0.15.20"]
 # The documentation site is built with Fumadocs (Next.js); see `docs/`.
 # Python's only roles are converting the tutorial notebooks to Markdown
-# (`nbconvert`) and generating the API reference from docstrings (`griffe`,
-# injected via the `fumadocs-python` npm package in the `gen-api` recipe).
-docs = ["nbconvert", "pytest-markdown-docs", { include-group = "interactive" }]
+# (`nbconvert`) and dumping the API surface from docstrings (`griffe`, driven by
+# `docs/scripts/gen_api_dump.py` in the `gen-api` recipe). griffe is held to the
+# 1.x line: `griffe-typingdoc` 0.2.x, which reads the `Doc[...]` annotations,
+# does not support 2.x.
+docs = [
+  "griffe>=1.13,<2",
+  "griffe-typingdoc>=0.2.8,<1",
+  "nbconvert",
+  "pytest-markdown-docs",
+  { include-group = "interactive" },
+]
 interactive = [
   "ipykernel",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,14 @@ dev = ["prek>=0.4", "ruff==0.15.20"]
 # Python's only roles are converting the tutorial notebooks to Markdown
 # (`nbconvert`) and dumping the API surface from docstrings (`griffe`, driven by
 # `docs/scripts/gen_api_dump.py` in the `gen-api` recipe). griffe is held to the
-# 1.x line: `griffe-typingdoc` 0.2.x, which reads the `Doc[...]` annotations,
-# does not support 2.x. The floor is 1.15 because earlier 1.x releases infer
-# different return annotations, which changes the generated pages.
+# 1.x line, and `griffe-typingdoc` (which reads the `Doc[...]` annotations) below
+# 0.3 with it: from 0.3.1 it depends on `griffelib`, the distribution griffe 2.x
+# ships its library in, and that would install a second copy of the `griffe`
+# package on top of this one. The floor is 1.15 because earlier 1.x releases
+# infer different return annotations, which changes the generated pages.
 docs = [
   "griffe>=1.15,<2",
-  "griffe-typingdoc>=0.2.8,<1",
+  "griffe-typingdoc>=0.2.8,<0.3",
   "nbconvert",
   "pytest-markdown-docs",
   { include-group = "interactive" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ dev = ["prek>=0.4", "ruff==0.15.20"]
 # Python's only roles are converting the tutorial notebooks to Markdown
 # (`nbconvert`) and dumping the API surface from docstrings (`griffe`, driven by
 # `docs/scripts/gen_api_dump.py` in the `gen-api` recipe). griffe is held to the
-# 1.x line because `griffe-typingdoc` (<1), which reads the `Doc[...]` annotations,
-# does not support griffe 2.x. The floor is 1.15 because earlier 1.x releases infer
+# 1.x line: `griffe-typingdoc` 0.2.x, which reads the `Doc[...]` annotations,
+# does not support 2.x. The floor is 1.15 because earlier 1.x releases infer
 # different return annotations, which changes the generated pages.
 docs = [
   "griffe>=1.15,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -1170,7 +1170,7 @@ dev = [
     { name = "ruff", specifier = "==0.15.20" },
 ]
 docs = [
-    { name = "griffe", specifier = ">=1.13,<2" },
+    { name = "griffe", specifier = ">=1.15,<2" },
     { name = "griffe-typingdoc", specifier = ">=0.2.8,<1" },
     { name = "ipykernel" },
     { name = "matplotlib" },

--- a/uv.lock
+++ b/uv.lock
@@ -547,24 +547,15 @@ wheels = [
 
 [[package]]
 name = "griffe-typingdoc"
-version = "0.3.1"
+version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "griffelib" },
+    { name = "griffe" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/26/28182e0c8055842bf3da774dee1d5b789c0f236c078dcbdca1937b5214dc/griffe_typingdoc-0.3.1.tar.gz", hash = "sha256:2ff4703115cb7f8a65b9fdcdd1f3c3a15f813b6554621b52eaad094c4782ce96", size = 31218, upload-time = "2026-02-21T09:38:54.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/15/92e1cdd63515f18e35c357f10970f5a8b46fed15d615305497241c944be2/griffe_typingdoc-0.2.9.tar.gz", hash = "sha256:99c05bf09a9c391464e3937718c9a5a1055bb95ed549f4f7706be9a71578669c", size = 32878, upload-time = "2025-09-05T15:45:32.178Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/c4/cf543fbde49e1ae44830ef0840a4d6ee9f4e4f338138a7766d4e37cf6440/griffe_typingdoc-0.3.1-py3-none-any.whl", hash = "sha256:ecbd457ef6883126b8b6023abf12e08c58e1c152238a2f0e2afdd67a64b07021", size = 10092, upload-time = "2026-02-20T14:53:47.84Z" },
-]
-
-[[package]]
-name = "griffelib"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/33/f2e21b688e36d5e3d1ee681aed9b7e651b97bc8c31e9ec096d7f7a2181e3/griffe_typingdoc-0.2.9-py3-none-any.whl", hash = "sha256:cc6b1e34d64e1659da5b3d37506214834bc8fbb62b081b2fb43563ee5cdaf8f5", size = 9876, upload-time = "2025-09-05T15:45:31.137Z" },
 ]
 
 [[package]]
@@ -1171,7 +1162,7 @@ dev = [
 ]
 docs = [
     { name = "griffe", specifier = ">=1.15,<2" },
-    { name = "griffe-typingdoc", specifier = ">=0.2.8,<1" },
+    { name = "griffe-typingdoc", specifier = ">=0.2.8,<0.3" },
     { name = "ipykernel" },
     { name = "matplotlib" },
     { name = "nbconvert" },

--- a/uv.lock
+++ b/uv.lock
@@ -534,6 +534,40 @@ wheels = [
 ]
 
 [[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+]
+
+[[package]]
+name = "griffe-typingdoc"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/26/28182e0c8055842bf3da774dee1d5b789c0f236c078dcbdca1937b5214dc/griffe_typingdoc-0.3.1.tar.gz", hash = "sha256:2ff4703115cb7f8a65b9fdcdd1f3c3a15f813b6554621b52eaad094c4782ce96", size = 31218, upload-time = "2026-02-21T09:38:54.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/c4/cf543fbde49e1ae44830ef0840a4d6ee9f4e4f338138a7766d4e37cf6440/griffe_typingdoc-0.3.1-py3-none-any.whl", hash = "sha256:ecbd457ef6883126b8b6023abf12e08c58e1c152238a2f0e2afdd67a64b07021", size = 10092, upload-time = "2026-02-20T14:53:47.84Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
+]
+
+[[package]]
 name = "h5py"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1073,6 +1107,8 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "griffe" },
+    { name = "griffe-typingdoc" },
     { name = "ipykernel" },
     { name = "matplotlib" },
     { name = "nbconvert" },
@@ -1134,6 +1170,8 @@ dev = [
     { name = "ruff", specifier = "==0.15.20" },
 ]
 docs = [
+    { name = "griffe", specifier = ">=1.13,<2" },
+    { name = "griffe-typingdoc", specifier = ">=0.2.8,<1" },
     { name = "ipykernel" },
     { name = "matplotlib" },
     { name = "nbconvert" },


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The generated Python API reference came from [`fumadocs-python`](https://fumadocs.dev/docs/ui/python), a 0.x package that also shipped its Python half (`fumapy`) *inside* `docs/node_modules`. That arrangement had three standing problems:

1. **It broke on minor bumps.** The `0.0.11` → `0.1.1` bump in #255 rebuilt `PySourceCode`'s collapsible on `@base-ui/react` with a function `className` and no `use client` boundary, killing every `/api/**` prerender. #255 had to carry a local override just to keep the docs building.
2. **It inverted the toolchain.** `just gen-api` ran `uv run --with docs/node_modules/fumadocs-python --with 'griffe<2' …`, so a *Python* step depended on `npm ci` having run first, and `griffe` was an ephemeral injection that never reached `uv.lock`. The `griffe<2` pin existed only because upstream targeted that line.
3. **It silently dropped content.** Its `convertDoc` handles only `text` and `admonition` sections, so all 20 `Raises:` sections in monoprop's docstrings render nowhere, and ~80 lines of `generate-api.mjs` exist purely to work around its truncation of multi-line `Returns:`.

The code we actually depended on is small — 449 lines of Python, 151 lines of JS, ~140 lines of JSX, 8 lines of CSS tokens — and MIT-licensed, so this PR ports it in-repo rather than reimplementing it. The three new files carry the upstream MIT notice.

Behaviour is unchanged by construction: the griffe dump and all 26 generated MDX pages come out **byte-identical** to what the dependency produced, so the `/api/...` URL scheme, the cross-reference index and the `#<member>` anchors are untouched. The only markup change is the anchor `id` moving from a wrapper `<div>` onto the card itself, which retires the `anchored()` HOC and its casts.

## Changes

- Add `docs/scripts/gen_api_dump.py` — the griffe walker and docstring simplifier, replacing the vendored `fumapy` CLI.
- Add `docs/scripts/api-mdx.mjs` — the `convert`/`write` MDX emitter.
- Add `docs/src/components/py.tsx` — the `Py*` components, absorbing the `anchored()` wrappers and the `PySourceCode` override from #255.
- Declare `griffe>=1.13,<2` and `griffe-typingdoc>=0.2.8,<1` in the `docs` dependency group; they now resolve through `uv.lock`.
- Drop `fumadocs-python` from `docs/package.json`; add `yaml`, which was only reaching us transitively.
- Simplify `gen-api` to `python docs/scripts/gen_api_dump.py` and delete the `fumapy :=` justfile variable — the recipe no longer touches `docs/node_modules`.
- Move the two `--color-fdpy-*` badge tokens into `docs/src/app/global.css`.
- Update `documenting.mdx` for the new two-stage pipeline, and fix its stale claim that `just serve-docs` regenerates the API reference.

## Verification

- **Dump byte-identical** to the pre-change `docs/monoprop.json`, modulo setuptools-scm dev-version strings.
- **All 26 MDX pages + `meta.json` byte-identical** (`diff -r`, empty).
- **Rendered HTML**: article markup identical on the component-heavy pages; the 141 `#<member>` anchor ids are the same set. Residual whole-file diffs are Next.js asset hashes and RSC module ids only.
- Clean `next build` (150 pages, no prerender errors), `just gen-api`, `just doctest-py`, `just doctest-docs` all pass. The two `remark-xref: unresolved cross-reference` warnings for `[MonomialPropagator.build_graph][]` in `cutoff.mdx` are pre-existing and byte-for-byte unchanged.

## Follow-ups (deliberately not in this PR)

Each of these changes the generated output, so it breaks the byte-identical safety net and belongs in a separate change. A `/simplify` pass over the port pinned down the first two precisely:

- **Two return annotations are wrong today.** griffe's Google parser defaults to `returns_multiple_items`, which splits a `Returns:` block one item per physical line *and* distributes a tuple annotation element-wise across the pieces — so the dump's first item keeps only the first line and the wrong type. `MonomialPropagator.graph_size` renders as `int` instead of `tuple[int, int]`, and `circuit.expand_monomials` as `list` instead of its tuple. Passing `docstring_options={"returns_multiple_items": False}` to `griffe.load` fixes both and retires the ~80-line `extractReturnsFromSource` regex bandaid in `generate-api.mjs`.
- **Private attributes are being published.** `_attributes_from_signature` filters `is_private`, but `_merge_attributes` (the path taken when a class documents an `Attributes:` section) does not, and `generate-api.mjs`'s `prunePrivate` only covers classes/functions/modules. So `__slots__`, `_structural`, `_atol`, `__hash__` and friends render as attribute cards on `ExpGate`, `Circuit`, `FermiOperator`, `MajoranaOperator` and the `Pauli` pages — ~17 junk cards. Adding the filter also collapses the two near-identical merge functions into one.
- Render the 19 `Raises:` sections that `convertDoc` drops on the floor (it handles only `text` and `admonition`), and give it an `else` that warns so the next unhandled kind isn't silently lost. Module- and class-level docstring remainders are dropped entirely too.
- Prune the dump: class `source`, `inherited_members`, class `parameters` and the absolute-path `filepath` are ~106 KB (25%) that no consumer reads, and `filepath` makes the dump non-reproducible across checkouts.
- Move the pruning policy (`MODULES`/`KEEP`/`prunePrivate`) somewhere both consumers share — `remark-xref.mjs` builds its index from the *unpruned* dump, so 26 of its 228 entries point at pages that are never generated.
- Rename the now-misleading `fdpy-` CSS token prefix.

## Checklist

- [ ] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: Claude Code
- [x] I used the following tool to generate or modify code: Claude Code (ported the vendored MIT sources into `docs/scripts/` and `docs/src/components/`, verified against byte-identical output)
