### PR TITLE
chore(docs): ⬆️ move the API reference to griffe 2.x

### DIFF
--- a/docs/content/docs/documenting.mdx
+++ b/docs/content/docs/documenting.mdx
@@ -163,8 +163,9 @@ def my_function(x: int) -> str:
 
 Docstrings may cross-reference other symbols with the same `[Symbol][]` /
 `[Display][fully.qualified.path]` syntax described in
-[Cross-references to the API](#cross-references-to-the-api); griffe resolves
-them into links when the reference is regenerated.
+[Cross-references to the API](#cross-references-to-the-api). `generate-api.mjs`
+resolves them into links when the reference is regenerated — griffe only records
+the docstring text.
 
 Inside a class docstring a bare `[name][]` only reaches that class's *own*
 members. Inherited members are rendered on the subclass page but are not in the

--- a/docs/content/docs/features/cutoff.mdx
+++ b/docs/content/docs/features/cutoff.mdx
@@ -52,7 +52,8 @@ structural measure: `cutoff` bounds the Pauli weight.
 
 ## Gate-application length cap
 
-[MonomialPropagator.build_graph][] and [MonomialPropagator.propagate][] accept
+[MonomialPropagator.build_graph][monomial_propagator.MonomialPropagator.build_graph]
+and [MonomialPropagator.propagate][monomial_propagator.MonomialPropagator.propagate] accept
 `only_rotate_len_k` to apply gates only to terms whose length is at most `k`.
 This is independent of the structural cutoff. Omitting the argument or passing
 `None` imposes no additional gate-application cap.

--- a/docs/content/docs/features/evaluation.mdx
+++ b/docs/content/docs/features/evaluation.mdx
@@ -100,4 +100,5 @@ coeffs = sim.contract_partially(parameters, inplace=False)
 
 To read the fully evolved operator as a [MajoranaOperator][] (or [PauliOperator][] for
 [PauliPropagator][]) — without modifying the
-simulator — use [MonomialPropagator.evolved_operator][].
+simulator — use [MajoranaPropagator.evolved_operator][majorana_propagator.MajoranaPropagator.evolved_operator]
+(or [PauliPropagator.evolved_operator][pauli_propagator.PauliPropagator.evolved_operator]).

--- a/docs/scripts/api-mdx.mjs
+++ b/docs/scripts/api-mdx.mjs
@@ -28,6 +28,8 @@ export function convert(mod, options = {}) {
   const tabContents = [];
 
   if (mod.description) content.push(encodeText(mod.description));
+  const remainder = convertDoc(mod.docstring ?? []);
+  if (remainder) content.push(remainder);
   for (const attr of mod.attributes) content.push(convertAttribute(attr));
 
   if (Object.keys(mod.classes).length > 0) {
@@ -79,6 +81,8 @@ function convertClass(cls) {
   const content = [];
 
   if (cls.description) content.push(encodeText(cls.description));
+  const remainder = convertDoc(cls.docstring ?? []);
+  if (remainder) content.push(remainder);
   if (cls.attributes.length > 0) content.push(heading(2, 'Attributes'));
   for (const attr of cls.attributes) content.push(convertAttribute(attr));
   if (Object.keys(cls.functions).length > 0) {
@@ -143,12 +147,20 @@ function convertAttribute(attribute) {
   );
 }
 
-/** Render the docstring sections `simplify_docstring` left in `remainder`. */
+/**
+ * Render the docstring sections `simplify_docstring` left in `remainder`.
+ *
+ * Anything not handled here is dropped, which is why the default warns: which
+ * sections griffe splits out is a function of its version, so a docstring can
+ * stop rendering without anything else changing. `Raises:` is the known case --
+ * 19 of them are dropped today.
+ */
 function convertDoc(docstring) {
   const lines = [];
   for (const item of docstring) {
-    if (item.kind === 'text') lines.push(encodeText(item.value));
-    if (item.kind === 'admonition') {
+    if (item.kind === 'text') {
+      lines.push(encodeText(item.value));
+    } else if (item.kind === 'admonition') {
       lines.push(
         element(
           'Callout',
@@ -156,6 +168,8 @@ function convertDoc(docstring) {
           encodeText(item.value.description),
         ),
       );
+    } else {
+      console.warn(`api-mdx: dropping unhandled docstring section "${item.kind}"`);
     }
   }
   return lines.join('\n\n');

--- a/docs/scripts/gen_api_dump.py
+++ b/docs/scripts/gen_api_dump.py
@@ -60,7 +60,6 @@ from importlib.metadata import version
 from pathlib import Path
 
 import griffe
-from griffe_typingdoc import TypingDocExtension
 
 # ---------------------------------------------------------------------------
 # The JSON schema
@@ -570,8 +569,6 @@ def main() -> None:
             docstring_parser="auto",
             # The renderer shows each function's source in a collapsible block.
             store_source=True,
-            # Reads `Doc[...]` annotations (PEP 727) as descriptions.
-            extensions=griffe.load_extensions(TypingDocExtension),
         )
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,13 +55,7 @@ dev = ["prek>=0.4", "ruff==0.15.20"]
 # The documentation site is built with Fumadocs (Next.js); see `docs/`.
 # Python's only roles are converting the tutorial notebooks to Markdown
 # (`nbconvert`) and dumping the API surface from docstrings (`griffe`, driven by
-# `docs/scripts/gen_api_dump.py` in the `gen-api` recipe). griffe 2.0 split
-# itself into three distributions: `griffe` is now a metapackage over
-# `griffecli` + `griffelib`, and the importable `griffe` package lives in
-# `griffelib` -- which is what we depend on, since the API reference never
-# shells out to the CLI. The 2.2 floor is where `Note:`-style admonitions are
-# detected in Google docstrings and where expressions stringify faithfully; both
-# show up in the generated pages.
+# `docs/scripts/gen_api_dump.py` in the `gen-api` recipe).
 docs = [
   "griffelib>=2.2,<3",
   "nbconvert",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,15 +55,15 @@ dev = ["prek>=0.4", "ruff==0.15.20"]
 # The documentation site is built with Fumadocs (Next.js); see `docs/`.
 # Python's only roles are converting the tutorial notebooks to Markdown
 # (`nbconvert`) and dumping the API surface from docstrings (`griffe`, driven by
-# `docs/scripts/gen_api_dump.py` in the `gen-api` recipe). griffe is held to the
-# 1.x line, and `griffe-typingdoc` (which reads the `Doc[...]` annotations) below
-# 0.3 with it: from 0.3.1 it depends on `griffelib`, the distribution griffe 2.x
-# ships its library in, and that would install a second copy of the `griffe`
-# package on top of this one. The floor is 1.15 because earlier 1.x releases
-# infer different return annotations, which changes the generated pages.
+# `docs/scripts/gen_api_dump.py` in the `gen-api` recipe). griffe 2.0 split
+# itself into three distributions: `griffe` is now a metapackage over
+# `griffecli` + `griffelib`, and the importable `griffe` package lives in
+# `griffelib` -- which is what we depend on, since the API reference never
+# shells out to the CLI. The 2.2 floor is where `Note:`-style admonitions are
+# detected in Google docstrings and where expressions stringify faithfully; both
+# show up in the generated pages.
 docs = [
-  "griffe>=1.15,<2",
-  "griffe-typingdoc>=0.2.8,<0.3",
+  "griffelib>=2.2,<3",
   "nbconvert",
   "pytest-markdown-docs",
   { include-group = "interactive" },

--- a/uv.lock
+++ b/uv.lock
@@ -534,28 +534,12 @@ wheels = [
 ]
 
 [[package]]
-name = "griffe"
-version = "1.15.0"
+name = "griffelib"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
-]
-
-[[package]]
-name = "griffe-typingdoc"
-version = "0.2.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffe" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/63/15/92e1cdd63515f18e35c357f10970f5a8b46fed15d615305497241c944be2/griffe_typingdoc-0.2.9.tar.gz", hash = "sha256:99c05bf09a9c391464e3937718c9a5a1055bb95ed549f4f7706be9a71578669c", size = 32878, upload-time = "2025-09-05T15:45:32.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/33/f2e21b688e36d5e3d1ee681aed9b7e651b97bc8c31e9ec096d7f7a2181e3/griffe_typingdoc-0.2.9-py3-none-any.whl", hash = "sha256:cc6b1e34d64e1659da5b3d37506214834bc8fbb62b081b2fb43563ee5cdaf8f5", size = 9876, upload-time = "2025-09-05T15:45:31.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
 ]
 
 [[package]]
@@ -1098,8 +1082,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
-    { name = "griffe" },
-    { name = "griffe-typingdoc" },
+    { name = "griffelib" },
     { name = "ipykernel" },
     { name = "matplotlib" },
     { name = "nbconvert" },
@@ -1161,8 +1144,7 @@ dev = [
     { name = "ruff", specifier = "==0.15.20" },
 ]
 docs = [
-    { name = "griffe", specifier = ">=1.15,<2" },
-    { name = "griffe-typingdoc", specifier = ">=0.2.8,<0.3" },
+    { name = "griffelib", specifier = ">=2.2,<3" },
     { name = "ipykernel" },
     { name = "matplotlib" },
     { name = "nbconvert" },


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Moves the API-reference pipeline to griffe 2.x, and in doing so removes an unsound dependency resolution.

griffe 2.0 split itself into three distributions: `griffe` is now a metapackage over `griffecli` + `griffelib`, and the importable `griffe` package ships in **`griffelib`**. `griffe-typingdoc` 0.3.1 switched to `griffelib>=2.0`, so a `griffe<2` pin does not actually keep griffe 2.x out — it invites *both* in. On #258's branch the lock resolved griffe 1.15.0 **and** griffelib 2.2.0, two distributions owning the same 44 files under `griffe/`; which one wins is install-order luck. (#258 shipped a `griffe-typingdoc<0.3` cap so it stays coherent on its own; this PR removes the need for that cap.) That failure mode is not hypothetical — while preparing this change, `uv sync` uninstalling `griffelib` deleted files griffe 1.15.0's RECORD also owned, leaving `import griffe` working but `griffe.parse_google` missing until a forced reinstall.

The upgrade itself is cheap. Every griffe symbol the walker uses is unchanged in 2.x — `load` (same 16-kwarg signature), `load_extensions`, `JSONEncoder`, `Expr`, `ParameterKind`, `parse_google`, and every model attribute read — so `gen_api_dump.py` needs no porting. `griffe-typingdoc` goes away entirely: it reads PEP 727 `Doc[...]` annotations and `src/monoprop` has none, so dumps with and without it are byte-identical. Bisecting the 2.x line, griffe 2.0.0 through 2.1.0 reproduce the 1.15 dump exactly; only 2.2.0 differs, by three hunks, and both are griffe bug fixes.

One of those fixes needed a companion change. griffe 2.2 correctly splits the `Note:` on `MonomialPropagator` out of the class description into an `admonition` section — but `convertClass` never rendered the docstring remainder, so the Note would have **silently disappeared from the page**. `convertClass` and `convert` now render it, which turns the Note into a `<Callout>`. `convertDoc` also gained a warning for section kinds it does not handle, since which sections griffe splits out is version-dependent and silent dropping is exactly how content goes missing across an upgrade.

## Changes

- `pyproject.toml` — replace `griffe>=1.15,<2` + `griffe-typingdoc>=0.2.8,<0.3` with `griffelib>=2.2,<3`; rewrite the pin comment (every clause of the old one is now wrong).
- `docs/scripts/gen_api_dump.py` — drop the `griffe_typingdoc` import and the `extensions=` argument. No other change.
- `docs/scripts/api-mdx.mjs` — render class- and module-level docstring remainders; warn on unhandled section kinds.
- `docs/content/docs/documenting.mdx` — fix a pre-existing claim that griffe resolves `[Symbol][]` links (it is `generate-api.mjs` that does).

Second commit, independent of the upgrade: qualify the ambiguous cross-reference targets in `features/cutoff.mdx` and `features/evaluation.mdx`. `build_graph`, `propagate` and `evolved_operator` each name three symbols, so the bare form was dropped from the ambiguous-leaf index and rendered as literal text. `evolved_operator` also moves to the two concrete front-ends, which is where it is documented — the abstract base has no page anchor for it.

## Verification

The generated tree is gitignored, so the evidence is below. Baseline captured from `main` (`412315e`), all diffs version-normalised for setuptools-scm.

**Dump — exactly the three expected hunks:**

<details><summary><code>diff before.json docs/monoprop.json</code></summary>

1. `MonomialPropagator.description` loses the trailing `Note:` block.
2. `MonomialPropagator.docstring` gains `{"kind": "admonition", "title": "Note", "value": {"annotation": "note", ...}}`.
3. `FermiOperator.terms` value: `[(t if isinstance(t, FermiString) else FermiString(t)) for t in terms]` → `[t if isinstance(t, FermiString) else FermiString(t) for t in terms]`.

</details>

**Rendered MDX — 2 files, 13 changed lines:**

<details><summary><code>diff -r before/api docs/content/docs/api</code></summary>

```diff
--- before/api/fermi/FermiOperator.mdx
+++ docs/content/docs/api/fermi/FermiOperator.mdx
-<PyAttribute name={"terms"} type={null} value={"[(t if isinstance(t, FermiString) else FermiString(t)) for t in terms]"} />
+<PyAttribute name={"terms"} type={null} value={"[t if isinstance(t, FermiString) else FermiString(t) for t in terms]"} />

--- before/api/monomial_propagator/MonomialPropagator.mdx
+++ docs/content/docs/api/monomial_propagator/MonomialPropagator.mdx
-Note:
-    Heisenberg evolution consumes each [`build_graph`](...) / [`propagate`](...) call's gates
-    back-to-front, so splitting one circuit across several calls is *not* equivalent to a
-    single call; in the Schrodinger picture (front-to-back) it is.
+<Callout title={"Note"} type={"note"}>
+
+Heisenberg evolution consumes each [`build_graph`](...) / [`propagate`](...) call's gates
+back-to-front, so splitting one circuit across several calls is *not* equivalent to a
+single call; in the Schrodinger picture (front-to-back) it is.
+
+</Callout>
```

</details>

- **Anchor set identical** — 143 `PyFunction`/`PyAttribute` ids, same set, so no `#member` fragment moved.
- **Cross-reference map identical** — 227 entries, byte-for-byte. This is the only artifact that would expose a prose-link regression, since `remark-xref.mjs`'s bare-name index silently drops leaves that map to two URLs.
- **Build clean** — `npm run build`, 150 pages, no prerender error; the `<Callout>` renders on `/api/monomial_propagator/MonomialPropagator` with its two xrefs intact.
- **`just doctest-py` and `just doctest-docs`** pass (they share the edited dependency group).
- **Resolution is coherent again** — `uv.lock` lists only `griffelib` 2.2.0; the venv has a single `griffe*` dist-info; `griffe.parse_google` no longer carries the 1.x `**options`.
- **Zero unresolved-xref warnings** — the first fully clean docs build here. Three were firing on `main` (two in `cutoff.mdx` since before #258, one in `evaluation.mdx` from #256's prose links); the second commit fixes them. They were never affected by the upgrade itself, since the xref map is byte-identical. Verified beyond the warning going away: all four references render as real links, and every `#fragment` target exists on its destination page.

## Follow-ups

Unchanged from #258's list, none of them unblocked or blocked by this (the prose-xref follow-up it mentioned is done here): the `returns_multiple_items` fix, the private-attribute filter, rendering the 19 `Raises:` sections (now at least *reported* rather than silent), dump pruning, sharing the pruning policy, and the `fdpy-` token rename.

## Checklist

- [ ] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: Claude Code
- [x] I used the following tool to generate or modify code: Claude Code (dependency swap, the docstring-remainder rendering, and the before/after verification)
