### PR TITLE
feat(docs): 🖼️ add Figure/Caption component for MDX figures

### DIFF
--- a/docs/content/docs/benchmarks.mdx
+++ b/docs/content/docs/benchmarks.mdx
@@ -26,20 +26,28 @@ range than `monoprop` itself, so it is kept out of the main resolution.
 The chosen problem is the 1D Hubbard model, tracking the runtime, expectation value,
 and operator size at each Trotter step.
 
+<Figure>
 ![Benchmark results for the 1D Hubbard model in MajoranaPropagation.jl vs monoprop: number of terms, final overlap, runtime, and memory vs layers](/benchmarks/majorana_results.png)
 
-Number of terms, final overlap, runtime, and memory vs. circuit layers for the 1D Fermi-Hubbard
-model, comparing `monoprop` against `MajoranaPropagation.jl`. See the
-section below for details on the setup and how to reproduce these results.
+<Caption>
+  Number of terms, final overlap, runtime, and memory vs. circuit layers for the 1D Fermi-Hubbard
+  model, comparing `monoprop` against `MajoranaPropagation.jl`. See the
+  section below for details on the setup and how to reproduce these results.
+</Caption>
+</Figure>
 
+<Figure>
 ![Runtime for the 1D Hubbard model in MajoranaPropagation.jl vs monoprop: seconds vs circuit layers, linear axes](/benchmarks/majorana_runtime.png)
 
-Runtime on its own, both axes linear. Solid lines are `monoprop`, dashed are
-`MajoranaPropagation.jl`, and colour is the system size. Read it as seconds: the Julia engine's
-591 s at 60 sites / 18 layers is drawn 140× the height of `monoprop`'s 4.2 s, and all three
-`monoprop` curves consequently lie along the bottom of the axis — annotated with the top of that
-band, since flat here means small, not zero. For `monoprop`'s own growth with depth, read the
-term-count and memory panels of the combined figure, or the numbers below.
+<Caption>
+  Runtime on its own, both axes linear. Solid lines are `monoprop`, dashed are
+  `MajoranaPropagation.jl`, and colour is the system size. Read it as seconds: the Julia engine's
+  591 s at 60 sites / 18 layers is drawn 140× the height of `monoprop`'s 4.2 s, and all three
+  `monoprop` curves consequently lie along the bottom of the axis — annotated with the top of that
+  band, since flat here means small, not zero. For `monoprop`'s own growth with depth, read the
+  term-count and memory panels of the combined figure, or the numbers below.
+</Caption>
+</Figure>
 
 
 #### SPECS
@@ -158,11 +166,15 @@ The chosen problem is the Trotterized time evolution of a 2D transverse-field Is
 expectation value, and operator size at each Trotter step.
 
 
+<Figure>
 ![Benchmark results for Pauli Propagation engines: Runtime and Memory per Trotter step](/benchmarks/pauli_results.png)
 
-Runtime and memory usage per Trotter step for the 2D TFIM problem, comparing `monoprop` against
-other Pauli propagation engines. See the [Pauli Propagation](#pauli-propagation) section below for
-details on the setup and how to reproduce these results.
+<Caption>
+  Runtime and memory usage per Trotter step for the 2D TFIM problem, comparing `monoprop` against
+  other Pauli propagation engines. See the [Pauli Propagation](#pauli-propagation) section below for
+  details on the setup and how to reproduce these results.
+</Caption>
+</Figure>
 
 
 #### SPECS
@@ -307,20 +319,30 @@ benchmark does the opposite: it holds the circuit depth and the truncation fixed
 lattice, from 6x6 (36 qubits) to 18x18 (324 qubits). Every engine runs the identical model at
 each size, in its own subprocess, and contributes one totals record per size.
 
+<Figure>
 ![Total runtime versus lattice size, for five Pauli-propagation engines](/benchmarks/pauli_scaling_runtime.png)
 
-At a fixed coefficient truncation the operator saturates: past ~100 qubits every engine carries
-the same ~5.8M terms whatever the lattice, so this measures *cost per term kept* rather than a
-growing problem. `monoprop`'s total runtime stays nearly flat in that regime, which is what makes
-the gap widen with size.
+<Caption>
+  At a fixed coefficient truncation the operator saturates: past ~100 qubits every engine carries
+  the same ~5.8M terms whatever the lattice, so this measures *cost per term kept* rather than a
+  growing problem. `monoprop`'s total runtime stays nearly flat in that regime, which is what makes
+  the gap widen with size.
+</Caption>
+</Figure>
 
+<Figure>
 ![Final operator memory versus lattice size, for five Pauli-propagation engines](/benchmarks/pauli_scaling_memory.png)
 
-The same saturation shows up in memory: `monoprop`'s footprint flattens near 690 MB from 12x12
-on, while `PauliPropagation.jl`'s keeps climbing to ~1.8 GB at 324 qubits. Compare across engines
-only with the third caveat below in mind — these are not all the same measurement.
+<Caption>
+  The same saturation shows up in memory: `monoprop`'s footprint flattens near 690 MB from 12x12
+  on, while `PauliPropagation.jl`'s keeps climbing to ~1.8 GB at 324 qubits. Compare across engines
+  only with the third caveat below in mind — these are not all the same measurement.
+</Caption>
+</Figure>
 
+<Figure>
 ![Bar chart of monoprop's speed-up over each other engine, grouped by qubit count](/benchmarks/pauli_speedup.png)
+</Figure>
 
 | qubits | PauliPropagation.jl | QuEra ppvm | Qiskit pauli-prop | cuPauliProp (GPU) |
 | -----: | -----: | -----: | -----: | -----: |

--- a/docs/content/docs/documenting.mdx
+++ b/docs/content/docs/documenting.mdx
@@ -61,6 +61,25 @@ References are defined in `docs/bibliography.bib`. Cite them with `[@key]`:
 This follows the approach of [@smith2024].
 ```
 
+### Figures
+
+Fumadocs UI ships no figure/caption pair, so use the `Figure` and `Caption`
+components (`docs/src/components/figure.tsx`) instead of a plain paragraph
+after an image:
+
+```mdx
+<Figure>
+![Alt text describing the image](/path/to/image.png)
+
+<Caption>
+  What the figure shows and how to read it.
+</Caption>
+</Figure>
+```
+
+`Caption` is optional — omit it for a figure that needs no caption. See
+`docs/content/docs/benchmarks.mdx` for real examples.
+
 ### Cross-references to the API
 
 Link to any documented Python symbol with the mkdocstrings-style reference

--- a/docs/src/components/figure.tsx
+++ b/docs/src/components/figure.tsx
@@ -15,7 +15,7 @@ export function Figure({ children }: { children?: ReactNode }) {
 
 export function Caption({ children }: { children?: ReactNode }) {
   return (
-    <figcaption className="text-fd-muted-foreground text-sm mt-2 prose-no-margin">
+    <figcaption className="text-fd-muted-foreground text-sm mt-4 prose-no-margin">
       {children}
     </figcaption>
   );

--- a/docs/src/components/figure.tsx
+++ b/docs/src/components/figure.tsx
@@ -6,10 +6,11 @@
 import type { ReactNode } from 'react';
 
 export function Figure({ children }: { children?: ReactNode }) {
-  // Markdown wraps a lone image in a `<p>`; its prose margin-bottom collapses
-  // with (and swamps) `Caption`'s margin-top, so it has to be zeroed here for
-  // the caption's own spacing to have any visible effect.
-  return <figure className="my-6 [&>p]:mb-0">{children}</figure>;
+  // Markdown wraps a lone image in a `<p>`, and prose typography puts its own
+  // margin on both: `mb-0` on the `<p>` and `my-0` on the `<img>` (a block
+  // element with no border/padding around it, so its margin would otherwise
+  // collapse straight through the `<p>` and swamp `Caption`'s margin-top).
+  return <figure className="my-6 [&>p]:mb-0 [&_img]:my-0">{children}</figure>;
 }
 
 export function Caption({ children }: { children?: ReactNode }) {

--- a/docs/src/components/figure.tsx
+++ b/docs/src/components/figure.tsx
@@ -1,0 +1,18 @@
+// Fumadocs ships no figure/caption pair, so the benchmarks page (and any other
+// page with images) rolled its own caption as a plain paragraph after the
+// image. This gives that pattern a real `<figure>`/`<figcaption>` and matches
+// it visually to the muted, small-text captions already used for API cards.
+
+import type { ReactNode } from 'react';
+
+export function Figure({ children }: { children?: ReactNode }) {
+  return <figure className="my-6">{children}</figure>;
+}
+
+export function Caption({ children }: { children?: ReactNode }) {
+  return (
+    <figcaption className="text-fd-muted-foreground text-sm mt-3 prose-no-margin">
+      {children}
+    </figcaption>
+  );
+}

--- a/docs/src/components/figure.tsx
+++ b/docs/src/components/figure.tsx
@@ -6,7 +6,10 @@
 import type { ReactNode } from 'react';
 
 export function Figure({ children }: { children?: ReactNode }) {
-  return <figure className="my-6">{children}</figure>;
+  // Markdown wraps a lone image in a `<p>`; its prose margin-bottom collapses
+  // with (and swamps) `Caption`'s margin-top, so it has to be zeroed here for
+  // the caption's own spacing to have any visible effect.
+  return <figure className="my-6 [&>p]:mb-0">{children}</figure>;
 }
 
 export function Caption({ children }: { children?: ReactNode }) {

--- a/docs/src/components/figure.tsx
+++ b/docs/src/components/figure.tsx
@@ -11,7 +11,7 @@ export function Figure({ children }: { children?: ReactNode }) {
 
 export function Caption({ children }: { children?: ReactNode }) {
   return (
-    <figcaption className="text-fd-muted-foreground text-sm mt-[0.5625rem] prose-no-margin">
+    <figcaption className="text-fd-muted-foreground text-sm mt-2 prose-no-margin">
       {children}
     </figcaption>
   );

--- a/docs/src/components/figure.tsx
+++ b/docs/src/components/figure.tsx
@@ -11,7 +11,7 @@ export function Figure({ children }: { children?: ReactNode }) {
 
 export function Caption({ children }: { children?: ReactNode }) {
   return (
-    <figcaption className="text-fd-muted-foreground text-sm mt-3 prose-no-margin">
+    <figcaption className="text-fd-muted-foreground text-sm mt-[0.5625rem] prose-no-margin">
       {children}
     </figcaption>
   );

--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -1,5 +1,6 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import * as Py from '@/components/py';
+import { Figure, Caption } from '@/components/figure';
 import type { MDXComponents } from 'mdx/types';
 import type { ImgHTMLAttributes } from 'react';
 
@@ -22,6 +23,8 @@ export function getMDXComponents(components?: MDXComponents) {
     ...defaultMdxComponents,
     // Py* components (plus Tab/Tabs) used by the generated Python API pages.
     ...Py,
+    Figure,
+    Caption,
     img: Img,
     ...components,
   } satisfies MDXComponents;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Fumadocs UI doesn't ship a figure/caption component. The benchmarks page (and any other page with images) worked around this by putting a plain paragraph right after the image markdown to act as an ad-hoc caption, with no semantic `<figure>`/`<figcaption>` markup. This adds a small `Figure`/`Caption` component pair and switches the benchmarks page's six figures over to it.

## Changes

- Add `docs/src/components/figure.tsx` exporting `Figure` and `Caption`, styled to match the existing muted small-text caption convention used for API cards (`py.tsx`).
- Register both components in `docs/src/components/mdx.tsx`'s `getMDXComponents`.
- Convert the six image + plain-paragraph pairs in `docs/content/docs/benchmarks.mdx` to `<Figure>...<Caption>...</Caption></Figure>`.
- Document the new components in `docs/content/docs/documenting.mdx` under a new "Figures" subsection.

Verified with a full `next build` — the benchmarks and documenting pages compile and render real `<figure>`/`<figcaption>` markup.

## Checklist

- [ ] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Code (claude-sonnet-5)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/main/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/main/CLA.md).