### PR TITLE
test(operator): ✅ pin the index table's power-of-two sizing

### DIFF
--- a/cpp/monoprop/detail/operator/OperatorIndex.h
+++ b/cpp/monoprop/detail/operator/OperatorIndex.h
@@ -272,6 +272,7 @@ public:
         return (rows_.capacity() * sizeof(PosT)) - (std::min(rows_.capacity(), size_ * stride_) * sizeof(PosT));
     }
 
+    // Resident, not reserved: rehash_to assigns every slot, so unlike slack_bytes() this is all faulted.
     auto index_estimated_memory_bytes() const -> size_t {
         return sizeof(OperatorIndex) + (table_.slots.capacity() * sizeof(Slot));
     }

--- a/cpp/tests/operator_index_tests.cpp
+++ b/cpp/tests/operator_index_tests.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <array>
+#include <bit>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
@@ -194,4 +195,35 @@ BOOST_AUTO_TEST_CASE(find_batch_on_empty_store_is_all_missing) {
     for (size_t i = 0; i < keys.size(); ++i) {
         BOOST_TEST(out[i] == Store::kNotFound);
     }
+}
+
+// The table's slot count is the largest single item in the operator's byte ledger at scale (34.7%,
+// 21.90 B/term on the hubbard weak ladder), and nothing else pinned it. Both halves are load-bearing:
+// power-of-two is what makes bucket selection `& mask` instead of a modulo, and minimality is what
+// keeps the over-provision down to that quantisation alone. These slots are written by rehash_to, so
+// they are resident rather than reserved -- halving the table moved measured VmHWM by 18%.
+BOOST_AUTO_TEST_CASE(index_table_is_the_smallest_power_of_two_at_the_load_cap) {
+    constexpr size_t kEntries = 2000; // > kMinSlots*0.7, so several doublings run
+
+    // Derive sizeof(Slot) from an empty store's kMinSlots=16 rather than assuming it: it is 8 bytes
+    // by default but 16 under monoprop_WIDE_TERM_INDEX, where a padded 64-bit index widens it.
+    const Store empty;
+    const size_t slot_size = (empty.index_estimated_memory_bytes() - sizeof(Store)) / 16;
+    BOOST_TEST(slot_size > 0u);
+
+    Store s;
+    size_t inserted = 0;
+    for (size_t a = 0; a < 2 * N && inserted < kEntries; ++a) {
+        for (size_t b = a + 1; b < 2 * N && inserted < kEntries; ++b) {
+            s.push_back(bs({a, b}));
+            s.emplace(s.row(inserted), inserted);
+            ++inserted;
+        }
+    }
+    BOOST_TEST(inserted == kEntries); // 2*N positions must supply enough distinct pairs
+
+    const size_t slots = (s.index_estimated_memory_bytes() - sizeof(Store)) / slot_size;
+    BOOST_TEST(std::has_single_bit(slots));
+    BOOST_TEST(kEntries * 10 <= slots * 7);
+    BOOST_TEST(kEntries * 10 > (slots / 2) * 7);
 }


### PR DESCRIPTION
`indexing_bytes` is the largest single item in the operator byte ledger — 34.7%, 21.90 B/term on the Hubbard weak ladder — and nothing pinned how the table is sized. This adds the test, plus one line of documentation on the header.

## What is asserted

The slot count is the **smallest power of two** holding `size()` entries under the 0.7 load cap. Both halves matter and both are now asserted:

- **power-of-two** is what makes bucket selection `& mask` rather than a modulo;
- **minimality** is what bounds the over-provision to that quantisation alone, so the ledger term stays predictable.

Slot width is derived from an empty `Store` rather than hardcoded, so the case also holds under `monoprop_WIDE_TERM_INDEX`.

It also records that these bytes are **resident, not reserved**. `rehash_to` assigns every slot, so unlike `slack_bytes()` the empty ones are faulted — measured, halving the table cut `VmHWM` by 18.0% at a fixed partition count.

## Verification

No engine change: `_core.so` is byte-identical either side of the commit (md5 `edb00c44…`).

Rebased onto `97f95f76` and re-run on a `dev-x86` compute node (job 1852924):

| suite | result |
|---|---|
| `ctest -L unit` | 100% passed, 0 failed **out of 242** |
| `ctest -L serial` | 100% passed, 0 failed **out of 241** |
| `ctest -L mpi` | 1/1 passed |

Main's baseline is 241 unit / 240 serial; this adds one case. It was confirmed to actually run rather than be silently absent — `Test #192: index_table_is_the_smallest_power_of_two_at_the_load_cap … Passed` appears in both label runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
