### PR TITLE
refactor(cpp): ♻️ extract the row hash table from OperatorIndex

### DIFF
--- a/cpp/monoprop/detail/operator/CMakeLists.txt
+++ b/cpp/monoprop/detail/operator/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(
         "MPOperator.h"
         "OperatorIndex.h"
         "RowAccess.h"
+        "RowHashTable.h"
 )

--- a/cpp/monoprop/detail/operator/OperatorIndex.h
+++ b/cpp/monoprop/detail/operator/OperatorIndex.h
@@ -15,33 +15,26 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
-#include <bit>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <format>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <span>
-#include <stdexcept>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "monoprop/TypeAliases.h"
 #include "monoprop/core/Monomial.h"
+#include "monoprop/detail/operator/RowHashTable.h"
 
 namespace monoprop::detail {
 
-class TermIndexCeilingReached : public std::runtime_error {
-public:
-    using std::runtime_error::runtime_error;
-};
-
-// Operator-term store: entropy-packed position-list rows plus a keyless open-addressing hash index over
-// those rows. Row layout: slot 0 = popcount c (or kOverflowMarker if c > inline_width_), slots 1..c =
+// Operator-term store: entropy-packed position-list rows plus a RowHashTable keyed over them. The rows
+// are this class's business and the index is not: nothing below reads a slot, and nothing in
+// RowHashTable reads a row -- the two meet only through the hash and equality callables passed in.
+// Row layout: slot 0 = popcount c (or kOverflowMarker if c > inline_width_), slots 1..c =
 // ascending set-bit positions; stride_ is fixed for the container's life so row offsets stay stable.
 // inline_width_ is a free parameter -- any width is correct, over-long rows spill losslessly to overflow.
 // Single-writer: one partition, one thread; parallelism is cross-partition.
@@ -66,13 +59,10 @@ public:
     static_assert(kMaxInlinePositions < std::numeric_limits<PosT>::max(),
                   "kOverflowMarker sentinel must not collide with a valid popcount");
 
-    // Valid term indices are < kIndexCeiling (check_append_fits refuses the append that would reach
-    // it, check_index_fits the index itself), so the all-ones TermIndex is free to mark an empty slot.
-    static constexpr size_t kIndexCeiling = static_cast<size_t>(std::numeric_limits<TermIndex>::max());
-    static constexpr TermIndex kEmptySlot = std::numeric_limits<TermIndex>::max();
-    // find_batch's "absent" result; same value as detail::kMissingIndex (not included here — the
-    // operator store must not depend on evolution headers).
-    static constexpr size_t kNotFound = std::numeric_limits<size_t>::max();
+    // The table's row-index ceiling and its "absent" result, re-exported: a caller sizes or checks a
+    // partition through this store and never sees the table underneath.
+    static constexpr size_t kIndexCeiling = RowHashTable::kIndexCeiling;
+    static constexpr size_t kNotFound = RowHashTable::kNotFound;
 
     explicit OperatorIndex(size_t inline_width = kDefaultInlinePositions)
         : inline_width_(std::clamp<size_t>(inline_width, 1, kMaxInlinePositions)),
@@ -88,12 +78,8 @@ public:
         out->rows_ = rows_;
         out->size_ = size_;
         out->overflow_ = overflow_;
-        out->reserve_index(table_.count);
-        for (const Slot &e : table_.slots) {
-            if (e.idx != kEmptySlot) {
-                out->insert_slot_(e.idx, e.h);
-            }
-        }
+        out->reserve_index(table_.count());
+        table_.for_each_slot([&out](TermIndex idx, uint32_t h) { out->table_.insert_distinct(idx, h); });
         return out;
     }
 
@@ -110,7 +96,7 @@ public:
     // exact-fit: an exact fit would realloc the whole operator every layer.
     auto grow_rows_geometric(size_t n) -> size_t {
         const size_t base = size_;
-        check_append_fits(base, n);
+        RowHashTable::check_append_fits(base, n);
         if (capacity() < base + n) {
             const size_t cap = capacity();
             reserve_rows(std::max(base + n, cap + (cap / 2) + 1));
@@ -223,60 +209,19 @@ public:
     }
 
     auto find(const key_type &key) const -> std::optional<size_t> {
-        const uint32_t h = fold_hash(key);
-        if (table_.count == 0) {
-            return std::nullopt;
-        }
-        size_t s = spread(h) & table_.mask;
-        for (;; s = (s + 1) & table_.mask) {
-            const Slot &e = table_.slots[s];
-            if (e.idx == kEmptySlot) {
-                return std::nullopt;
-            }
-            if (e.h == h && row_eq_key(static_cast<size_t>(e.idx), key)) {
-                return static_cast<size_t>(e.idx);
-            }
-        }
+        return table_.find(fold_hash(key), [this, &key](size_t i) { return row_eq_key(i, key); });
     }
 
-    // Group-prefetch batch find: out[i] = row index of keys[i], or kNotFound. Same result as n
-    // find() calls, but overlaps dram misses via a per-group hash/probe/confirm pipeline. An h
-    // collision falls back to an exact find. must not run concurrently with inserts.
+    // Group-prefetch batch find: out[i] = row index of keys[i], or kNotFound. The prefetch the pipeline
+    // is built around is the row prefetch below -- the table issues it between probe and confirm.
     auto find_batch(const key_type *keys, size_t n, size_t *out) const -> void {
-        static constexpr size_t G = 16; // keys prefetched together per pipeline pass
-        std::array<uint32_t, G> hh;
-        std::array<size_t, G> sp;
-        std::array<TermIndex, G> cand;
-        for (size_t base = 0; base < n; base += G) {
-            const size_t g = std::min(G, n - base);
-            for (size_t j = 0; j < g; ++j) {
-                hh[j] = fold_hash(keys[base + j]);
-                sp[j] = spread(hh[j]);
-                __builtin_prefetch(&table_.slots[sp[j] & table_.mask], 0, 0);
-            }
-            for (size_t j = 0; j < g; ++j) {
-                cand[j] = kEmptySlot;
-                if (table_.count == 0) {
-                    continue;
-                }
-                cand[j] = probe_hash_match_(hh[j], sp[j] & table_.mask);
-                if (cand[j] != kEmptySlot) {
-                    __builtin_prefetch(&rows_[static_cast<size_t>(cand[j]) * stride_], 0, 0);
-                }
-            }
-            for (size_t j = 0; j < g; ++j) {
-                if (cand[j] != kEmptySlot && row_eq_key(static_cast<size_t>(cand[j]), keys[base + j])) {
-                    out[base + j] = static_cast<size_t>(cand[j]);
-                }
-                else if (cand[j] != kEmptySlot) {
-                    const auto v = find(keys[base + j]);
-                    out[base + j] = v ? *v : kNotFound;
-                }
-                else {
-                    out[base + j] = kNotFound;
-                }
-            }
-        }
+        table_.find_batch(
+            keys,
+            n,
+            out,
+            [](const key_type &k) { return fold_hash(k); },
+            [this](size_t i) { __builtin_prefetch(&rows_[i * stride_], 0, 0); },
+            [this](size_t i, const key_type &k) { return row_eq_key(i, k); });
     }
 
     // find_batch over ascending position lists: query q is pos_flat[pos_off[q] .. pos_off[q] + k_of[q]).
@@ -286,46 +231,14 @@ public:
                               std::span<const uint32_t> k_of,
                               std::span<size_t> out,
                               std::span<uint32_t> hash_out = {}) const -> void {
-        const size_t n = pos_off.size();
-        static constexpr size_t G = 16;
-        std::array<uint32_t, G> hh;
-        std::array<size_t, G> sp;
-        std::array<TermIndex, G> cand;
-        for (size_t base = 0; base < n; base += G) {
-            const size_t g = std::min(G, n - base);
-            for (size_t j = 0; j < g; ++j) {
-                hh[j] = fold_hash_positions(pos_flat.subspan(pos_off[base + j], k_of[base + j]));
-                sp[j] = spread(hh[j]);
-                __builtin_prefetch(&table_.slots[sp[j] & table_.mask], 0, 0);
-            }
-            if (!hash_out.empty()) {
-                std::copy_n(hh.begin(), g, hash_out.begin() + static_cast<std::ptrdiff_t>(base));
-            }
-            for (size_t j = 0; j < g; ++j) {
-                cand[j] = kEmptySlot;
-                if (table_.count == 0) {
-                    continue;
-                }
-                cand[j] = probe_hash_match_(hh[j], sp[j] & table_.mask);
-                if (cand[j] != kEmptySlot) {
-                    __builtin_prefetch(&rows_[static_cast<size_t>(cand[j]) * stride_], 0, 0);
-                }
-            }
-            for (size_t j = 0; j < g; ++j) {
-                const size_t q = base + j;
-                const std::span<const PosT> qpos = pos_flat.subspan(pos_off[q], k_of[q]);
-                if (cand[j] == kEmptySlot) {
-                    out[q] = kNotFound;
-                }
-                else if (row_eq_positions(static_cast<size_t>(cand[j]), qpos)) {
-                    out[q] = static_cast<size_t>(cand[j]);
-                }
-                else {
-                    // A 32-bit collision: rare enough to walk the chain from the top rather than resume it.
-                    out[q] = find_positions_(hh[j], qpos);
-                }
-            }
-        }
+        table_.find_batch_at(
+            pos_off.size(),
+            out.data(),
+            [pos_flat, pos_off, k_of](size_t q) { return pos_flat.subspan(pos_off[q], k_of[q]); },
+            [](std::span<const PosT> q) { return fold_hash_positions(q); },
+            [this](size_t i) { __builtin_prefetch(&rows_[i * stride_], 0, 0); },
+            [this](size_t i, std::span<const PosT> q) { return row_eq_positions(i, q); },
+            hash_out);
     }
 
     // fold_hash of the monomial `pos` describes, through the same fold, so it is equal by construction.
@@ -339,156 +252,39 @@ public:
 
     // Insert-or-no-op. Row at `value` must already be written (the confirm reads dense rows).
     auto emplace(const key_type &key, mapped_type value) -> void {
-        check_index_fits(value);
-        const uint32_t h = fold_hash(key);
-        table_.rehash_if_needed();
-        size_t s = spread(h) & table_.mask;
-        while (table_.slots[s].idx != kEmptySlot) {
-            if (table_.slots[s].h == h && row_eq_key(static_cast<size_t>(table_.slots[s].idx), key)) {
-                return;
-            }
-            s = (s + 1) & table_.mask;
-        }
-        table_.slots[s] = Slot{static_cast<TermIndex>(value), h};
-        ++table_.count;
+        table_.emplace(fold_hash(key), value, [this, &key](size_t i) { return row_eq_key(i, key); });
     }
     // Insert n distinct rows with consecutive indices [base, base+n). Rows must already be written.
     template <typename KeyFn>
     auto bulk_insert(size_t n, mapped_type base, KeyFn &&key_at) -> void {
-        if (n == 0) {
-            return;
-        }
-        bulk_insert_hashed(n, base, [&key_at](size_t k) { return fold_hash(key_at(k)); });
+        table_.insert_distinct_range(base, n, [&key_at](size_t k) { return fold_hash(key_at(k)); });
     }
     // bulk_insert with the hashes already in hand: same precondition (n distinct rows, already written,
-    // at consecutive indices) and the same slot assignment. `hashes[k]` must be fold_hash of the key of
+    // at consecutive indices) and the same slot assignment. `hash_at(k)` must be fold_hash of the key of
     // row base+k -- a wrong one leaves the row unfindable, which surfaces later as a duplicate insert.
     template <typename HashFn>
     auto bulk_insert_hashed(size_t n, mapped_type base, HashFn &&hash_at) -> void {
-        if (n == 0) {
-            return;
-        }
-        check_index_fits(base + n - 1);
-        static constexpr size_t G = 16;
-        std::array<uint32_t, G> hh;
-        for (size_t b = 0; b < n; b += G) {
-            const size_t g = std::min(G, n - b);
-            for (size_t j = 0; j < g; ++j) {
-                hh[j] = hash_at(b + j);
-                __builtin_prefetch(&table_.slots[spread(hh[j]) & table_.mask], /*rw=*/1, /*locality=*/0);
-            }
-            for (size_t j = 0; j < g; ++j) {
-                insert_slot_(static_cast<TermIndex>(base + b + j), hh[j]);
-            }
-        }
+        table_.insert_distinct_range(base, n, std::forward<HashFn>(hash_at));
     }
     template <typename Func>
     auto for_each(Func &&fn) const -> void {
-        for (const Slot &e : table_.slots) {
-            if (e.idx != kEmptySlot) {
-                fn(row(static_cast<size_t>(e.idx)), static_cast<size_t>(e.idx));
-            }
-        }
+        table_.for_each_slot([this, &fn](TermIndex idx, uint32_t) { fn(row(idx), static_cast<size_t>(idx)); });
     }
     // Diagnostic: the part of memory_bytes() that is unused geometric-growth capacity.
     [[nodiscard]] auto slack_bytes() const -> size_t {
         return (rows_.capacity() * sizeof(PosT)) - (std::min(rows_.capacity(), size_ * stride_) * sizeof(PosT));
     }
 
-    auto index_estimated_memory_bytes() const -> size_t {
-        return sizeof(OperatorIndex) + (table_.slots.capacity() * sizeof(Slot));
-    }
+    auto index_estimated_memory_bytes() const -> size_t { return sizeof(OperatorIndex) + table_.slot_bytes(); }
 
 private:
-    struct Slot {
-        TermIndex idx = kEmptySlot;
-        uint32_t h = 0;
-    };
-
-    // First slot on h's probe chain whose stored hash matches, or kEmptySlot if the chain ends first.
-    // Matches on h alone and leaves the dense-row comparison to the caller — that deferral is what lets
-    // find_batch prefetch the row between probe and confirm, so do not fold row_eq_key in here (find()
-    // deliberately keeps its own confirming variant). `start` must already be masked; the table must not
-    // be mutated concurrently.
-    [[gnu::always_inline]] auto probe_hash_match_(uint32_t h, size_t start) const -> TermIndex {
-        for (size_t s = start;; s = (s + 1) & table_.mask) {
-            const Slot &e = table_.slots[s];
-            if (e.idx == kEmptySlot) {
-                return kEmptySlot;
-            }
-            if (e.h == h) {
-                return e.idx;
-            }
-        }
+    static auto fold_hash(const key_type &q) noexcept -> uint32_t {
+        return RowHashTable::fold(MonomialHash<NumModes>{}(q));
     }
-
-    static uint32_t fold_hash(const key_type &q) noexcept {
-        const size_t full = MonomialHash<NumModes>{}(q);
-        return static_cast<uint32_t>(full ^ (static_cast<uint64_t>(full) >> 32));
-    }
-    // Avalanche the cached 32-bit fold into a full-width hash (splitmix64 finalizer): the stored h
-    // is only an equality pre-filter, so it must be re-mixed before its low bits drive table bucketing.
-    static size_t spread(uint32_t h) noexcept {
-        uint64_t x = static_cast<uint64_t>(h) * 0x9E3779B97F4A7C15ULL;
-        x ^= x >> 30;
-        x *= 0xBF58476D1CE4E5B9ULL;
-        x ^= x >> 27;
-        x *= 0x94D049BB133111EBULL;
-        x ^= x >> 31;
-        return static_cast<size_t>(x);
-    }
-
-    // One open-addressing table: power-of-2 slot count, linear probing, max load factor 0.7
-    // (the group-prefetch win erodes at high load — longer probe chains add un-prefetched reads).
-    struct Table {
-        std::vector<Slot> slots = std::vector<Slot>(kMinSlots, Slot{});
-        size_t mask = kMinSlots - 1;
-        size_t count = 0;
-
-        auto rehash_if_needed() -> void {
-            if ((count + 1) * 10 >= slots.size() * 7) {
-                rehash_to(slots.size() * 2);
-            }
-        }
-        auto rehash_to(size_t new_cap) -> void {
-            new_cap = std::bit_ceil(std::max<size_t>(new_cap, kMinSlots));
-            if (new_cap <= slots.size()) {
-                return;
-            }
-            std::vector<Slot> old = std::move(slots);
-            slots.assign(new_cap, Slot{});
-            mask = new_cap - 1;
-            for (const Slot &e : old) {
-                if (e.idx == kEmptySlot) {
-                    continue;
-                }
-                size_t s = spread(e.h) & mask;
-                while (slots[s].idx != kEmptySlot) {
-                    s = (s + 1) & mask;
-                }
-                slots[s] = e;
-            }
-        }
-    };
-    static constexpr size_t kMinSlots = 16;
-    // Slot count for `n` entries at ≤0.7 load.
-    static auto slots_for_(size_t n) -> size_t { return std::bit_ceil(std::max<size_t>(kMinSlots, (n * 10 / 7) + 1)); }
 
     [[nodiscard]] auto capacity() const -> size_t { return rows_.capacity() / stride_; }
     auto reserve_rows(size_t n) -> void { rows_.reserve(n * stride_); }
-    auto reserve_index(size_t n) -> void { table_.rehash_to(slots_for_(n + 1)); }
-
-    // Insert (idx, h) into the table with no duplicate probe — callers on this path insert provably distinct
-    // keys (⊕G-injective miss batches, clone re-insertion).
-    auto insert_slot_(TermIndex idx, uint32_t h) -> void {
-        table_.rehash_if_needed();
-        size_t s = spread(h) & table_.mask;
-        while (table_.slots[s].idx != kEmptySlot) {
-            s = (s + 1) & table_.mask;
-        }
-        table_.slots[s] = Slot{idx, h};
-        ++table_.count;
-    }
+    auto reserve_index(size_t n) -> void { table_.reserve(n); }
 
     // Compare row i against key q without materializing the row (the find confirm). Reads the
     // popcount byte first, so a false h prefilter match usually costs one byte compare.
@@ -525,49 +321,13 @@ private:
         return std::equal(q.begin(), q.end(), &rows_[(i * stride_) + 1]);
     }
 
-    // find()'s chain walk for a position-list key, hash already folded; only the collision arm reaches it.
-    [[nodiscard]] auto find_positions_(uint32_t h, std::span<const PosT> q) const -> size_t {
-        if (table_.count == 0) {
-            return kNotFound;
-        }
-        for (size_t s = spread(h) & table_.mask;; s = (s + 1) & table_.mask) {
-            const Slot &e = table_.slots[s];
-            if (e.idx == kEmptySlot) {
-                return kNotFound;
-            }
-            if (e.h == h && row_eq_positions(static_cast<size_t>(e.idx), q)) {
-                return static_cast<size_t>(e.idx);
-            }
-        }
-    }
-
-    // Refused before anything grows: an append that would pass the ceiling cannot be unwound, and
-    // size_ must never reach a count whose last index is unrepresentable. Written as a subtraction
-    // because base + n is the sum that would wrap.
-    static auto check_append_fits(size_t base, size_t n) -> void {
-        if (n > kIndexCeiling - base) {
-            throw TermIndexCeilingReached(
-                std::format("OperatorIndex: appending {} terms to a partition holding {} would pass the "
-                            "2^32 TermIndex ceiling; raise the partition or rank count to split it further.",
-                            n,
-                            base));
-        }
-    }
-
-    static auto check_index_fits(size_t value) -> void {
-        if (value >= kIndexCeiling) {
-            throw TermIndexCeilingReached("OperatorIndex: this partition's term count reached the 2^32 TermIndex "
-                                          "ceiling; raise the partition or rank count to split it further.");
-        }
-    }
-
     DefaultInitVector<PosT> rows_ = {};
     size_t size_ = 0;
     size_t inline_width_ = kMaxInlinePositions;
     size_t stride_ = 1 + kMaxInlinePositions;
     // Lossless side-map for rows whose popcount exceeds inline_width_.
     std::unordered_map<size_t, value_type> overflow_ = {};
-    Table table_ = {};
+    RowHashTable table_ = {};
 };
 
 } // namespace monoprop::detail

--- a/cpp/monoprop/detail/operator/RowHashTable.h
+++ b/cpp/monoprop/detail/operator/RowHashTable.h
@@ -1,0 +1,317 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <limits>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "monoprop/TypeAliases.h"
+
+namespace monoprop::detail {
+
+class TermIndexCeilingReached : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+// The keyless open-addressing index a row store puts over its rows: power-of-2 slot count, linear
+// probing, max load factor 0.7 (the group-prefetch win erodes at higher load -- longer probe chains add
+// un-prefetched reads). A slot holds a row index plus a 32-bit hash used only as an equality
+// pre-filter, so the table never stores or compares a key itself.
+//
+// Keyless is why the hash and the equality test arrive as callables rather than as members: the whole
+// point is that the caller owns the row representation. `eq(row_index)` confirms a pre-filter hit
+// against the caller's rows, and no operation here reads a row.
+//
+// The layout this produces is load-bearing, not an implementation detail: it fixes the iteration order
+// of for_each_slot(), which sets the order of a propagator's user-visible evolved-term list and
+// therefore its floating-point accumulation order. A store that keyed rows through its own copy of this
+// logic could diverge on that while still looking correct, which is the reason the index lives apart
+// from the row representation rather than inside one.
+//
+// Single-writer, matching its owners: one partition, one thread; parallelism is cross-partition.
+class RowHashTable {
+public:
+    // Valid row indices are < kIndexCeiling (check_append_fits refuses the append that would reach it,
+    // check_index_fits the index itself), so the all-ones TermIndex is free to mark an empty slot.
+    static constexpr size_t kIndexCeiling = static_cast<size_t>(std::numeric_limits<TermIndex>::max());
+    static constexpr TermIndex kEmptySlot = std::numeric_limits<TermIndex>::max();
+    // find_batch's "absent" result; same value as detail::kMissingIndex (not included here -- the
+    // operator store must not depend on evolution headers).
+    static constexpr size_t kNotFound = std::numeric_limits<size_t>::max();
+
+    [[nodiscard]] auto count() const noexcept -> size_t { return count_; }
+    [[nodiscard]] auto slot_bytes() const -> size_t { return slots_.capacity() * sizeof(Slot); }
+
+    // Slot capacity for `n` rows at <= 0.7 load. The +1 keeps a table reserved for exactly n rows off
+    // the rehash threshold on the n-th insert.
+    auto reserve(size_t n) -> void { rehash_to(slots_for_(n + 1)); }
+
+    // The 32-bit form of a full-width row hash, which is what a slot stores as its equality
+    // pre-filter. Each store supplies its own full-width hash and folds it here, so the two agree on
+    // the pre-filter's format by construction.
+    [[nodiscard]] static constexpr auto fold(size_t full) noexcept -> uint32_t {
+        return static_cast<uint32_t>(full ^ (static_cast<uint64_t>(full) >> 32));
+    }
+
+    // Refused before anything grows: an append that would pass the ceiling cannot be unwound, and a
+    // store's size must never reach a count whose last index is unrepresentable. Written as a
+    // subtraction because base + n is the sum that would wrap.
+    static auto check_append_fits(size_t base, size_t n) -> void {
+        if (n > kIndexCeiling - base) {
+            throw TermIndexCeilingReached(
+                std::format("appending {} rows to a partition holding {} would pass the 2^32 TermIndex "
+                            "ceiling; raise the partition or rank count to split it further.",
+                            n,
+                            base));
+        }
+    }
+
+    static auto check_index_fits(size_t value) -> void {
+        if (value >= kIndexCeiling) {
+            throw TermIndexCeilingReached("this partition's row count reached the 2^32 TermIndex ceiling; "
+                                          "raise the partition or rank count to split it further.");
+        }
+    }
+
+    // eq(row_index) -> bool confirms a hash pre-filter hit.
+    template <typename Eq>
+    auto find(uint32_t h, Eq &&eq) const -> std::optional<size_t> {
+        if (count_ == 0) {
+            return std::nullopt;
+        }
+        size_t s = spread(h) & mask_;
+        for (;; s = (s + 1) & mask_) {
+            const Slot &e = slots_[s];
+            if (e.idx == kEmptySlot) {
+                return std::nullopt;
+            }
+            if (e.h == h && eq(static_cast<size_t>(e.idx))) {
+                return static_cast<size_t>(e.idx);
+            }
+        }
+    }
+
+    // Insert-or-no-op. The row at `value` must already be written -- eq reads it.
+    template <typename Eq>
+    auto emplace(uint32_t h, size_t value, Eq &&eq) -> void {
+        check_index_fits(value);
+        rehash_if_needed();
+        size_t s = spread(h) & mask_;
+        while (slots_[s].idx != kEmptySlot) {
+            if (slots_[s].h == h && eq(static_cast<size_t>(slots_[s].idx))) {
+                return;
+            }
+            s = (s + 1) & mask_;
+        }
+        slots_[s] = Slot{static_cast<TermIndex>(value), h};
+        ++count_;
+    }
+
+    // Insert with no duplicate probe -- callers on this path insert provably distinct keys
+    // (+G-injective miss batches, clone re-insertion).
+    // insert_distinct over consecutive row indices [base, base + n), hashing each through hash_at(k).
+    // The stores' bulk_insert is this and nothing else, so it lives here rather than once per backend.
+    template <typename HashFn>
+    auto insert_distinct_range(size_t base, size_t n, HashFn &&hash_at) -> void {
+        if (n == 0) {
+            return;
+        }
+        check_index_fits(base + n - 1);
+        static constexpr size_t G = 16; // rows hashed together per prefetch pass
+        std::array<uint32_t, G> hh;
+        for (size_t b = 0; b < n; b += G) {
+            const size_t g = std::min(G, n - b);
+            for (size_t j = 0; j < g; ++j) {
+                hh[j] = hash_at(b + j);
+                // A rehash inside the loop below invalidates these addresses; a stale prefetch is a
+                // wasted hint, never a wrong insert.
+                __builtin_prefetch(&slots_[spread(hh[j]) & mask_], /*rw=*/1, /*locality=*/0);
+            }
+            for (size_t j = 0; j < g; ++j) {
+                insert_distinct(static_cast<TermIndex>(base + b + j), hh[j]);
+            }
+        }
+    }
+
+    auto insert_distinct(TermIndex idx, uint32_t h) -> void {
+        rehash_if_needed();
+        size_t s = spread(h) & mask_;
+        while (slots_[s].idx != kEmptySlot) {
+            s = (s + 1) & mask_;
+        }
+        slots_[s] = Slot{idx, h};
+        ++count_;
+    }
+
+    // Group-prefetch batch find: out[i] = row index of keys[i], or kNotFound. Same result as n find()
+    // calls, but overlaps dram misses via a per-group hash/probe/confirm pipeline. An h collision falls
+    // back to an exact find. Must not run concurrently with inserts.
+    //
+    // The three callables are what make the pipeline possible without the table knowing a row:
+    // hash(key) -> uint32_t, prefetch_row(row_index) issued between probe and confirm (which is the
+    // whole reason confirmation is deferred rather than folded into the probe), and
+    // eq(row_index, key) -> bool.
+    template <typename Key, typename Hash, typename PrefetchRow, typename Eq>
+    auto find_batch(const Key *keys, size_t n, size_t *out, Hash &&hash, PrefetchRow &&prefetch_row, Eq &&eq) const
+        -> void {
+        find_batch_at(n, out, [keys](size_t i) -> const Key & { return keys[i]; }, hash, prefetch_row, eq);
+    }
+
+    // find_batch over keys reached through key_at(i) rather than an array: a query form that is not an
+    // array of keys (a flattened position list, say) keeps this one pipeline instead of copying it.
+    // key_at is called once per key in the hash pass and again in the confirm pass, so it must be cheap
+    // and stable. When hash_out is non-empty it receives every key's folded hash, which is what an
+    // insert of the misses hands back to insert_distinct_range.
+    template <typename KeyAt, typename Hash, typename PrefetchRow, typename Eq>
+    auto find_batch_at(size_t n,
+                       size_t *out,
+                       KeyAt &&key_at,
+                       Hash &&hash,
+                       PrefetchRow &&prefetch_row,
+                       Eq &&eq,
+                       std::span<uint32_t> hash_out = {}) const -> void {
+        static constexpr size_t G = 16; // keys prefetched together per pipeline pass
+        std::array<uint32_t, G> hh;
+        std::array<size_t, G> sp;
+        std::array<TermIndex, G> cand;
+        for (size_t base = 0; base < n; base += G) {
+            const size_t g = std::min(G, n - base);
+            for (size_t j = 0; j < g; ++j) {
+                hh[j] = hash(key_at(base + j));
+                sp[j] = spread(hh[j]);
+                __builtin_prefetch(&slots_[sp[j] & mask_], 0, 0);
+            }
+            if (!hash_out.empty()) {
+                std::copy_n(hh.begin(), g, hash_out.begin() + static_cast<std::ptrdiff_t>(base));
+            }
+            for (size_t j = 0; j < g; ++j) {
+                cand[j] = kEmptySlot;
+                if (count_ == 0) {
+                    continue;
+                }
+                cand[j] = probe_hash_match_(hh[j], sp[j] & mask_);
+                if (cand[j] != kEmptySlot) {
+                    prefetch_row(static_cast<size_t>(cand[j]));
+                }
+            }
+            for (size_t j = 0; j < g; ++j) {
+                const size_t q = base + j;
+                if (cand[j] == kEmptySlot) {
+                    out[q] = kNotFound;
+                }
+                else if (eq(static_cast<size_t>(cand[j]), key_at(q))) {
+                    out[q] = static_cast<size_t>(cand[j]);
+                }
+                else {
+                    // A 32-bit collision: rare enough to walk the chain from the top rather than resume it.
+                    const auto v = find(hh[j], [&eq, &key_at, q](size_t i) { return eq(i, key_at(q)); });
+                    out[q] = v ? *v : kNotFound;
+                }
+            }
+        }
+    }
+
+    // Occupied slots in table order, as fn(row_index, stored_hash). That order is the store's iteration
+    // order; see the class comment on why it must not drift between stores.
+    template <typename Fn>
+    auto for_each_slot(Fn &&fn) const -> void {
+        for (const Slot &e : slots_) {
+            if (e.idx != kEmptySlot) {
+                fn(e.idx, e.h);
+            }
+        }
+    }
+
+private:
+    struct Slot {
+        TermIndex idx = kEmptySlot;
+        uint32_t h = 0;
+    };
+
+    static constexpr size_t kMinSlots = 16;
+
+    static auto slots_for_(size_t n) -> size_t { return std::bit_ceil(std::max<size_t>(kMinSlots, (n * 10 / 7) + 1)); }
+
+    // Avalanche the cached 32-bit fold into a full-width hash (splitmix64 finalizer): the stored h is
+    // only an equality pre-filter, so it must be re-mixed before its low bits drive table bucketing.
+    static auto spread(uint32_t h) noexcept -> size_t {
+        uint64_t x = static_cast<uint64_t>(h) * 0x9E3779B97F4A7C15ULL;
+        x ^= x >> 30;
+        x *= 0xBF58476D1CE4E5B9ULL;
+        x ^= x >> 27;
+        x *= 0x94D049BB133111EBULL;
+        x ^= x >> 31;
+        return static_cast<size_t>(x);
+    }
+
+    // First slot on h's probe chain whose stored hash matches, or kEmptySlot if the chain ends first.
+    // Matches on h alone and leaves confirmation to the caller -- that deferral is what lets find_batch
+    // prefetch the row between probe and confirm, so do not fold eq in here (find() deliberately keeps
+    // its own confirming variant).  `start` must already be masked; the table must not be mutated
+    // concurrently.
+    [[gnu::always_inline]] auto probe_hash_match_(uint32_t h, size_t start) const -> TermIndex {
+        for (size_t s = start;; s = (s + 1) & mask_) {
+            const Slot &e = slots_[s];
+            if (e.idx == kEmptySlot) {
+                return kEmptySlot;
+            }
+            if (e.h == h) {
+                return e.idx;
+            }
+        }
+    }
+
+    auto rehash_if_needed() -> void {
+        if ((count_ + 1) * 10 >= slots_.size() * 7) {
+            rehash_to(slots_.size() * 2);
+        }
+    }
+
+    auto rehash_to(size_t new_cap) -> void {
+        new_cap = std::bit_ceil(std::max<size_t>(new_cap, kMinSlots));
+        if (new_cap <= slots_.size()) {
+            return;
+        }
+        std::vector<Slot> old = std::move(slots_);
+        slots_.assign(new_cap, Slot{});
+        mask_ = new_cap - 1;
+        for (const Slot &e : old) {
+            if (e.idx == kEmptySlot) {
+                continue;
+            }
+            size_t s = spread(e.h) & mask_;
+            while (slots_[s].idx != kEmptySlot) {
+                s = (s + 1) & mask_;
+            }
+            slots_[s] = e;
+        }
+    }
+
+    std::vector<Slot> slots_ = std::vector<Slot>(kMinSlots, Slot{});
+    size_t mask_ = kMinSlots - 1;
+    size_t count_ = 0;
+};
+
+} // namespace monoprop::detail


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Stacked on #302 — review that first; this PR's diff against it is `RowHashTable.h` plus the `OperatorIndex` rewrite.

## Summary

Second of five PRs carved out of #226. `OperatorIndex` carries two things that have nothing to do with each other: a keyless open-addressing hash table, and the packed row storage the table indexes into. A second row backend is coming, and it needs the table and not the rows, so the table moves out first, on its own, with no behaviour change.

`RowHashTable` is the table alone — power-of-two slots, linear probing, load factor 0.7, a 32-bit folded hash kept beside each slot as an equality pre-filter. It stores no keys: hashing, equality and prefetch arrive as callables from the owner, which is what lets a caller key its rows in whatever form it already has them in. `OperatorIndex` keeps its own API and forwards to it.

This is deliberately inert. The table's slot layout fixes `for_each_slot` order, which fixes evolved-term order, which fixes floating-point accumulation order — so a reordering here would move energies. Verified against main's implementation over 4000 random monomials: identical iteration order, `find` / `find_batch` results, clone order and `memory_bytes`.

## Changes

- `cpp/monoprop/detail/operator/RowHashTable.h`: new. The table, `TermIndexCeilingReached`, `kIndexCeiling`, `fold`, `find` / `find_batch` / `emplace` / `insert_distinct` / `insert_distinct_range`, `for_each_slot`, `reserve`, `slot_bytes`.
- `cpp/monoprop/detail/operator/OperatorIndex.h`: keeps the rows, delegates the table. `-195` lines.
- `cpp/monoprop/detail/operator/CMakeLists.txt`: list the new header.

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

Covered by the existing `operator_index_tests.cpp`; the gate for a change of this kind is `just diff-baseline` (#302), which must come out byte-identical.

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: ClaudeCode (claude-opus-5)
- [x] I used the following tool to generate or modify code: ClaudeCode (claude-opus-5)
