### PR TITLE
fix(build): 🐛 anchor uv cache-keys to the source tree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,12 +92,16 @@ python-preference = "only-managed"
 keyring-provider = "subprocess"
 cache-keys = [
   { file = "pyproject.toml" },
+  { file = "CMakeLists.txt" },
+  { file = "cmake/**/*" },
+  { file = "cpp/**/CMakeLists.txt" },
   { file = "cpp/include/**/*.h" },
   { file = "cpp/include/**/*.h.in" },
   { file = "cpp/monoprop/**/*.{h,cpp}" },
-  { file = "**/CMakeLists.txt" },
-  { file = "cmake/**/*" },
+  { file = "src/monoprop/**/CMakeLists.txt" },
+  { file = "src/monoprop/bindings/binder.h" },
   { file = "src/monoprop/bindings/bindings.cpp.in" },
+  { file = "tools/*.py" },
 ]
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`cache-keys` had `{ file = "**/CMakeLists.txt" }`, which matches the whole project directory — and uv's globs ignore `.gitignore`. In CI the venv is `./.venv`, so the key also covered the 15 `CMakeLists.txt` files pyscf ships in `site-packages` (`docs` group). uv records the key *before* installing, so the first `uv run` of `just build-docs` built monoprop and then stamped those files with the current time; the next `uv run` saw a newer key and rebuilt from scratch (~92 s) and reinstalled. Both commands use identical dependency groups — only that mtime differed. `test.yml` paid the same ~91 s per matrix entry via the `find-package-smoke/CMakeLists.txt` it writes. Invisible locally, where `UV_PROJECT_ENVIRONMENT` puts the venv outside the tree.

## Changes

- Anchor the `CMakeLists.txt` patterns at the three directories holding all 18 tracked ones, instead of matching the venv and the build tree.
- Add two missing inputs: `src/monoprop/bindings/binder.h` and `tools/*.py` — editing the binding template or a generator triggered no rebuild at all. `tools/*.py` rather than `tools/**/*` keeps the generators' bytecode cache out of the key.

Verified in a clean worktree with the venv inside the project: `uv run` #2 is now a cache hit, and touching `binder.h`, `generate-binders.py` or `_binding_layout.py` each rebuilds exactly once.

## Checklist

- [x] Documentation updated if needed — n/a

## AI/LLM disclosure

- [x] Claude Code (Opus 5), for both the description and the change
