### PR TITLE
chore(devcontainer): 🔧 mount docs build artifacts as volumes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,12 @@
   "securityOpt": [
     "seccomp=unconfined"
   ],
+  // Mounts for node_modules and .next to avoid slow host filesystem performance
+  // and other potential issues.
+  "mounts": [
+    "source=monoprop-docs-next,target=${containerWorkspaceFolder}/docs/.next,type=volume",
+    "source=monoprop-docs-node-modules,target=${containerWorkspaceFolder}/docs/node_modules,type=volume"
+  ],
   "remoteUser": "vscode",
   "customizations": {
     "vscode": {

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -24,3 +24,8 @@ from libstdcxx.v6.printers import register_libstdcxx_printers
 register_libstdcxx_printers (None)
 end
 EOT
+
+# set permissions for node_modules and .next directories to avoid permission
+# issues when running commands in the container
+sudo mkdir -p "$WORKSPACE/docs/.next" "$WORKSPACE/docs/node_modules"
+sudo chown -R vscode:vscode "$WORKSPACE/docs/.next" "$WORKSPACE/docs/node_modules"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Keep `docs/.next` and `docs/node_modules` out of the host-mounted workspace inside the devcontainer, avoiding slow bind-mount I/O and file-permission mismatches when running docs builds locally.

## Changes

- `.devcontainer/devcontainer.json`: mount `docs/.next` and `docs/node_modules` as named Docker volumes instead of the host bind mount.
- `.devcontainer/postCreateCommand.sh`: create those directories and `chown` them to `vscode` post-create so the volumes aren't root-owned.

## Checklist

- [ ] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code
- [ ] I used the following tool to generate or modify code: Claude Code