### PR TITLE
feat(docs): 📈 add Umami analytics tracking script

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -7,6 +7,13 @@ import 'katex/dist/katex.min.css';
 export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     <html lang="en" className={gtPlanar.className} suppressHydrationWarning>
+      <head>
+        <script
+          defer
+          src="https://cloud.umami.is/script.js"
+          data-website-id="aef9f54a-22cb-4455-ad63-ff2d82f908ad"
+        />
+      </head>
       <body className="flex flex-col min-h-screen">
         <RootProvider
           // The docs site is exported as static files, so search must load the


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Add the Umami analytics tracking script to the docs site's root layout so page views are tracked across the whole site.

## Changes

- Add the Umami `<script defer>` tag to `docs/src/app/layout.tsx`'s `<head>`.

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Code (claude-sonnet-5)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/main/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/main/CLA.md).