### PR TITLE
chore(benches): make the benchmark set a fixed, runnable table

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -78,6 +78,16 @@ jobs:
         run: |
           just bench-bmf "$BENCHER_LABEL" > bmf.json
 
+      - name: Upload the raw measurement
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-${{ inputs.label }}
+          path: |
+            bmf.json
+            benches/results/*.json
+          if-no-files-found: warn
+
       - uses: bencherdev/bencher@v0.6.12
 
       # The project slug and API key go through the environment rather than the
@@ -101,11 +111,6 @@ jobs:
             --threshold-lower-boundary _ \
             --threshold-upper-boundary 0.99 \
             --threshold-measure peak-memory \
-            --threshold-test percentage \
-            --threshold-max-sample-size 64 \
-            --threshold-lower-boundary _ \
-            --threshold-upper-boundary 0.10 \
-            --threshold-measure resting-memory \
             --threshold-test percentage \
             --threshold-max-sample-size 64 \
             --threshold-lower-boundary _ \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,16 +48,19 @@ The root `pyproject.toml` declares a `[tool.uv.workspace]`, so one `uv.lock` cov
 - `monoprop` (repository root, `src/monoprop/`) — the library, built by scikit-build-core.
 - `packages/monoprop-bench-tools/` (`monoprop_bench_tools`) — the reusable half of the benchmark
   harness, published to PyPI: `memory.cpu` / `memory.gpu` (peak-footprint measurement), `models`
-  (the benchmarked problem builders), `report` and `bmf` (the artifact renderers). Pure Python,
-  built by hatchling, versioned off the same git tags as `monoprop`. It ships the console scripts
-  `monoprop-bench-report` and `monoprop-bench-bmf`. It contains **no benchmarks**.
+  (the benchmarked problem builders), `report` and `bmf` (the artifact renderers), and `rungs`
+  (the rung-table loader, runner and ladder collator). Pure Python, built by hatchling, versioned
+  off the same git tags as `monoprop`. It ships the console scripts `monoprop-bench-report`,
+  `monoprop-bench-bmf`, `monoprop-bench-rung` and `monoprop-bench-ladder`. It contains **no
+  benchmarks and no rung table** — those are data whose names campaigns already depend on.
 - `packages/bench-third-party/` — cross-engine comparison scripts. Listed in the workspace
   `exclude`: it pins a narrower `requires-python`, a git dependency and linux-x86_64-only CUDA
   wheels, so it is a standalone uv project with its own `uv.lock`. Run it with
   `cd packages/bench-third-party && uv sync`, never from the root environment.
-- `benches/` — monoprop's own benchmark suite (`conftest.py`, `bench_*.py`, `results/`). It stays in
-  the repository and imports the tools package. Benchmark names are Bencher's history key, so they
-  must not move with a library release; that is why the suite is not in `monoprop-bench-tools`.
+- `benches/` — monoprop's own benchmark suite (`conftest.py`, `bench_*.py`, `rungs.toml`,
+  `results/`). It stays in the repository and imports the tools package. Benchmark
+  names are Bencher's history key and rung ids name artifacts already written, so neither may move
+  with a library release; that is why the suite is not in `monoprop-bench-tools`.
 
 Dependency groups follow from that split: `test` is monoprop's own suite only (cibuildwheel installs
 it against a built wheel, so it must not reference a workspace member), `workspace-test` adds
@@ -83,7 +86,14 @@ Key files:
   continuous-benchmarking workflow. Both read the schema written by `benches/conftest.py`, so a
   change to the recorded sections has to land on both sides of the package boundary. Benchmark
   names are Bencher's history key, so renaming or moving a `bench_*` test orphans its tracked
-  series.
+  series. Both bench modules measure the same four operations — `build_graph`, `propagate`,
+  `energy`, `gradient`.
+- `benches/rungs.toml` and `monoprop_bench_tools.rungs`: the benchmark set at the sizes the
+  library is used at, as a table rather than a loop, so a campaign cannot quietly run a different
+  grid. Every row carries `expect_terms`, and a result missing it by >0.1% is refused: at a fixed
+  seed and tolerance the term count is reproducible to the digit, so the gate catches a mistyped
+  knob rather than tolerating noise. A row with `expect_terms = 0` has never been calibrated and
+  refuses to run. The scheduler that submits a rung is deliberately not in this repository.
 - **`rounds > 1` overlaps two rounds' live memory** (`setup=` runs before the prior round's
   teardown) — pin `--bench-rounds=1`; `record_memory` measures that construction transient,
   not per-op cost (use `op_memory`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ The root `pyproject.toml` declares a `[tool.uv.workspace]`, so one `uv.lock` cov
   wheels, so it is a standalone uv project with its own `uv.lock`. Run it with
   `cd packages/bench-third-party && uv sync`, never from the root environment.
 - `benches/` — monoprop's own benchmark suite (`conftest.py`, `bench_*.py`, `rungs.toml`,
-  `results/`). It stays in the repository and imports the tools package. Benchmark
+  `RUNGS.md`, `results/`). It stays in the repository and imports the tools package. Benchmark
   names are Bencher's history key and rung ids name artifacts already written, so neither may move
   with a library release; that is why the suite is not in `monoprop-bench-tools`.
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -11,19 +11,53 @@ documentation for detailed instructions.
 ## What lives where
 
 This directory holds only monoprop's own benchmarks — `conftest.py` (the fixtures
-and the results schema), `bench_random.py`, `bench_models.py`, and `results/`.
+and the results schema), `bench_random.py`, `bench_models.py`, `rungs.toml` (the
+benchmark set) and `results/`.
+
+Both bench modules measure the same four operations — `build_graph`, `propagate`,
+`energy` and `gradient` — so a number means the same thing whichever problem
+produced it.
 
 Benchmark names are the key [Bencher](https://bencher.dev/) stores history under,
 so they stay here rather than moving with a library release.
 
 Everything reusable is in the `monoprop-bench-tools` package
 ([`../packages/monoprop-bench-tools`](../packages/monoprop-bench-tools)): the
-memory instrumentation, the model builders, and the two renderers that turn a
-run's artifacts into `REPORT.md` and Bencher Metric Format JSON.
+memory instrumentation, the model builders, the two renderers that turn a run's
+artifacts into `REPORT.md` and Bencher Metric Format JSON, and the runner that
+executes one row of `rungs.toml` and gates the result on its term count.
 
 Cross-engine comparisons against other propagation libraries live in
 [`../packages/bench-third-party`](../packages/bench-third-party), a standalone uv
 project with its own lockfile.
+
+## The rung ladder
+
+`rungs.toml` is the benchmark set: one row per cell, giving the picture, the model,
+the operations, the geometry, the size knobs and the exact term count that
+configuration produces. A row, not a loop, so a campaign cannot quietly run a
+different grid and two campaigns' numbers are comparable row for row.
+
+```bash
+monoprop-bench-rung benches/rungs.toml list             # the set, and what each costs
+monoprop-bench-rung benches/rungs.toml <id> --dry-run   # the plan, no allocation spent
+monoprop-bench-rung benches/rungs.toml <id> --rep 1     # one rep
+monoprop-bench-ladder benches/rungs.toml benches/results  # the block to paste into the PR
+```
+
+Nothing runs these for you. Run the rungs your change could plausibly move and put
+the block in the pull request: it carries the timings, the peak memory, and the
+resolved parameters of every problem measured.
+
+`expect_terms` is a gate, not documentation: a result missing it by more than 0.1%
+is refused, so a mistyped tolerance fails the cell instead of measuring a different
+problem under the right name. A row nobody has calibrated says so twice --
+`expect_terms = 0` and `TBD` on the unmeasured knob -- and refuses to run.
+
+`cost_seconds` and `cost_gib_per_node` are the opposite: what one rep last cost, so
+you can see what a rung takes before you spend it. Documentation, never a gate.
+The machine and scheduler that run a rung are not in this repository; the table,
+the runner and the gate are.
 
 ## Fixed-model sizing
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -12,7 +12,7 @@ documentation for detailed instructions.
 
 This directory holds only monoprop's own benchmarks — `conftest.py` (the fixtures
 and the results schema), `bench_random.py`, `bench_models.py`, `rungs.toml` (the
-benchmark set) and `results/`.
+benchmark set), [`RUNGS.md`](RUNGS.md) (how to run it) and `results/`.
 
 Both bench modules measure the same four operations — `build_graph`, `propagate`,
 `energy` and `gradient` — so a number means the same thing whichever problem
@@ -58,6 +58,10 @@ problem under the right name. A row nobody has calibrated says so twice --
 you can see what a rung takes before you spend it. Documentation, never a gate.
 The machine and scheduler that run a rung are not in this repository; the table,
 the runner and the gate are.
+
+**[`RUNGS.md`](RUNGS.md)** is the guide: every model's parameters and what they do,
+how the geometry maps onto a machine, example Slurm scripts, the pinning and
+allocation-sizing traps, and how to calibrate a `TBD` row.
 
 ## Fixed-model sizing
 

--- a/benches/RUNGS.md
+++ b/benches/RUNGS.md
@@ -394,17 +394,69 @@ that machine's; the failure modes are not.
 Peak resident memory over the 38 scaling rungs fits
 
 ```
-GiB/node = 3.39 + 0.0634 × Mterms/node
+GiB/node = 3.40 + 0.0634 × Mterms/node        (marginal cost 68.0 B/term)
 ```
 
-within −2.9/+4.5 GiB/node of the line. Use it to pick a node count, not to predict a rung: it is
-a fit over one campaign on one machine, and `cost_gib_per_node` on the row itself is the better
-number where a row has one.
+within −2.9/+4.5 GiB/node of the line. Two cautions before you use it. The constant dominates at
+small loads, so the *apparent* bytes per term is about 180 at 25 Mterms/node and only settles to
+68–71 above roughly 1000 Mterms/node — a per-term figure read off a small rung overestimates a
+large one badly. And it is a fit over one campaign on one machine: where a row carries
+`cost_gib_per_node`, that number is better than the line.
 
-`build_graph` does not obey it. It *extends* the graph rather than replacing it, retaining one
-layer-set per gate, while `propagate` releases each layer as it contracts. Hubbard reaches 97M
-terms through `propagate` in well under 2 GiB, yet four successive `build_graph` calls on the same
-model exceed a 242 GiB node. That is why the graph-holding rungs stop at a single node.
+`build_graph` does not obey it at all, and the gap is not subtle. Measured at identical model
+parameters (`hubbard`, cutoff 6, `lower_atol` 1e-4):
+
+| operation | Trotter steps | terms | peak RSS |
+| --- | ---: | ---: | ---: |
+| `propagate` | 29 | 1,169,024 | 0.38 GiB |
+| `build_graph` | 2 | — | **exceeded a 20 GiB cap** |
+
+`build_graph` *extends* the graph rather than replacing it, retaining one layer-set per gate,
+while `propagate` releases each layer as it contracts. So it was killed at more than 20 GiB while
+running one fourteenth of the Trotter steps — at least a fiftyfold separation on the same problem.
+That is why the graph rungs are the ones whose fit is an open question, and why a graph rung that
+does not fit is a result worth recording rather than a failure.
+
+## What each configuration costs
+
+### `hubbard` / `propagate` on compute nodes
+
+The measured map from the size knob to everything else. Cutoff 10, 8 ranks/node × 16 partitions,
+AMD EPYC 7742 with 242 GiB per node, five reps per row (ten on the smallest). `nodes` is the
+smallest allocation the row was measured on, so `GiB/node` and `median s` are that machine's.
+
+| `--hubbard-lower-atol` | terms | nodes | GiB/node | median s | Mterms/s/node |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `1.25e-05` | 96,981,051 | 1 | 10.8 | 10.8 | 9.02 |
+| `8.8e-06` | 184,124,520 | 2 | 9.6 | 10.6 | 8.70 |
+| `5.9e-06` | 377,482,074 | 1 | 26.6 | 47.7 | 7.91 |
+| `3.9e-06` | 781,669,404 | 2 | 28.0 | 50.9 | 7.68 |
+| `2.6e-06` | 1,569,152,761 | 1 | 99.9 | 215.6 | 7.28 |
+| `1.73e-06` | 3,104,527,573 | 2 | 100.2 | 222.3 | 6.98 |
+| `1.14e-06` | 6,125,805,627 | 2 | 200.2 | 450.2 | 6.80 |
+| `7.35e-07` | 12,255,330,837 | 8 | 99.9 | 227.3 | 6.74 |
+| `4.68e-07` | 24,419,998,198 | 8 | 201.3 | 471.0 | 6.48 |
+| `2.94e-07` | 48,317,129,677 | 32 | 101.3 | 249.6 | 6.05 |
+| `1.82e-07` | 94,684,031,363 | 64 | 84.3 | 257.1 | 5.76 |
+
+Two things to read off it. The knob is **steep** — halving `lower_atol` roughly doubles the term
+count, so it is the only axis that reaches these sizes and a small typo in it is a large change in
+problem. And throughput is nearly flat in problem size at about **7 Mterms/s/node**, drifting from
+9.0 down to 5.8 across three orders of magnitude, which is what makes it a usable planning number:
+
+```
+nodes   ≈ Mterms / 1500      (~100 GiB/node, half of a 242 GiB node)
+nodes   ≈ Mterms / 3000      (~200 GiB/node, filling it)
+seconds ≈ Mterms / nodes / 7
+```
+
+Checked against the rows above: 1569 Mterms gives 1.0 nodes at 100 GiB (measured: 1 node,
+99.9 GiB), 24420 gives 8.1 nodes at 200 GiB (measured: 8 nodes, 201.3 GiB), and 48317 gives
+32.2 at 100 GiB (measured: 32 nodes, 101.3 GiB). The time rule lands within about 15% —
+predicting 224 s, 436 s and 216 s against 215.6, 471.0 and 249.6 measured.
+
+The `1.82e-07` row is the one exception to the memory law in the whole campaign: 84.3 GiB/node
+against 97.1 predicted, identically on all five reps. Reproducible and unexplained.
 
 ## Reporting the result
 

--- a/benches/RUNGS.md
+++ b/benches/RUNGS.md
@@ -78,7 +78,7 @@ up here and is nearly invisible on `pauli`.
 
 | `--hubbard-…` | default | what it does |
 | --- | --- | --- |
-| `num-sites` | 60 | lattice sites; 2 spin orbitals each, so 120 modes |
+| `num-sites` | 60 | lattice sites; 2 spin orbitals each, so 120 modes. At most 125 |
 | `hopping` | 1.0 | nearest-neighbour hopping amplitude `t` |
 | `interaction` | -2.0 | on-site interaction `U` |
 | `chemical-potential` | 0.0 | `mu` |
@@ -96,7 +96,7 @@ Heisenberg picture only. One circuit layer per `num-layers`, so all four operati
 
 | `--pauli-…` | default | what it does |
 | --- | --- | --- |
-| `num-qubits` | 127 | heavy-hex lattice size |
+| `num-qubits` | 127 | heavy-hex lattice size — **effectively fixed**, see below |
 | `num-layers` | 20 | kicked-Ising layers |
 | `observable-qubit` | 62 | qubit the measured `Z` sits on |
 | `theta` | π/4 | single-qubit X-rotation angle |
@@ -111,7 +111,7 @@ The only model with both pictures. Its options carry no model prefix.
 | option | default | what it does |
 | --- | --- | --- |
 | `--num-generators` | 100 | random generators, i.e. circuit gates |
-| `--num-modes` | 128 | fermionic modes |
+| `--num-modes` | 128 | fermionic modes — **at most 250**, see below |
 | `--gen-length` | 4 | Majorana operators per generator |
 | `--obs-terms` | 10000 | **the size knob** — terms in the observable |
 | `--cutoff` | 6 | truncation cutoff |
@@ -119,6 +119,27 @@ The only model with both pictures. Its options carry no model prefix.
 
 The Schrödinger rungs set `schrodinger_cutoff = cutoff + 2`. Its cap is lower than the
 Heisenberg one at the same knobs, so calibrate the two separately rather than assuming they match.
+
+### How large can the system be
+
+The system-size axes are not all free, and two of them have hard ceilings that are not obvious
+from the option list.
+
+**Modes are capped at 250 by the build.** `monoprop_MAX_NUM_MODES` is a CMake cache variable
+defaulting to `250`, and the extension ships propagator variants in strides of 32 up to 256. So
+`--num-modes` accepts at most 250 and `--hubbard-num-sites` at most 125 (two spin orbitals per
+site) unless you rebuild with a larger `monoprop_MAX_NUM_MODES`. The random rungs sit at 250,
+which is the ceiling.
+
+**`--pauli-num-qubits` is effectively fixed at 127.** The kicked-Ising circuit is built over
+`HEAVY_HEX_TOPOLOGY`, a hard-coded IBM Eagle coupling map: 144 pairs whose highest index is 126.
+Passing anything below 127 fails with `If a term acts on a qubit index >= num_qubits`, and
+anything above 127 just adds qubits no gate touches. Size the Pauli model with `--pauli-cutoff`,
+`--pauli-num-layers` and `--pauli-lower-atol` instead. Benchmarking a different lattice means
+adding a second topology to `models.py`, not changing a flag.
+
+**Hubbard's lattice is free**, up to the 125-site ceiling above, and `--hubbard-trotter-steps`
+scales the `propagate` call count independently of the term count.
 
 ### Why `lower_atol` is the size knob
 

--- a/benches/RUNGS.md
+++ b/benches/RUNGS.md
@@ -263,6 +263,115 @@ done
 monoprop-bench-ladder benches/rungs.toml runs --family strong
 ```
 
+### Running everything
+
+A whole family needs one allocation per node count, so the job list is the table grouped by
+`nodes`. Generate it rather than typing it — the table is the only place that knows:
+
+```bash
+# jobs.txt: one line per allocation, "<nodes> <rung> <rung> ..."
+python - <<'EOF' > jobs.txt
+import collections, pathlib
+from monoprop_bench_tools import rungs
+
+FAMILY = "strong"          # or "weak", or "size", or None for the lot
+table = rungs.load_rungs(pathlib.Path("benches/rungs.toml"))
+jobs = collections.defaultdict(list)
+for r in table.values():
+    if not r.calibrated:
+        continue           # uncalibrated rows refuse to run; calibrate them first
+    if FAMILY and r.family != FAMILY:
+        continue
+    jobs[r.nodes].append(r.id)
+for nodes, ids in sorted(jobs.items()):
+    print(nodes, *ids)
+EOF
+cat jobs.txt
+```
+
+```
+1 strong-1569m-n1
+2 strong-1569m-n2 strong-6126m-n2
+4 strong-1569m-n4 strong-6126m-n4
+8 strong-1569m-n8 strong-6126m-n8 strong-24420m-n8
+16 strong-1569m-n16 strong-6126m-n16 strong-24420m-n16
+32 strong-1569m-n32 strong-6126m-n32 strong-24420m-n32
+64 strong-1569m-n64 strong-6126m-n64 strong-24420m-n64
+```
+
+Submit one job per line. `run_rungs.sh` takes the node count and the rung ids as its arguments:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=monoprop-ladder
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=16
+#SBATCH --exclusive
+
+set -uo pipefail                  # not -e: a refused rep must not kill the job
+
+cd "$SLURM_SUBMIT_DIR"
+module load foss/2025b
+source .venv/bin/activate
+
+for rung in "$@"; do
+  reps=$(python -c "
+import pathlib, sys
+from monoprop_bench_tools import rungs
+print(rungs.load_rungs(pathlib.Path('benches/rungs.toml'))['$rung'].reps)")
+  for rep in $(seq 1 "$reps"); do
+    srun --cpu-bind=cores --distribution=block:block \
+      monoprop-bench-rung benches/rungs.toml "$rung" --rep "$rep" --results runs
+  done
+done
+```
+
+```bash
+while read -r nodes rungs_on_this_node; do
+  sbatch --nodes="$nodes" --time=2:00:00 run_rungs.sh $rungs_on_this_node
+done < jobs.txt
+```
+
+Then collate once, over every job's artifacts:
+
+```bash
+monoprop-bench-ladder benches/rungs.toml runs --family strong
+```
+
+### What you get out
+
+One table per family plus the resolved parameters. The `strong` table from the campaign whose
+numbers this repository ships looks like this — 8 ranks/node × 16 partitions on 242 GiB EPYC 7742
+nodes, five reps per rung:
+
+```
+## strong
+
+| rung | nodes | R | P | terms | Mterms/node | reps | median s | min s | Mterms/s/node | GiB/node | declared s | vs declared |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| strong-1569m-n1 | 1 | 8 | 128 | 1,569,152,761 | 1569 | 5 | 215.60 | ... | 7.28 | 99.9 | 215.60 | 1.000x |
+| strong-1569m-n2 | 2 | 16 | 256 | 1,569,152,761 | 785 | 5 | 105.90 | ... | 7.41 | 51.5 | 105.90 | 1.000x |
+| strong-1569m-n4 | 4 | 32 | 512 | 1,569,152,761 | 392 | 5 | 53.30 | ... | 7.35 | 28.0 | 53.30 | 1.000x |
+| strong-1569m-n8 | 8 | 64 | 1024 | 1,569,152,761 | 196 | 5 | 28.60 | ... | 6.86 | 15.9 | 28.60 | 1.000x |
+| strong-1569m-n16 | 16 | 128 | 2048 | 1,569,152,761 | 98 | 5 | 18.10 | ... | 5.41 | 11.0 | 18.10 | 1.000x |
+| strong-1569m-n32 | 32 | 256 | 4096 | 1,569,152,761 | 49 | 5 | 16.10 | ... | 3.04 | 6.6 | 16.10 | 1.000x |
+| strong-1569m-n64 | 64 | 512 | 8192 | 1,569,152,761 | 25 | 5 | 24.00 | ... | 1.02 | 4.1 | 24.00 | 1.000x |
+
+## Problems measured
+
+- **strong-1569m-n8** — hubbard / heisenberg, propagate, 8 x 8 x 16 (nodes x ranks/node x partitions)
+  - chemical_potential=0.0, cutoff=10, hopping=1.0, interaction=-2.0, lower_atol=1.25e-05,
+    neel_start_spin=down, num_sites=60, observable_site=46, observable_spin=up,
+    trotter_dt=0.2, trotter_steps=29
+```
+
+Those medians are the campaign's, replayed through the collator, so `vs declared` is `1.000x` by
+construction and `min s` is elided — a real run fills both. The **shape** is what to expect, and
+the shape is the answer: this ladder halves cleanly to 8 nodes, gains almost nothing from 16 to
+32, and is *slower* at 64 than at 32. `Mterms/s/node` is where you read that — 7.28 at one node,
+6.86 at eight, 1.02 at sixty-four. A strong-scaling curve that turns over is the result, not a
+failed run.
+
 ### Things that quietly cost you
 
 Measured on Deucalion (AMD EPYC 7742, 128 physical cores per node, SMT off). The numbers are

--- a/benches/RUNGS.md
+++ b/benches/RUNGS.md
@@ -1,0 +1,306 @@
+# Running the rungs
+
+`rungs.toml` is monoprop's benchmark set. This page is how to run it: what each model's
+parameters mean, how the geometry maps onto a machine, and example Slurm scripts.
+
+Nothing here runs automatically. No CI workflow gates a pull request on these. Running the
+rungs your change could plausibly move, and putting the numbers in the pull request, is your
+job — and `monoprop-bench-ladder` prints the block to paste.
+
+## The three commands
+
+```bash
+# What the set contains, and what one rep of each last cost.
+monoprop-bench-rung benches/rungs.toml list
+
+# The exact pytest line, geometry and environment, without spending anything.
+monoprop-bench-rung benches/rungs.toml n1-100m-hubbard-propagate --dry-run
+
+# One rep. Repeat with --rep 2, 3, ... for the rest.
+monoprop-bench-rung benches/rungs.toml n1-100m-hubbard-propagate --rep 1 --results runs
+
+# Collate every gate-clean rep into the block to paste into the pull request.
+monoprop-bench-ladder benches/rungs.toml runs
+```
+
+`list` marks an uncalibrated row with `*` and shows `?` where nobody has timed it:
+
+```
+  n1-100m-hubbard-propagate    size   N=1   P=128      96,981,051  ?
+  weak-97m-n4                  weak   N=4   P=512     377,482,074  13.1s 11.5GiB/node
+* st-10m-random-propagate      size   N=1   P=1                 0  ?
+```
+
+## What a row declares
+
+| field | meaning |
+| --- | --- |
+| `id` | unique; names the artifacts, so it is stable once a rung has been run |
+| `family` | `size`, `strong` or `weak` |
+| `picture` | `heisenberg` or `schrodinger`; only the random model has this axis |
+| `model` | `random`, `hubbard` or `pauli` |
+| `ops` | any of `build_graph`, `propagate`, `energy`, `gradient` |
+| `nodes`, `ranks_per_node`, `partitions` | the geometry; see below |
+| `args` | `--<option>=<value>` handed to pytest verbatim — the size knobs live here |
+| `expect_terms` | **the gate**: the exact term count this configuration produces |
+| `reps` | how many separate process launches to run |
+| `cost_seconds`, `cost_gib_per_node` | what one rep last cost — documentation, never a gate |
+| `walltime` | a Slurm allowance for one rung, reps included |
+
+Two of these behave in opposite directions, and it matters which is which.
+
+**`expect_terms` is a gate.** A result missing it by more than 0.1% is refused and the artifact
+renamed `.refused.json`. The term count is reproducible to the digit at a fixed seed and
+tolerance, so this catches a mistyped knob before it becomes a number in a pull request. The
+geometry and the timing-round count are checked the same way.
+
+**`cost_seconds` and `cost_gib_per_node` are documentation.** They say what one rep took the
+last time anyone measured it, so you can size an allocation before you spend it. A timing is
+noisy and your machine is not the machine they were taken on; nothing gates on them.
+
+A row nobody has calibrated says so twice — `expect_terms = 0` and `TBD` in place of every
+unmeasured size knob — and refuses to run. `TBD` rather than `0` because `0` is not neutral:
+`lower_atol = 0` prunes nothing and is the *largest* problem the model can pose.
+
+## The models and their parameters
+
+Override any field with `--<model>-<field>`, underscores becoming hyphens:
+`--hubbard-trotter-steps=2`, `--pauli-lower-atol=5e-05`.
+
+The resolved values — not just your overrides — are recorded in each run's artifact and printed
+by `monoprop-bench-ladder` under `## Problems measured`, so a reviewer never has to resolve your
+flags against these defaults by hand.
+
+### `hubbard` — 1D Fermi-Hubbard under first-order Trotter
+
+Heisenberg picture only. Calls `propagate` once per Trotter step, so a cost paid per call shows
+up here and is nearly invisible on `pauli`.
+
+| `--hubbard-…` | default | what it does |
+| --- | --- | --- |
+| `num-sites` | 60 | lattice sites; 2 spin orbitals each, so 120 modes |
+| `hopping` | 1.0 | nearest-neighbour hopping amplitude `t` |
+| `interaction` | -2.0 | on-site interaction `U` |
+| `chemical-potential` | 0.0 | `mu` |
+| `trotter-dt` | 0.2 | time step |
+| `trotter-steps` | 29 | Trotter steps, and therefore `propagate` calls |
+| `observable-site` | 46 | site the measured number operator sits on |
+| `observable-spin` | `up` | spin of that operator |
+| `neel-start-spin` | `down` | spin on site 0 of the Néel initial state |
+| `cutoff` | 6 | maximum Majorana-string length kept |
+| `lower-atol` | 1e-4 | **the size knob** — prune coefficients below this |
+
+### `pauli` — kicked Ising on an IBM Eagle heavy-hex lattice
+
+Heisenberg picture only. One circuit layer per `num-layers`, so all four operations fit.
+
+| `--pauli-…` | default | what it does |
+| --- | --- | --- |
+| `num-qubits` | 127 | heavy-hex lattice size |
+| `num-layers` | 20 | kicked-Ising layers |
+| `observable-qubit` | 62 | qubit the measured `Z` sits on |
+| `theta` | π/4 | single-qubit X-rotation angle |
+| `coupling` | π/4 | two-qubit ZZ coupling angle |
+| `cutoff` | 8 | maximum Pauli-string weight kept |
+| `lower-atol` | 1e-4 | **the size knob** |
+
+### `random` — random Majorana generators
+
+The only model with both pictures. Its options carry no model prefix.
+
+| option | default | what it does |
+| --- | --- | --- |
+| `--num-generators` | 100 | random generators, i.e. circuit gates |
+| `--num-modes` | 128 | fermionic modes |
+| `--gen-length` | 4 | Majorana operators per generator |
+| `--obs-terms` | 10000 | **the size knob** — terms in the observable |
+| `--cutoff` | 6 | truncation cutoff |
+| `--seed` | 0 | random seed; the term count is only reproducible at a fixed seed |
+
+The Schrödinger rungs set `schrodinger_cutoff = cutoff + 2`. Its cap is lower than the
+Heisenberg one at the same knobs, so calibrate the two separately rather than assuming they match.
+
+### Why `lower_atol` is the size knob
+
+At the default `lower_atol = 1e-4` both fixed models are saturated in their other axes:
+`--hubbard-cutoff` is flat from 10 and `--hubbard-num-sites` flat from 60, so sweeping either
+measures nothing. Tightening `lower_atol` is the only axis that reaches 100M terms and beyond.
+
+Shrinking a model needs its observable index too — `--hubbard-observable-site` defaults to 46 and
+`--pauli-observable-qubit` to 62, so a smaller lattice must move the observable or the build
+fails with an index past the end.
+
+## Geometry
+
+Three numbers, and one derived:
+
+- **`nodes`** — compute nodes in the allocation.
+- **`ranks_per_node`** — MPI ranks per node. `ranks = nodes × ranks_per_node`.
+- **`partitions`** — engine partitions per rank, one thread each.
+- **`P = ranks × partitions`** is the flat world the engine sees, and the number that matters:
+  phase shares are a function of `P`, not of the code. The same change can look like a win at
+  `P=128` and a loss at `P=4096`, so a result quoted without its geometry says little.
+
+`ranks_per_node × partitions` should equal the node's physical core count. The two layouts the
+scaling rungs were taken at are `1 × 128` (one rank spanning the node) and `8 × 16` (one rank per
+NUMA domain on a dual EPYC 7742).
+
+The runner exports `monoprop_PARTITIONS` and `monoprop_NUM_THREADS` from the row; you supply the
+ranks through `srun`. The gate checks that what actually ran matches the row, so a mismatch fails
+the cell rather than producing a mislabelled number.
+
+## Running one rung locally
+
+Single-rank rungs (`ranks_per_node = 1`) need no MPI:
+
+```bash
+monoprop-bench-rung benches/rungs.toml st-10m-hubbard-propagate --rep 1 --results runs
+```
+
+On a login or shared node, cap the threads first. `nproc` reports the whole machine, not your
+share, and an uncapped construction phase will fail with `Resource temporarily unavailable`:
+
+```bash
+export monoprop_NUM_THREADS=4 OMP_NUM_THREADS=4
+```
+
+Anything past the smallest rungs wants a compute node.
+
+## Slurm
+
+The launcher is not in this repository — these are examples to adapt, not a supported script.
+Substitute your own account, partition and module names.
+
+### One rung on one node
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=monoprop-rung
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=8         # = ranks_per_node
+#SBATCH --cpus-per-task=16          # = partitions
+#SBATCH --exclusive
+#SBATCH --time=0:20:00
+
+set -euo pipefail
+
+RUNG=n1-100m-hubbard-propagate
+REPS=10
+RESULTS="$SLURM_SUBMIT_DIR/runs/$RUNG"
+mkdir -p "$RESULTS"
+
+module load foss/2025b                  # your MPI + GCC >= 14 toolchain
+source .venv/bin/activate
+
+for rep in $(seq 1 "$REPS"); do
+  srun --cpu-bind=cores --distribution=block:block \
+    monoprop-bench-rung benches/rungs.toml "$RUNG" --rep "$rep" --results "$RESULTS" || true
+done
+
+monoprop-bench-ladder benches/rungs.toml "$RESULTS"
+```
+
+Each rep is a separate `srun`, and that is deliberate: `pytest-benchmark`'s `pedantic` builds
+round *k+1*'s arguments before releasing round *k*'s, so a second timing round inside one process
+holds two propagators and doubles peak RSS. The runner forces `--bench-rounds=1` for that reason.
+Repetition has to come from repeated process launches.
+
+The `|| true` is what keeps a refused rep from taking the rest of the job with it under `set -e`;
+one refusal is not a reason to lose the other nine. `monoprop-bench-ladder` skips refused
+artifacts and reports how many reps it actually found, so a partial run is still readable. Drop
+the `|| true` if you would rather the job stop on the first refusal — but read the message either
+way, because it names exactly which check failed.
+
+### One rung across many nodes
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=monoprop-strong
+#SBATCH --nodes=8
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=16
+#SBATCH --exclusive
+#SBATCH --time=1:15:00
+```
+
+The body is identical — `srun` inherits the node count, and the runner reads `nodes` from the row
+only to check that it matches. Confirm with `--dry-run` before submitting: it prints the derived
+`R` and `P` alongside the declared cost, which is the cheapest place to catch a wrong geometry.
+
+### A ladder in one allocation
+
+Rungs sharing a node count can share a job. Keep one results directory per rung so the
+artifacts stay separable:
+
+```bash
+for rung in strong-1569m-n8 strong-6126m-n8 strong-24420m-n8; do
+  for rep in $(seq 1 5); do
+    srun --cpu-bind=cores --distribution=block:block \
+      monoprop-bench-rung benches/rungs.toml "$rung" --rep "$rep" --results "runs/$rung" || true
+  done
+done
+monoprop-bench-ladder benches/rungs.toml runs --family strong
+```
+
+### Things that quietly cost you
+
+Measured on Deucalion (AMD EPYC 7742, 128 physical cores per node, SMT off). The numbers are
+that machine's; the failure modes are not.
+
+- **Let Slurm do the pinning.** `--cpu-bind=none` measured a 1.45x penalty against
+  `--cpu-bind=cores`. A Slurm cgroup with no pinning at all still beat the engine placing threads
+  over an unconfined mask, so the engine's own placement is not a substitute.
+- **Keep `ranks × partitions` an exact divisor of the cores.** Above the core count, thread
+  placement falls back to unpinned silently — no warning, just a slower run. Involuntary context
+  switches are the tell: they jumped by four orders of magnitude when pinning was lost.
+- **Leave `MALLOC_ARENA_MAX` alone.** Setting it to the partition count cost ~16% of wall, because
+  the rank runs more threads than partitions and they then contend for too few arenas.
+- **`--exclusive`, always.** A shared node makes the timing a measurement of your neighbour.
+- **Add `-s` if you are debugging a crash.** pytest's fd capture swallows the C++ layer's stderr,
+  so a run can look like it produced nothing when it in fact printed the reason.
+
+### Sizing an allocation
+
+Peak resident memory over the 38 scaling rungs fits
+
+```
+GiB/node = 3.39 + 0.0634 × Mterms/node
+```
+
+within −2.9/+4.5 GiB/node of the line. Use it to pick a node count, not to predict a rung: it is
+a fit over one campaign on one machine, and `cost_gib_per_node` on the row itself is the better
+number where a row has one.
+
+`build_graph` does not obey it. It *extends* the graph rather than replacing it, retaining one
+layer-set per gate, while `propagate` releases each layer as it contracts. Hubbard reaches 97M
+terms through `propagate` in well under 2 GiB, yet four successive `build_graph` calls on the same
+model exceed a 242 GiB node. That is why the graph-holding rungs stop at a single node.
+
+## Reporting the result
+
+```bash
+monoprop-bench-ladder benches/rungs.toml runs
+```
+
+prints two things: a table per family, and a `## Problems measured` section listing each rung's
+resolved parameters. Paste both. Read the median and the min — these distributions are skewed, so
+a mean tracks stragglers rather than the cost of the work.
+
+`vs declared` compares your median to the row's `cost_seconds`. Treat it as context, not a verdict:
+it may have been taken on other hardware, at another commit, under another Slurm configuration.
+If your run *is* the new reference, update `cost_seconds` and `cost_gib_per_node` in the row and
+say in the pull request which machine and commit they came from.
+
+## Calibrating an uncalibrated row
+
+A `TBD` row cannot run, so measure it before you fill it in:
+
+1. Copy the row into a scratch table, replace `TBD` with your candidate knob value and set
+   `expect_terms` to something deliberately wrong.
+2. Run one rep. The gate refuses it and prints the term count it actually measured.
+3. Put that number in `expect_terms`, and the knob value in `args`. Run again; it should pass.
+4. Fill in `cost_seconds` and `cost_gib_per_node` from the ladder, and open a pull request with
+   the row and the machine it was measured on.
+
+Step 2 is not a workaround. Reading the count off a refusal is how the gate is meant to be used,
+and it means a calibrated row has been seen to pass at least once.

--- a/benches/RUNGS.md
+++ b/benches/RUNGS.md
@@ -458,6 +458,108 @@ predicting 224 s, 436 s and 216 s against 215.6, 471.0 and 249.6 measured.
 The `1.82e-07` row is the one exception to the memory law in the whole campaign: 84.3 GiB/node
 against 97.1 predicted, identically on all five reps. Reproducible and unexplained.
 
+### Every model at its defaults
+
+One process, 8 threads, on a shared login node with a **20 GiB** per-user memory cap. Timings
+here are indicative only — they are not a compute node and not pinned. Terms are exact and
+reproducible; peak RSS is a real kernel `VmHWM`; `> 20 GiB` means the cell was killed at that cap,
+which is a lower bound, not the model's requirement. A 242 GiB compute node goes much further.
+
+| model | operation | terms | peak RSS | time |
+| --- | --- | ---: | ---: | ---: |
+| hubbard | `propagate` | 1,169,024 | 465 MiB | 3.5 s |
+| hubbard | `build_graph` | — | **> 20 GiB** | — |
+| hubbard | `energy` | — | **> 20 GiB** | — |
+| hubbard | `gradient` | — | **> 20 GiB** | — |
+| pauli | `propagate` | 223,372 | 400 MiB | 823 ms |
+| pauli | `build_graph` | 223,372 | 429 MiB | 1.0 s |
+| pauli | `energy` | 223,372 | 434 MiB | 191 ms |
+| pauli | `gradient` | 223,372 | 864 MiB | 910 ms |
+| random / heisenberg | `propagate` | 70,336 | 385 MiB | 11 ms |
+| random / heisenberg | `build_graph` | 70,336 | 388 MiB | 13 ms |
+| random / heisenberg | `energy` | 70,336 | 384 MiB | 1 ms |
+| random / heisenberg | `gradient` | 70,336 | 383 MiB | 2 ms |
+| random / schrodinger | `propagate` | 11,167,248 | 1.73 GiB | 5.0 s |
+| random / schrodinger | `build_graph` | 11,167,248 | 1.99 GiB | 4.7 s |
+| random / schrodinger | `energy` | 11,167,248 | 1.72 GiB | 391 ms |
+| random / schrodinger | `gradient` | 11,167,248 | 1.81 GiB | 814 ms |
+
+The defaults are not a ladder — they differ by 160x in size. `random` in the Schrödinger picture
+is 159x its own Heisenberg size at identical knobs, because `schrodinger_cutoff = cutoff + 2`
+admits two more Majorana lengths. And the three hubbard rows that hold a graph all died: at the
+default configuration only `propagate` fits in 20 GiB.
+
+### Size knob against cost
+
+Same login node and caveats. `B/term` is the crude ratio including the ~380 MiB process floor,
+which is why it looks enormous at small sizes; the marginal figures below are the transferable ones.
+
+| model / operation | knobs | terms | peak RSS | time |
+| --- | --- | ---: | ---: | ---: |
+| `hubbard` / `propagate` | `cutoff=10, lower_atol=1e-03` | 20,758 | 377 MiB | 1.6 s |
+| | `lower_atol=3e-04` | 222,705 | 394 MiB | 1.7 s |
+| | `lower_atol=1e-04` | 1,887,255 | 542 MiB | 4.7 s |
+| | `lower_atol=5e-05` | 7,156,480 | 997 MiB | 13.1 s |
+| | `lower_atol=3e-05` | 18,873,340 | 1.47 GiB | 43.2 s |
+| `hubbard` / `build_graph` | `cutoff=10, lower_atol=1e-03, steps=2` | 139,674,993 | 12.68 GiB | 35.0 s |
+| | `lower_atol=3e-04, steps=2` | — | **> 20 GiB** | — |
+| `pauli` / `propagate` | `cutoff=14, lower_atol=1e-03` | 515,102 | 441 MiB | 1.1 s |
+| | `lower_atol=3e-04` | 5,129,772 | 818 MiB | 6.2 s |
+| | `lower_atol=1e-04` | 30,992,523 | 3.06 GiB | 48.4 s |
+| | `lower_atol=5e-05` | 91,273,861 | 7.16 GiB | 157.6 s |
+| `pauli` / `build_graph` | `cutoff=14, lower_atol=1e-03` | 515,102 | 458 MiB | 1.3 s |
+| | `lower_atol=3e-04` | 5,129,772 | 1002 MiB | 7.4 s |
+| | `lower_atol=1e-04` | 30,992,523 | 4.23 GiB | 63.2 s |
+
+That last `pauli` row is the calibrated `n1-100m-pauli-propagate` rung: 91,273,861 terms at
+`cutoff=14, lower_atol=5e-05`, which is where the table's `expect_terms` for it comes from.
+
+### Marginal cost per term
+
+Least-squares slope of peak RSS against term count over each ladder above, which removes the
+process floor and is the number that transfers between machines.
+
+| model / operation | marginal B/term | floor |
+| --- | ---: | ---: |
+| `hubbard` / `propagate` | 63.2 | 424 MiB |
+| `pauli` / `propagate` | 79.4 | 510 MiB |
+| `pauli` / `build_graph` | 134.0 | 371 MiB |
+| `random` / `propagate` (heisenberg) | 134.3 | 375 MiB |
+| `random` / `build_graph` (heisenberg) | 149.6 | 378 MiB |
+| `random` / `energy` (heisenberg) | 141.2 | 379 MiB |
+| `random` / `gradient` (heisenberg) | 144.6 | 379 MiB |
+
+Hubbard's 63.2 B/term here against the 68.0 B/term fitted over 38 compute-node rungs is the one
+independent check available on any of this: two machines, two partition counts, two harnesses,
+7% apart. Take the per-term costs as good to roughly that.
+
+`build_graph` costs about 1.7x `propagate` per term on `pauli` (134.0 against 79.4). On `hubbard`
+the ratio is far worse, because the graph retains a layer-set per Trotter step rather than per
+gate — which is what puts the hubbard graph rows out of reach entirely.
+
+### The random model's observable multiplier
+
+`--obs-terms` sets the observable's size; what gets propagated is larger. At 1000 gates, 250 modes
+and cutoff 6 the ratio is flat across the range measured:
+
+| `--obs-terms` | propagated terms | ratio |
+| ---: | ---: | ---: |
+| 100 | 3,319 | ×33.2 |
+| 1,000 | 33,315 | ×33.3 |
+| 5,000 | 166,367 | ×33.3 |
+| 20,000 | 661,545 | ×33.1 |
+
+So to calibrate a random rung, **start at `obs_terms ≈ target / 33`**: about 300,000 for 10M
+terms, 3,000,000 for 100M, 30,000,000 for 1B. Those are extrapolations from a range topping out at
+0.66M terms — three orders of magnitude below the largest target — and truncation at the cutoff may
+bend the ratio well before then. They are a starting point for the calibration loop, not values to
+put in `expect_terms`.
+
+The Schrödinger picture is a different matter. At 1000 gates and 250 modes it exceeded 20 GiB at
+**every** observable size tried, `obs_terms=100` included, so its cost is driven by the generator
+count and the mode count rather than by the observable. Calibrate it on a compute node and expect
+its ladder to need far more memory than the Heisenberg one at the same knobs.
+
 ## Reporting the result
 
 ```bash

--- a/benches/bench_models.py
+++ b/benches/bench_models.py
@@ -25,10 +25,8 @@ Run one group per pytest process: build_graph/propagate and energy/gradient do n
 from __future__ import annotations
 
 import os
-from typing import Any
 
 import pytest
-from monoprop_bench_tools.memory.cpu import resting_rss_bytes
 from monoprop_bench_tools.models import MODELS, barrier_setup, barriered
 
 # `build_graph` extends the graph, so a driver that re-applies its circuit retains one layer-set per step
@@ -43,47 +41,6 @@ def skip_if_graph_will_not_fit(model: str, steps: int) -> None:
             f"{model}: {steps} successive build_graph calls retain {steps} layer-sets, "
             f"measured to exceed 242 GiB. Set monoprop_BENCH_ALLOW_BIG_GRAPH=1 to run it."
         )
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("model", list(MODELS))
-def test_model(
-    benchmark,
-    bench_comm,
-    model_configs,
-    model,
-    record_model_config,
-    record_model_stats,
-):
-    """Benchmark a fixed in-place model simulation (Heisenberg picture)."""
-    _config_cls, build_fn, steps_fn = MODELS[model]
-    config = model_configs[model]
-    steps = steps_fn(config)
-    record_model_config(model, config)
-
-    state: dict[str, Any] = {}
-
-    def setup():
-        state["baseline_rss"] = resting_rss_bytes()
-        state["built"] = build_fn(config, comm=bench_comm)
-        return (state["built"], steps), {}
-
-    def run(built, n_steps):
-        propagator, circuit = built
-        for _ in range(n_steps):
-            propagator.propagate(circuit)
-        return propagator.expectation_value()
-
-    result = benchmark.pedantic(
-        barriered(run, bench_comm),
-        setup=barrier_setup(bench_comm, setup),
-        rounds=1,
-        iterations=1,
-    )
-    assert isinstance(result, float)
-
-    propagator, _circuit = state["built"]
-    record_model_stats(model, propagator, state["baseline_rss"])
 
 
 @pytest.mark.slow

--- a/benches/bench_random.py
+++ b/benches/bench_random.py
@@ -18,9 +18,6 @@ from __future__ import annotations
 
 from monoprop_bench_tools.models import barrier_setup, barriered
 
-PARE_THRESHOLD = 1e-10
-INPLACE_LOWER_ATOL = 1e-5
-
 
 def test_random_build_graph(
     benchmark,
@@ -85,22 +82,6 @@ def test_random_propagate(
     assert record_opsize(last[0]) > 0
 
 
-def test_random_pare(benchmark, built_graph, bench_comm, bench_rounds):
-    """Benchmark paring the graph."""
-
-    def pare():
-        return built_graph.expectation_value_and_gradient_functional(
-            pare_threshold=PARE_THRESHOLD,
-        )
-
-    benchmark.pedantic(
-        barriered(pare, bench_comm),
-        setup=barrier_setup(bench_comm),
-        rounds=bench_rounds,
-        iterations=1,
-    )
-
-
 def test_random_energy(
     benchmark, built_graph, random_problem, bench_comm, bench_rounds, op_memory
 ):
@@ -140,23 +121,3 @@ def test_random_gradient(
     )
     op_memory.close(built_graph)
     assert len(gradient) == len(random_problem.parameters)
-
-
-def test_random_inplace(benchmark, make_random_propagator, bench_comm, bench_rounds):
-    """Benchmark in-place evolution + expectation value (no graph stored)."""
-
-    def setup():
-        return (make_random_propagator(lower_atol=INPLACE_LOWER_ATOL),), {}
-
-    def run(built):
-        propagator, circuit = built
-        propagator.propagate(circuit)
-        return propagator.expectation_value()
-
-    result = benchmark.pedantic(
-        barriered(run, bench_comm),
-        setup=barrier_setup(bench_comm, setup),
-        rounds=bench_rounds,
-        iterations=1,
-    )
-    assert isinstance(result, float)

--- a/benches/conftest.py
+++ b/benches/conftest.py
@@ -45,11 +45,7 @@ from typing import TYPE_CHECKING, Any
 
 import psutil
 import pytest
-from monoprop_bench_tools.memory.cpu import (
-    HighWaterMark,
-    pinned_thread_summary,
-    resting_rss_bytes,
-)
+from monoprop_bench_tools.memory.cpu import HighWaterMark, pinned_thread_summary
 from monoprop_bench_tools.models import (
     MODELS,
     RandomProblem,
@@ -143,8 +139,6 @@ _RESULTS: dict[str, Any] = {
     "memhwm": {},  # node id -> summed peak RSS, whole test, setup() included
     "memhwm_max": {},  # node id -> worst-rank peak RSS, whole test, setup() included
     "opsize": {},  # picture / model / node id -> {"terms": n}
-    "memrest": {},  # picture / model -> resting RSS bytes
-    "membase": {},  # fixed model -> resting RSS bytes before the model is built
     "configs": {},  # fixed model -> config dataclass fields
     "opmem": {},  # fixed model -> per-field operator memory split (bytes)
     # Timed call only (see ``OpMemory``), each {"sum", "max"}.
@@ -348,10 +342,8 @@ def record_model_config() -> Callable[[str, Any], None]:
     return _do
 
 
-def _record_model_stats(
-    comm: Any, key: str, propagator: Any, baseline_rss: int | None = None
-) -> None:
-    """Record term count, operator memory breakdown and footprint under ``key``."""
+def _record_model_stats(comm: Any, key: str, propagator: Any) -> None:
+    """Record term count and operator memory breakdown under ``key``."""
     _record("opsize", key, {"terms": _reduce_sum(comm, propagator.size())})
 
     # Placement is only observable while the propagator's threads are alive.
@@ -365,25 +357,6 @@ def _record_model_stats(
             key,
             {k: _reduce_sum(comm, v) for k, v in breakdown().items()},
         )
-
-    resting = _reduce_sum(comm, resting_rss_bytes())
-    if resting:  # 0 => /proc unavailable; skip rather than record 0 MiB
-        _record("memrest", key, resting)
-
-    if baseline_rss is not None:
-        baseline = _reduce_sum(comm, baseline_rss)
-        if baseline:
-            _record("membase", key, baseline)
-
-
-@pytest.fixture
-def record_model_stats(bench_comm: Any) -> Callable[..., None]:
-    """Return ``record(model, propagator, baseline_rss)`` for fixed-model runs."""
-
-    def _do(model: str, propagator: Any, baseline_rss: int) -> None:
-        _record_model_stats(bench_comm, model, propagator, baseline_rss)
-
-    return _do
 
 
 class OpMemory:
@@ -541,10 +514,8 @@ def built_graph(
     """Return a propagator whose graph has been built (no coefficients contracted).
 
     Session-scoped per picture so the graph is built once and shared across the
-    read-only graph benchmarks (``pare``, ``energy``, ``gradient``).
-
-    Also records the operator size and resting footprint for this picture while the
-    graph is resident.
+    read-only graph benchmarks (``energy``, ``gradient``), and records the operator
+    size for this picture while the graph is resident.
     """
     mp, circuit = build_random_propagator(
         random_problem, comm=bench_comm, schrodinger=picture == "schrodinger"
@@ -553,12 +524,6 @@ def built_graph(
 
     # Under MPI the operator is partitioned, so sum the partitions.
     _record("opsize", picture, {"terms": _reduce_sum(bench_comm, mp.size())})
-
-    # Settled RSS once the build's transients are released -- the persistent
-    # footprint the per-operation peak cannot see.
-    resting = _reduce_sum(bench_comm, resting_rss_bytes())
-    if resting:  # 0 => /proc unavailable; skip rather than record 0 MiB
-        _record("memrest", picture, resting)
 
     return mp
 

--- a/benches/results/README.md
+++ b/benches/results/README.md
@@ -8,3 +8,11 @@ produced and combined.
 
 These files should **NOT** be added to the repo — only this `README.md` is
 tracked (see the `benches/results/**` rule in the top-level `.gitignore`).
+
+## Sections nothing here renders
+
+`<label>.json` carries more than `monoprop-bench-report` and `monoprop-bench-bmf`
+read. The operator-memory ledger — `opbytes`, `opmem`, `opmembreak`, `opmemdelta`,
+`opmempeak`, `opmembase` — is written for out-of-tree A/B tooling that attributes a
+memory change to a structure. It is unrendered, not dead: deleting it because no
+reader is visible from here breaks that tooling silently.

--- a/benches/rungs.toml
+++ b/benches/rungs.toml
@@ -1,0 +1,1048 @@
+# THE RUNG LADDER. One row per cell of monoprop's benchmark set.
+#
+# This table, not a loop and not a shell script, is what "the benchmark" means. Putting it
+# here is the point: a campaign cannot quietly run a different grid, two campaigns' numbers
+# are comparable row for row, and a reader outside the machine that ran it can see exactly
+# what was measured.
+#
+# Run one rep of one rung with:
+#
+#     monoprop-bench-rung benches/rungs.toml <id> --rep N --results <dir>
+#
+# and collate a directory of them with `monoprop-bench-ladder`. Repetition is repeated
+# invocations, never `--bench-rounds`: pedantic builds round k+1's arguments before
+# releasing round k's, so a second round holds two propagators and doubles peak RSS.
+#
+# FIELDS
+#   id             unique; names the artifacts, so it is stable once a rung has been run
+#   family         size | strong | weak
+#   picture        heisenberg | schrodinger  (only the random model has this axis)
+#   model          random | hubbard | pauli
+#   ops            subset of build_graph, propagate, energy, gradient
+#   nodes          compute nodes; ranks = nodes x ranks_per_node, world P = ranks x partitions
+#   ranks_per_node MPI ranks per node
+#   partitions     engine partitions per rank
+#   args           `--<option>=<value>` passed to pytest verbatim; the size knobs live here.
+#                  A knob whose value is `TBD` is one nobody has measured yet, and it forces
+#                  the rung uncalibrated. It is spelled `TBD` rather than left at 0 because
+#                  0 is not neutral -- `lower_atol = 0` prunes nothing and is the LARGEST
+#                  problem the model can pose, so a placeholder 0 invites exactly the
+#                  allocation-burning run the gate exists to prevent.
+#   expect_terms   THE GATE. The exact term count this configuration produces. A result that
+#                  misses it by more than 0.1% is refused, so a mistyped tolerance fails the
+#                  cell instead of silently measuring a different problem. **0 means the row
+#                  has never been calibrated and refuses to run.**
+#   reps           reps to run. 10 is the floor where a sign test over a family of this size
+#                  can resolve a single cell; 5 is what the scaling ladders below were run at.
+#   cost_seconds       WHAT ONE REP COSTS: median wall seconds, last time it was measured.
+#   cost_gib_per_node  and peak resident GiB per node. Both are 0 where nobody has measured
+#                  them yet. They are documentation, not a gate -- a timing is noisy and a
+#                  machine is not the machine these were taken on. They are here so you can
+#                  see what a rung costs before you spend it, and so `monoprop-bench-ladder`
+#                  can print measured-against-declared without a second file to keep in sync.
+#   walltime       Slurm allowance for one rung, reps included
+#
+# SIZING
+#   The size knob is the coefficient tolerance, not the cutoff or the system size: at the
+#   default `lower_atol = 1e-4` both fixed models are saturated in cutoff and in size, so a
+#   sweep over either measures nothing. See benches/README.md.
+#
+#   The random model's knob is `--obs-terms`. Its multiplier to propagated terms was
+#   measured at ~4.1 for cutoff 6 with 100 generators; at 1000 generators it is not that,
+#   which is why every random row below starts uncalibrated.
+#
+# WHY THE GRAPH ROWS STOP WHERE THEY DO
+#   `build_graph` extends the graph rather than replacing it, so it retains one layer-set
+#   per gate while `propagate` releases each layer as it contracts. Measured on Hubbard:
+#   propagate reaches 97M terms in well under 2 GiB, while four successive build_graph
+#   calls exceed a 242 GiB node. So `propagate` carries the full 10M/100M/1B ladder and the
+#   graph-holding operations stop at what fits one node -- and that cap is a measurement to
+#   be taken, not a number to be assumed.
+
+
+# WHERE THE DECLARED COSTS COME FROM
+#   Deucalion x86, 2026-08-27; perf/linear-routing-on-wire tip c2554554, _core.so md5 1157a5e2b421fb8bd18fc6d16fa39778
+#   AMD EPYC 7742, 128 physical cores and 242.0 GiB usable per node, SMT off
+#   8 MPI ranks per node x 16 partitions per rank, --cpu-bind=cores --distribution=block:block, MALLOC_ARENA_MAX unset
+#
+#   Memory over that campaign fits GiB/node = 3.39 + 0.0634 * Mterms_per_node, over
+#   38 rungs, every rung within -2.9/+4.5 GiB/node of the line.
+#   One exception: weak-1529m-n64 measures 84.3 against 97.1 predicted, identically on all five reps, so it is reproducible and unexplained.
+#
+#   The size rungs below carry no declared cost: they have never been run.
+
+
+# ---------------------------------------------------------------- size: Heisenberg propagate
+#
+# 10M single thread, 100M and 1B on one node, 1B across eight. Three models, because they
+# differ in propagate call count: Hubbard calls it once per Trotter step (29) and kicked
+# Ising once, so a cost paid per call shows up on one and is invisible on the other.
+
+[[rung]]
+id = "st-10m-hubbard-propagate"
+family = "size"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 1
+partitions = 1
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+note = "calibrate lower_atol between 5e-5 (7.16M) and 2.5e-5 (26.6M) at cutoff 10"
+
+[[rung]]
+id = "st-10m-pauli-propagate"
+family = "size"
+picture = "heisenberg"
+model = "pauli"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 1
+partitions = 1
+args = ["--pauli-cutoff=12", "--pauli-lower-atol=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+note = "calibrate; cutoff 12 at 1e-4 gives 12.7M, so the tolerance moves a little up"
+
+[[rung]]
+id = "st-10m-random-propagate"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 1
+partitions = 1
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "n1-100m-hubbard-propagate"
+family = "size"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.25e-05"]
+expect_terms = 96981051
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:20:00"
+
+[[rung]]
+id = "n1-100m-pauli-propagate"
+family = "size"
+picture = "heisenberg"
+model = "pauli"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--pauli-cutoff=14", "--pauli-lower-atol=5e-05"]
+expect_terms = 91273861
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:20:00"
+
+[[rung]]
+id = "n1-100m-random-propagate"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:30:00"
+
+[[rung]]
+id = "n1-1b-hubbard-propagate"
+family = "size"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=TBD"]
+expect_terms = 0
+reps = 5
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+note = "calibrate between 3.9e-06 (782M) and 2.6e-06 (1569M)"
+
+[[rung]]
+id = "n1-1b-pauli-propagate"
+family = "size"
+picture = "heisenberg"
+model = "pauli"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--pauli-cutoff=14", "--pauli-lower-atol=TBD"]
+expect_terms = 0
+reps = 5
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "n1-1b-random-propagate"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 5
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "n8-1b-hubbard-propagate"
+family = "size"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=TBD"]
+expect_terms = 0
+reps = 5
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:25:00"
+note = "same tolerance as n1-1b-hubbard-propagate; the two share a strong-scaling pair"
+
+[[rung]]
+id = "n8-1b-pauli-propagate"
+family = "size"
+picture = "heisenberg"
+model = "pauli"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--pauli-cutoff=14", "--pauli-lower-atol=TBD"]
+expect_terms = 0
+reps = 5
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:25:00"
+
+[[rung]]
+id = "n8-1b-random-propagate"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 5
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:25:00"
+
+
+# ------------------------------------------------------- size: graph, gradient and energy
+#
+# Random model, 1000 gates, both pictures. build_graph runs on its own: it and the
+# energy/gradient pair each hold their own operator, and running all three in one process
+# holds two per rank.
+#
+# There is no 1B row here, single- or multi-node, and that is deliberate. The single-node
+# cap is the largest `--obs-terms` whose retained graph fits 242 GiB, and it is calibrated
+# per picture: Schrodinger runs at `cutoff + 2`, so its cap is lower than Heisenberg's and
+# must be measured rather than copied.
+
+[[rung]]
+id = "st-10m-random-graph-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["build_graph"]
+nodes = 1
+ranks_per_node = 1
+partitions = 1
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "st-10m-random-eval-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 1
+ranks_per_node = 1
+partitions = 1
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "st-10m-random-graph-schrodinger"
+family = "size"
+picture = "schrodinger"
+model = "random"
+ops = ["build_graph"]
+nodes = 1
+ranks_per_node = 1
+partitions = 1
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "st-10m-random-eval-schrodinger"
+family = "size"
+picture = "schrodinger"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 1
+ranks_per_node = 1
+partitions = 1
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "n1-cap-random-graph-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["build_graph"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:40:00"
+note = "cap = the largest obs-terms whose retained graph fits 242 GiB; measure it"
+
+[[rung]]
+id = "n1-cap-random-eval-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:40:00"
+
+[[rung]]
+id = "n1-cap-random-graph-schrodinger"
+family = "size"
+picture = "schrodinger"
+model = "random"
+ops = ["build_graph"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:40:00"
+
+[[rung]]
+id = "n1-cap-random-eval-schrodinger"
+family = "size"
+picture = "schrodinger"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "0:40:00"
+
+
+# ----------------------------------------------------- strong and weak scaling, Hubbard propagate
+#
+# The August 2026 scaling campaign, verbatim: same model, same layout, same tolerances and
+# the same expected term counts, so a re-run and the committed baseline share an axis. 38
+# rungs over 1 to 64 nodes (128 to 8192 cores) at 8 ranks/node x 16 partitions, so R = 8N
+# and P = 128N, one core per partition.
+#
+# Problem size is `--hubbard-lower-atol` at a fixed cutoff of 10, which is saturated there
+# (cutoffs 10/12/14 give 96.98M/105.79M/106.82M at 1.25e-05), so all growth comes from the
+# tolerance and every rung stays inside the same operator family. The eleven sizes form a
+# doubling sequence and both families are built from it, so a cell reached by two ladders is
+# exactly the same problem -- nine such cells agreed to within 1.24%, most within 0.2%,
+# which is a free check on the whole apparatus and the reason the sequence is shared.
+#
+# EXCLUSIONS ARE MEASUREMENTS. `strong-6126m` has no 1-node rung and `strong-24420m` none
+# below 8, because at 8 ranks/node the problem does not fit in that many nodes' memory:
+# GiB/node = 3.39 + 0.0634 x Mterms/node against a 242.0 GiB grant. That is why the rung
+# count is not simply six ladders times seven nodes.
+#
+# `MALLOC_ARENA_MAX` is deliberately left unset for these rungs. Pinning it costs about 16%
+# of wall when the arena count is below the partition count, so a ladder that exports it
+# measures the allocator rather than the engine.
+
+[[rung]]
+id = "weak-97m-n1"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.25e-05"]
+expect_terms = 96981051
+reps = 10
+cost_seconds = 10.75
+cost_gib_per_node = 10.8
+walltime = "0:20:00"
+
+[[rung]]
+id = "weak-97m-n2"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 2
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=8.8e-06"]
+expect_terms = 184124520
+reps = 10
+cost_seconds = 10.58
+cost_gib_per_node = 9.6
+walltime = "0:20:00"
+
+[[rung]]
+id = "weak-97m-n4"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 4
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=5.9e-06"]
+expect_terms = 377482074
+reps = 10
+cost_seconds = 13.13
+cost_gib_per_node = 11.5
+walltime = "0:20:00"
+
+[[rung]]
+id = "weak-97m-n8"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=3.9e-06"]
+expect_terms = 781669404
+reps = 10
+cost_seconds = 14.54
+cost_gib_per_node = 10.9
+walltime = "0:20:00"
+
+[[rung]]
+id = "weak-97m-n16"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 16
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 10
+cost_seconds = 18.11
+cost_gib_per_node = 11.0
+walltime = "0:20:00"
+
+[[rung]]
+id = "weak-97m-n32"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 32
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.73e-06"]
+expect_terms = 3104527573
+reps = 10
+cost_seconds = 24.39
+cost_gib_per_node = 11.0
+walltime = "0:25:00"
+
+[[rung]]
+id = "weak-97m-n64"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 64
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 10
+cost_seconds = 36.59
+cost_gib_per_node = 11.4
+walltime = "0:25:00"
+
+[[rung]]
+id = "weak-385m-n1"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=5.9e-06"]
+expect_terms = 377482074
+reps = 5
+cost_seconds = 47.71
+cost_gib_per_node = 26.6
+walltime = "0:25:00"
+
+[[rung]]
+id = "weak-385m-n2"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 2
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=3.9e-06"]
+expect_terms = 781669404
+reps = 5
+cost_seconds = 50.9
+cost_gib_per_node = 28.0
+walltime = "0:25:00"
+
+[[rung]]
+id = "weak-385m-n4"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 4
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 53.29
+cost_gib_per_node = 27.9
+walltime = "0:25:00"
+
+[[rung]]
+id = "weak-385m-n8"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.73e-06"]
+expect_terms = 3104527573
+reps = 5
+cost_seconds = 54.73
+cost_gib_per_node = 27.5
+walltime = "0:25:00"
+
+[[rung]]
+id = "weak-385m-n16"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 16
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 5
+cost_seconds = 58.03
+cost_gib_per_node = 27.4
+walltime = "0:25:00"
+
+[[rung]]
+id = "weak-385m-n32"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 32
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=7.35e-07"]
+expect_terms = 12255330837
+reps = 5
+cost_seconds = 64.64
+cost_gib_per_node = 26.3
+walltime = "0:25:00"
+
+[[rung]]
+id = "weak-385m-n64"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 64
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=4.68e-07"]
+expect_terms = 24419998198
+reps = 5
+cost_seconds = 79.89
+cost_gib_per_node = 26.9
+walltime = "0:30:00"
+
+[[rung]]
+id = "weak-1529m-n1"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 215.61
+cost_gib_per_node = 99.9
+walltime = "0:45:00"
+
+[[rung]]
+id = "weak-1529m-n2"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 2
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.73e-06"]
+expect_terms = 3104527573
+reps = 5
+cost_seconds = 222.27
+cost_gib_per_node = 100.2
+walltime = "0:45:00"
+
+[[rung]]
+id = "weak-1529m-n4"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 4
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 5
+cost_seconds = 224.04
+cost_gib_per_node = 101.2
+walltime = "0:45:00"
+
+[[rung]]
+id = "weak-1529m-n8"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=7.35e-07"]
+expect_terms = 12255330837
+reps = 5
+cost_seconds = 227.33
+cost_gib_per_node = 99.9
+walltime = "0:45:00"
+
+[[rung]]
+id = "weak-1529m-n16"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 16
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=4.68e-07"]
+expect_terms = 24419998198
+reps = 5
+cost_seconds = 235.55
+cost_gib_per_node = 101.8
+walltime = "0:45:00"
+
+[[rung]]
+id = "weak-1529m-n32"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 32
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.94e-07"]
+expect_terms = 48317129677
+reps = 5
+cost_seconds = 249.62
+cost_gib_per_node = 101.3
+walltime = "0:50:00"
+
+[[rung]]
+id = "weak-1529m-n64"
+family = "weak"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 64
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.82e-07"]
+expect_terms = 94684031363
+reps = 5
+cost_seconds = 257.05
+cost_gib_per_node = 84.3
+walltime = "0:55:00"
+
+[[rung]]
+id = "strong-1569m-n1"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 215.61
+cost_gib_per_node = 99.9
+walltime = "0:45:00"
+
+[[rung]]
+id = "strong-1569m-n2"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 2
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 105.91
+cost_gib_per_node = 51.5
+walltime = "0:30:00"
+
+[[rung]]
+id = "strong-1569m-n4"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 4
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 53.34
+cost_gib_per_node = 28.0
+walltime = "0:25:00"
+
+[[rung]]
+id = "strong-1569m-n8"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 28.58
+cost_gib_per_node = 15.9
+walltime = "0:20:00"
+
+[[rung]]
+id = "strong-1569m-n16"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 16
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 18.12
+cost_gib_per_node = 11.0
+walltime = "0:20:00"
+
+[[rung]]
+id = "strong-1569m-n32"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 32
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 16.13
+cost_gib_per_node = 6.6
+walltime = "0:20:00"
+
+[[rung]]
+id = "strong-1569m-n64"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 64
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=2.6e-06"]
+expect_terms = 1569152761
+reps = 5
+cost_seconds = 23.99
+cost_gib_per_node = 4.1
+walltime = "0:20:00"
+
+[[rung]]
+id = "strong-6126m-n2"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 2
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 5
+cost_seconds = 450.19
+cost_gib_per_node = 200.2
+walltime = "1:15:00"
+
+[[rung]]
+id = "strong-6126m-n4"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 4
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 5
+cost_seconds = 224.45
+cost_gib_per_node = 101.3
+walltime = "0:45:00"
+
+[[rung]]
+id = "strong-6126m-n8"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 5
+cost_seconds = 109.53
+cost_gib_per_node = 51.3
+walltime = "0:30:00"
+
+[[rung]]
+id = "strong-6126m-n16"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 16
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 5
+cost_seconds = 58.75
+cost_gib_per_node = 27.4
+walltime = "0:25:00"
+
+[[rung]]
+id = "strong-6126m-n32"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 32
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 5
+cost_seconds = 38.09
+cost_gib_per_node = 16.1
+walltime = "0:25:00"
+
+[[rung]]
+id = "strong-6126m-n64"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 64
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=1.14e-06"]
+expect_terms = 6125805627
+reps = 5
+cost_seconds = 36.95
+cost_gib_per_node = 11.4
+walltime = "0:20:00"
+
+[[rung]]
+id = "strong-24420m-n8"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=4.68e-07"]
+expect_terms = 24419998198
+reps = 5
+cost_seconds = 471.03
+cost_gib_per_node = 201.3
+walltime = "1:15:00"
+
+[[rung]]
+id = "strong-24420m-n16"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 16
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=4.68e-07"]
+expect_terms = 24419998198
+reps = 5
+cost_seconds = 235.19
+cost_gib_per_node = 101.8
+walltime = "0:45:00"
+
+[[rung]]
+id = "strong-24420m-n32"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 32
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=4.68e-07"]
+expect_terms = 24419998198
+reps = 5
+cost_seconds = 127.1
+cost_gib_per_node = 52.2
+walltime = "0:35:00"
+
+[[rung]]
+id = "strong-24420m-n64"
+family = "strong"
+picture = "heisenberg"
+model = "hubbard"
+ops = ["propagate"]
+nodes = 64
+ranks_per_node = 8
+partitions = 16
+args = ["--hubbard-cutoff=10", "--hubbard-lower-atol=4.68e-07"]
+expect_terms = 24419998198
+reps = 5
+cost_seconds = 79.58
+cost_gib_per_node = 26.9
+walltime = "0:30:00"

--- a/benches/rungs.toml
+++ b/benches/rungs.toml
@@ -51,13 +51,19 @@
 #   measured at ~4.1 for cutoff 6 with 100 generators; at 1000 generators it is not that,
 #   which is why every random row below starts uncalibrated.
 #
-# WHY THE GRAPH ROWS STOP WHERE THEY DO
+# THE GRAPH ROWS RUN THE SAME LADDER, AND SOME OF THEM MAY NOT FIT
 #   `build_graph` extends the graph rather than replacing it, so it retains one layer-set
 #   per gate while `propagate` releases each layer as it contracts. Measured on Hubbard:
 #   propagate reaches 97M terms in well under 2 GiB, while four successive build_graph
-#   calls exceed a 242 GiB node. So `propagate` carries the full 10M/100M/1B ladder and the
-#   graph-holding operations stop at what fits one node -- and that cap is a measurement to
-#   be taken, not a number to be assumed.
+#   calls exceed a 242 GiB node. At 1000 generators the retained layer count is an order of
+#   magnitude larger again.
+#
+#   So the graph and eval rows are declared at the same 10M / 100M / 1B / multinode-1B
+#   points as propagate, and calibration finds out which of them fit. A row that does not
+#   fit is a RESULT -- record the node count it needed, or that it exceeded the machine, in
+#   its `note` and leave it uncalibrated. That is a measurement of the graph path's cost.
+#   Replacing those rows with one unnamed "largest that fits" rung hid the question instead
+#   of answering it, and hid it behind an extrapolation from 100 generators at that.
 
 
 # WHERE THE DECLARED COSTS COME FROM
@@ -351,7 +357,7 @@ cost_gib_per_node = 0
 walltime = "1:00:00"
 
 [[rung]]
-id = "n1-cap-random-graph-heisenberg"
+id = "n1-100m-random-graph-heisenberg"
 family = "size"
 picture = "heisenberg"
 model = "random"
@@ -364,27 +370,10 @@ expect_terms = 0
 reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
-walltime = "0:40:00"
-note = "cap = the largest obs-terms whose retained graph fits 242 GiB; measure it"
+walltime = "1:00:00"
 
 [[rung]]
-id = "n1-cap-random-eval-heisenberg"
-family = "size"
-picture = "heisenberg"
-model = "random"
-ops = ["energy", "gradient"]
-nodes = 1
-ranks_per_node = 8
-partitions = 16
-args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
-expect_terms = 0
-reps = 10
-cost_seconds = 0
-cost_gib_per_node = 0
-walltime = "0:40:00"
-
-[[rung]]
-id = "n1-cap-random-graph-schrodinger"
+id = "n1-100m-random-graph-schrodinger"
 family = "size"
 picture = "schrodinger"
 model = "random"
@@ -397,10 +386,26 @@ expect_terms = 0
 reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
-walltime = "0:40:00"
+walltime = "1:00:00"
 
 [[rung]]
-id = "n1-cap-random-eval-schrodinger"
+id = "n1-100m-random-eval-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "n1-100m-random-eval-schrodinger"
 family = "size"
 picture = "schrodinger"
 model = "random"
@@ -413,7 +418,135 @@ expect_terms = 0
 reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
-walltime = "0:40:00"
+walltime = "1:00:00"
+
+[[rung]]
+id = "n1-1b-random-graph-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["build_graph"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "2:00:00"
+
+[[rung]]
+id = "n1-1b-random-graph-schrodinger"
+family = "size"
+picture = "schrodinger"
+model = "random"
+ops = ["build_graph"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "2:00:00"
+
+[[rung]]
+id = "n1-1b-random-eval-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "2:00:00"
+
+[[rung]]
+id = "n1-1b-random-eval-schrodinger"
+family = "size"
+picture = "schrodinger"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 1
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "2:00:00"
+
+[[rung]]
+id = "n8-1b-random-graph-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["build_graph"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "n8-1b-random-graph-schrodinger"
+family = "size"
+picture = "schrodinger"
+model = "random"
+ops = ["build_graph"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "n8-1b-random-eval-heisenberg"
+family = "size"
+picture = "heisenberg"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
+
+[[rung]]
+id = "n8-1b-random-eval-schrodinger"
+family = "size"
+picture = "schrodinger"
+model = "random"
+ops = ["energy", "gradient"]
+nodes = 8
+ranks_per_node = 8
+partitions = 16
+args = ["--num-generators=1000", "--num-modes=250", "--cutoff=6", "--obs-terms=TBD"]
+expect_terms = 0
+reps = 10
+cost_seconds = 0
+cost_gib_per_node = 0
+walltime = "1:00:00"
 
 
 # ----------------------------------------------------- strong and weak scaling, Hubbard propagate

--- a/benches/rungs.toml
+++ b/benches/rungs.toml
@@ -133,7 +133,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~10M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~300_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n1-100m-hubbard-propagate"
 family = "size"
@@ -181,7 +181,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "0:30:00"
-
+note = "calibrate for ~100M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~3_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n1-1b-hubbard-propagate"
 family = "size"
@@ -230,7 +230,7 @@ reps = 5
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n8-1b-hubbard-propagate"
 family = "size"
@@ -291,7 +291,7 @@ walltime = "0:25:00"
 # cap is the largest `--obs-terms` whose retained graph fits 242 GiB, and it is calibrated
 # per picture: Schrodinger runs at `cutoff + 2`, so its cap is lower than Heisenberg's and
 # must be measured rather than copied.
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "st-10m-random-graph-heisenberg"
 family = "size"
@@ -307,7 +307,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~10M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~300_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "st-10m-random-eval-heisenberg"
 family = "size"
@@ -323,7 +323,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~10M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~300_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "st-10m-random-graph-schrodinger"
 family = "size"
@@ -339,7 +339,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~10M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~300_000 and read the true count off the gate's refusal; Schrodinger cost is driven by gates and modes, not obs_terms -- expect far more memory"
 [[rung]]
 id = "st-10m-random-eval-schrodinger"
 family = "size"
@@ -355,7 +355,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~10M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~300_000 and read the true count off the gate's refusal; Schrodinger cost is driven by gates and modes, not obs_terms -- expect far more memory"
 [[rung]]
 id = "n1-100m-random-graph-heisenberg"
 family = "size"
@@ -371,7 +371,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~100M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~3_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n1-100m-random-graph-schrodinger"
 family = "size"
@@ -387,7 +387,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~100M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~3_000_000 and read the true count off the gate's refusal; Schrodinger cost is driven by gates and modes, not obs_terms -- expect far more memory"
 [[rung]]
 id = "n1-100m-random-eval-heisenberg"
 family = "size"
@@ -403,7 +403,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~100M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~3_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n1-100m-random-eval-schrodinger"
 family = "size"
@@ -419,7 +419,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~100M terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~3_000_000 and read the true count off the gate's refusal; Schrodinger cost is driven by gates and modes, not obs_terms -- expect far more memory"
 [[rung]]
 id = "n1-1b-random-graph-heisenberg"
 family = "size"
@@ -435,7 +435,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "2:00:00"
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n1-1b-random-graph-schrodinger"
 family = "size"
@@ -451,7 +451,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "2:00:00"
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal; Schrodinger cost is driven by gates and modes, not obs_terms -- expect far more memory"
 [[rung]]
 id = "n1-1b-random-eval-heisenberg"
 family = "size"
@@ -467,7 +467,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "2:00:00"
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n1-1b-random-eval-schrodinger"
 family = "size"
@@ -483,7 +483,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "2:00:00"
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal; Schrodinger cost is driven by gates and modes, not obs_terms -- expect far more memory"
 [[rung]]
 id = "n8-1b-random-graph-heisenberg"
 family = "size"
@@ -499,7 +499,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n8-1b-random-graph-schrodinger"
 family = "size"
@@ -515,7 +515,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal; Schrodinger cost is driven by gates and modes, not obs_terms -- expect far more memory"
 [[rung]]
 id = "n8-1b-random-eval-heisenberg"
 family = "size"
@@ -531,7 +531,7 @@ reps = 10
 cost_seconds = 0
 cost_gib_per_node = 0
 walltime = "1:00:00"
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal"
 [[rung]]
 id = "n8-1b-random-eval-schrodinger"
 family = "size"
@@ -571,7 +571,7 @@ walltime = "1:00:00"
 # `MALLOC_ARENA_MAX` is deliberately left unset for these rungs. Pinning it costs about 16%
 # of wall when the arena count is below the partition count, so a ladder that exports it
 # measures the allocator rather than the engine.
-
+note = "calibrate for ~1B terms: measured x33 obs->propagated at 1000 gates/250 modes/cutoff 6, so start at obs_terms~30_000_000 and read the true count off the gate's refusal; Schrodinger cost is driven by gates and modes, not obs_terms -- expect far more memory"
 [[rung]]
 id = "weak-97m-n1"
 family = "weak"

--- a/docs/content/docs/benchmarks.mdx
+++ b/docs/content/docs/benchmarks.mdx
@@ -352,6 +352,10 @@ releases each layer as it contracts -- Hubbard reaches 97M terms in well under 2
 Running a rung needs a machine, a scheduler and an allocation, none of which belong in this
 repository. The table, the runner and the gate are here; the launcher that submits them is not.
 
+`benches/RUNGS.md` is the operator's guide: every model's parameters and what they do, how the
+geometry maps onto a machine, example Slurm scripts, the pinning and allocation-sizing traps, and
+how to calibrate a row nobody has measured.
+
 ### Scaling
 
 Node scaling of Hubbard `propagate` in the shipped default configuration, 1 to 64 nodes (128 to

--- a/docs/content/docs/benchmarks.mdx
+++ b/docs/content/docs/benchmarks.mdx
@@ -343,11 +343,15 @@ Sizes come from the coefficient tolerance, not from the cutoff or the system siz
 `lower_atol = 1e-4` both fixed models are saturated in both, so a sweep over either measures
 nothing.
 
-`propagate` carries the full ladder to a billion terms; `build_graph`, `energy` and `gradient`
-stop at what fits a single node. That is a measurement, not a convention. `build_graph` extends
-the graph rather than replacing it, so it retains one layer-set per gate while `propagate`
-releases each layer as it contracts -- Hubbard reaches 97M terms in well under 2 GiB through
-`propagate`, while four successive `build_graph` calls on the same model exceed a 242 GiB node.
+Every operation runs the same 10M / 100M / 1B / multinode-1B ladder, and some of the graph rungs
+may not fit. `build_graph` extends the graph rather than replacing it, so it retains one
+layer-set per gate while `propagate` releases each layer as it contracts -- Hubbard reaches 97M
+terms in well under 2 GiB through `propagate`, while four successive `build_graph` calls on the
+same model exceed a 242 GiB node, and at 1000 generators the retained layer count is an order of
+magnitude larger again. Which of the graph rungs fit is therefore a question calibration answers,
+not one the table should pre-empt: a row that does not fit records the node count it needed, or
+that it exceeded the machine, and stays uncalibrated. That is itself a measurement of what the
+graph path costs.
 
 Running a rung needs a machine, a scheduler and an allocation, none of which belong in this
 repository. The table, the runner and the gate are here; the launcher that submits them is not.

--- a/docs/content/docs/benchmarks.mdx
+++ b/docs/content/docs/benchmarks.mdx
@@ -269,16 +269,20 @@ monoprop_NUM_THREADS=10 just bench serial-t10  # cap the partition count
 uv run --group bench monoprop-bench-report benches/results  # rebuild report, no re-run
 ```
 
-The suite contains two benchmark groups:
+Both groups measure the same four operations -- `build_graph`, `propagate`, `energy` and
+`gradient` -- so a number means the same thing whichever problem produced it:
 
-- `bench_random.py` measures `build_graph`, `pare`, `energy`, `gradient`, and `inplace` on a random
-  problem. Configurable with `--gen-length` (4), `--obs-terms` (10000), `--num-generators`
+- `bench_random.py` runs them on a random problem, in both the Heisenberg and the Schrödinger
+  picture. Configurable with `--gen-length` (4), `--obs-terms` (10000), `--num-generators`
   (100), `--num-modes` (128), `--cutoff` (6), `--seed` (0) and `--bench-rounds` (1); defaults in
   parentheses.
-- `bench_models.py` measures two fixed models marked `slow`: a 120-qubit Fermi-Hubbard 29-step Trotter
-  run (`test_model[hubbard]`) and a 127-qubit kicked-Ising run over 20 layers
-  (`test_model[pauli]`). Override any config field with `--<model>-<field>`, e.g.
-  `--pauli-num-layers 30`; `just bench --help` lists them all.
+- `bench_models.py` runs them on two fixed models marked `slow`, Heisenberg only: a 120-qubit
+  Fermi-Hubbard 29-step Trotter run (`[hubbard]`) and a 127-qubit kicked-Ising run over 20 layers
+  (`[pauli]`). Override any config field with `--<model>-<field>`, e.g. `--pauli-num-layers 30`;
+  `just bench --help` lists them all.
+
+Run one group per process at scale: `build_graph`/`propagate` and `energy`/`gradient` each hold
+their own operator, and running all four together holds two per rank.
 
 Each run writes pytest-benchmark timings to `results/time-<label>.json` and the remaining metrics
 to `<label>.json`. `monoprop-bench-report` combines all labels in `results/REPORT.md`.
@@ -295,6 +299,170 @@ just bench-build-mpi                           # build once (MPI on)
 monoprop_NUM_THREADS=2 just bench-mpi r5t2 5 --map-by slot:PE=2 --bind-to core
 ```
 
+### Rungs
+
+The default sizes above fit a laptop and a CI runner. The sizes the library is actually used at
+do not, and a benchmark set that exists only as flags in someone's shell script cannot be
+reviewed, reproduced or compared across campaigns. `benches/rungs.toml` is therefore the
+benchmark set itself: one row per cell, giving the picture, the model, the operations, the
+geometry, the size knobs, and the exact term count that configuration is known to produce.
+
+```bash
+monoprop-bench-rung benches/rungs.toml list                        # the whole set
+monoprop-bench-rung benches/rungs.toml <id> --dry-run              # the plan, no allocation
+monoprop-bench-rung benches/rungs.toml <id> --rep 3 --results runs # one rep
+monoprop-bench-ladder benches/rungs.toml runs                      # the block to paste
+```
+
+Nothing runs these for you. They are the fixed benchmark set; running the ones a change could
+plausibly move, and putting the result in the pull request, is the author's job. That is what
+`monoprop-bench-ladder` prints: the timings, the peak memory, and the resolved parameters of every
+problem measured -- read back from the run rather than from the row's overrides, so a reviewer can
+see what was measured without resolving flags against a model's defaults.
+
+Each row also declares `cost_seconds` and `cost_gib_per_node`: what one rep last cost, so you can
+see what a rung will take before you spend it, and so the collated table can show this run against
+the last one. Those two are documentation, never a gate -- a timing is noisy and your machine is
+not the machine they were taken on.
+
+A rung declares `expect_terms`, and a result that misses it by more than 0.1% is **refused**: the
+term count is reproducible to the digit at a fixed seed and tolerance, so a mistyped knob then
+fails the cell instead of quietly measuring a different problem. The runner checks the geometry it
+actually ran under the same way, and refuses a run with more than one timing round, because
+`pedantic` builds round *k+1*'s arguments before releasing round *k*'s -- two propagators are
+resident at once and peak memory doubles. Repetition comes from repeated invocations, which is
+what `--rep` names.
+
+A row nobody has calibrated refuses to run at all. It says so twice: `expect_terms = 0`, and
+`TBD` in place of any size knob still to be measured. The knob is spelled `TBD` rather than left
+at `0` because `0` is not neutral -- `lower_atol = 0` prunes nothing and is the *largest* problem
+the model can pose, so a placeholder `0` invites exactly the allocation-burning run the gate
+exists to prevent.
+
+Sizes come from the coefficient tolerance, not from the cutoff or the system size: at the default
+`lower_atol = 1e-4` both fixed models are saturated in both, so a sweep over either measures
+nothing.
+
+`propagate` carries the full ladder to a billion terms; `build_graph`, `energy` and `gradient`
+stop at what fits a single node. That is a measurement, not a convention. `build_graph` extends
+the graph rather than replacing it, so it retains one layer-set per gate while `propagate`
+releases each layer as it contracts -- Hubbard reaches 97M terms in well under 2 GiB through
+`propagate`, while four successive `build_graph` calls on the same model exceed a 242 GiB node.
+
+Running a rung needs a machine, a scheduler and an allocation, none of which belong in this
+repository. The table, the runner and the gate are here; the launcher that submits them is not.
+
+### Scaling
+
+Node scaling of Hubbard `propagate` in the shipped default configuration, 1 to 64 nodes (128 to
+8192 cores) at 8 MPI ranks per node × 16 partitions, so `R = 8N` and `P = 128N` with one core per
+partition. Measured 2026-08-27 on AMD EPYC 7742 nodes with 242.0 GiB usable each; 38 rungs, five
+reps apiece (ten on the smallest weak ladder), every rep gate-checked on binary identity,
+environment and term count before its time was kept. These rungs are rows in `rungs.toml`; the
+medians below are the `cost_seconds` and `cost_gib_per_node` those rungs declare.
+
+Problem size is `--hubbard-lower-atol` at a fixed cutoff of 10, which is saturated there, so all
+growth comes from the tolerance and every rung stays inside the same operator family. The eleven
+sizes form a doubling sequence and both families are built from it, so a cell reached by two
+ladders is *exactly* the same problem — nine such cells agreed to within 1.24%, most within 0.2%,
+which is a free check on the whole apparatus.
+
+Some rungs are absent because the problem does not fit in that many nodes' memory, not because
+they were skipped: `strong-6126m` starts at two nodes and `strong-24420m` at eight.
+
+**`strong-1569m`** — 1,569,152,761 terms held fixed.
+
+| nodes | R | P | terms | Mterms/node | median s | Mterms/s/node | GiB/node |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 8 | 128 | 1,569,152,761 | 1569 | 215.61 | 7.28 | 99.9 |
+| 2 | 16 | 256 | 1,569,152,761 | 785 | 105.91 | 7.41 | 51.5 |
+| 4 | 32 | 512 | 1,569,152,761 | 392 | 53.34 | 7.35 | 28.0 |
+| 8 | 64 | 1024 | 1,569,152,761 | 196 | 28.58 | 6.86 | 15.9 |
+| 16 | 128 | 2048 | 1,569,152,761 | 98 | 18.12 | 5.41 | 11.0 |
+| 32 | 256 | 4096 | 1,569,152,761 | 49 | 16.13 | 3.04 | 6.6 |
+| 64 | 512 | 8192 | 1,569,152,761 | 25 | 23.99 | 1.02 | 4.1 |
+
+**`strong-6126m`** — 6,125,805,627 terms held fixed.
+
+| nodes | R | P | terms | Mterms/node | median s | Mterms/s/node | GiB/node |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 2 | 16 | 256 | 6,125,805,627 | 3063 | 450.19 | 6.80 | 200.2 |
+| 4 | 32 | 512 | 6,125,805,627 | 1531 | 224.45 | 6.82 | 101.3 |
+| 8 | 64 | 1024 | 6,125,805,627 | 766 | 109.53 | 6.99 | 51.3 |
+| 16 | 128 | 2048 | 6,125,805,627 | 383 | 58.75 | 6.52 | 27.4 |
+| 32 | 256 | 4096 | 6,125,805,627 | 191 | 38.09 | 5.03 | 16.1 |
+| 64 | 512 | 8192 | 6,125,805,627 | 96 | 36.95 | 2.59 | 11.4 |
+
+**`strong-24420m`** — 24,419,998,198 terms held fixed.
+
+| nodes | R | P | terms | Mterms/node | median s | Mterms/s/node | GiB/node |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 8 | 64 | 1024 | 24,419,998,198 | 3052 | 471.03 | 6.48 | 201.3 |
+| 16 | 128 | 2048 | 24,419,998,198 | 1526 | 235.19 | 6.49 | 101.8 |
+| 32 | 256 | 4096 | 24,419,998,198 | 763 | 127.10 | 6.00 | 52.2 |
+| 64 | 512 | 8192 | 24,419,998,198 | 382 | 79.58 | 4.79 | 26.9 |
+
+**`weak-97m`** — ~97M terms per node.
+
+| nodes | R | P | terms | Mterms/node | median s | Mterms/s/node | GiB/node |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 8 | 128 | 96,981,051 | 97 | 10.75 | 9.02 | 10.8 |
+| 2 | 16 | 256 | 184,124,520 | 92 | 10.58 | 8.70 | 9.6 |
+| 4 | 32 | 512 | 377,482,074 | 94 | 13.13 | 7.19 | 11.5 |
+| 8 | 64 | 1024 | 781,669,404 | 98 | 14.54 | 6.72 | 10.9 |
+| 16 | 128 | 2048 | 1,569,152,761 | 98 | 18.11 | 5.42 | 11.0 |
+| 32 | 256 | 4096 | 3,104,527,573 | 97 | 24.39 | 3.98 | 11.0 |
+| 64 | 512 | 8192 | 6,125,805,627 | 96 | 36.59 | 2.62 | 11.4 |
+
+**`weak-385m`** — ~385M terms per node.
+
+| nodes | R | P | terms | Mterms/node | median s | Mterms/s/node | GiB/node |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 8 | 128 | 377,482,074 | 377 | 47.71 | 7.91 | 26.6 |
+| 2 | 16 | 256 | 781,669,404 | 391 | 50.90 | 7.68 | 28.0 |
+| 4 | 32 | 512 | 1,569,152,761 | 392 | 53.29 | 7.36 | 27.9 |
+| 8 | 64 | 1024 | 3,104,527,573 | 388 | 54.73 | 7.09 | 27.5 |
+| 16 | 128 | 2048 | 6,125,805,627 | 383 | 58.03 | 6.60 | 27.4 |
+| 32 | 256 | 4096 | 12,255,330,837 | 383 | 64.64 | 5.92 | 26.3 |
+| 64 | 512 | 8192 | 24,419,998,198 | 382 | 79.89 | 4.78 | 26.9 |
+
+**`weak-1529m`** — ~1529M terms per node.
+
+| nodes | R | P | terms | Mterms/node | median s | Mterms/s/node | GiB/node |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 8 | 128 | 1,569,152,761 | 1569 | 215.61 | 7.28 | 99.9 |
+| 2 | 16 | 256 | 3,104,527,573 | 1552 | 222.27 | 6.98 | 100.2 |
+| 4 | 32 | 512 | 6,125,805,627 | 1531 | 224.04 | 6.84 | 101.2 |
+| 8 | 64 | 1024 | 12,255,330,837 | 1532 | 227.33 | 6.74 | 99.9 |
+| 16 | 128 | 2048 | 24,419,998,198 | 1526 | 235.55 | 6.48 | 101.8 |
+| 32 | 256 | 4096 | 48,317,129,677 | 1510 | 249.62 | 6.05 | 101.3 |
+| 64 | 512 | 8192 | 94,684,031,363 | 1479 | 257.05 | 5.76 | 84.3 |
+
+
+Two things follow from the strong curves, and only from having three of them. The reversal in
+`strong-1569m` at 64 nodes is not a property of a core count: the same hardware still improves at
+64 nodes on the two larger problems. What sets the optimum is the load *per node*, and it falls
+below roughly 50–100 Mterms/node at the point each curve turns. Each doubling of the problem buys
+one more useful doubling of nodes.
+
+Weak scaling says the same thing from the other side. At ~97M terms/node, 64 nodes runs at 29% of
+one node's efficiency; at ~385M it is 60%; at ~1529M it is 84% across 64× the hardware. A run that
+can afford about 1.5e9 terms per node weak-scales almost ideally to 8192 cores; one at 100M/node
+does not.
+
+Peak resident memory over all 38 rungs, spanning 25 to 3063 Mterms per node:
+
+```
+GiB/node = 3.39 + 0.0634 × Mterms/node
+```
+
+Both terms are real. The slope is the per-term cost, about 68 bytes per term. The constant is a
+genuine per-node floor that a model through the origin cannot reproduce — the smallest rung
+measures 4.1 GiB/node at 25 Mterms/node. Every rung falls within −2.9 to +4.5 GiB/node of that
+line except `weak-1529m` at 64 nodes, which measures 84.3 against 97.1 predicted, identically on
+all five reps; it is reproducible and unexplained, and no mechanism is claimed for it on the
+strength of one rung. The largest cell measured 201.3 GiB/node against a 242.0 GiB grant.
+
 ### Continuous benchmarking
 
 The `bench_main.yml` workflow benchmarks every commit on `main`. [Bencher](https://bencher.dev/)
@@ -307,18 +475,23 @@ just bench-bmf ci-linux         # the same results as Bencher Metric Format JSON
 ```
 
 `monoprop-bench-bmf` combines both artifacts because each Bencher upload accepts one adapter. The
-standard `python_pytest` adapter includes timings but omits memory and operator metrics. Four
+standard `python_pytest` adapter includes timings but omits memory and operator metrics. Three
 measures are recorded:
 
 | Measure | Unit | Source | Threshold |
 |---|---|---|---|
 | `latency` | nanoseconds | pytest-benchmark mean ± 1σ | Student's t-test, upper 0.99 |
-| `peak-memory` | bytes | per-operation peak RSS (`VmHWM`) | +10% |
-| `resting-memory` | bytes | settled operator + graph footprint | +10% |
+| `peak-memory` | bytes | per-operation peak RSS (`VmHWM`), summed over ranks | +10% |
 | `terms` | count | terms in the evolved operator | any change |
 
 For a fixed seed and problem size, `terms` is deterministic; any change therefore indicates an
-algorithmic change. Timing alerts from shared runners are recorded but do not fail the build.
+algorithmic change. It is tracked for that reason alone: it is the only check that a timing win is
+not an accuracy change. Timing alerts from shared runners are recorded but do not fail the build.
+
+`latency` is the mean, because Bencher's t-test threshold consumes a mean and a spread. A rung
+ladder reads the same runs on the median and the min instead -- these distributions are skewed, so
+a mean tracks stragglers rather than the cost of the work. The two statistics answer different
+questions and neither substitutes for the other.
 
 #### Testbeds
 
@@ -334,6 +507,16 @@ series.
 The bare-metal workflow provisions a dedicated node for each run. Its lower measurement variance
 supports tighter timing thresholds and permits execution of the fixed models omitted on the shared
 runner.
+
+**No benchmark workflow gates a pull request.** Both track the main branch, and a threshold over a
+series that spans runners is a report, not a verdict. Measuring a change is the author's job: run
+the rungs the change could plausibly move and put the numbers in the pull request. `Rungs` above
+says how.
+
+The bare-metal workflow is inert until a maintainer sets the `BENCH_BARE_METAL` repository
+variable -- without a RunsOn stack behind the `bench` label the job would queue until it timed out.
+Every run uploads `bmf.json` and the raw result JSON as an artifact, so a failed Bencher upload
+does not take the measurement with it.
 
 The `bench-markers` and `bench-rounds` inputs of the reusable `bench.yml` workflow select the
 benchmarks and repetition count. These values should remain fixed after establishing a testbed,

--- a/packages/monoprop-bench-tools/README.md
+++ b/packages/monoprop-bench-tools/README.md
@@ -12,6 +12,7 @@ vendoring the repository's `benches/` directory.
 | `monoprop_bench_tools.models` | Builders for the benchmarked problems: a configurable random problem, a 120-mode Fermi-Hubbard model, and a 127-qubit kicked-Ising model. |
 | `monoprop_bench_tools.report` | Renders a run's artifacts into a side-by-side Markdown report. |
 | `monoprop_bench_tools.bmf` | Renders a run's artifacts into [Bencher](https://bencher.dev/) Metric Format JSON. |
+| `monoprop_bench_tools.rungs` | Reads the rung table, runs one rung, gates the result on its term count, and collates a ladder. |
 
 ## Install
 
@@ -56,6 +57,8 @@ Render the artifacts of a run:
 ```bash
 monoprop-bench-report benches/results             # writes REPORT.md
 monoprop-bench-bmf benches/results ci-linux       # BMF JSON on stdout
+monoprop-bench-rung benches/rungs.toml list      # the benchmark set
+monoprop-bench-ladder benches/rungs.toml runs/   # scaling tables from rung artifacts
 ```
 
 Both read the two files a run leaves in the results directory:
@@ -65,9 +68,11 @@ operator sizes, configuration). The schema is documented in the repository's
 
 ## Scope
 
-This package deliberately holds no benchmarks. monoprop's own suite lives in the
-repository's `benches/` directory, because its benchmark names are the key
-Bencher's history is stored under and must not move with a library release.
+This package deliberately holds no benchmarks, and no rung table. monoprop's own
+suite and its `rungs.toml` live in the repository's `benches/` directory, because
+benchmark names are the key Bencher's history is stored under and a rung id names
+the artifacts a campaign has already written -- neither may move with a library
+release. What lives here is the machinery that reads them.
 
 ## License
 

--- a/packages/monoprop-bench-tools/pyproject.toml
+++ b/packages/monoprop-bench-tools/pyproject.toml
@@ -49,6 +49,8 @@ Changelog = "https://github.com/Algorithmiq/monoprop/releases"
 [project.scripts]
 monoprop-bench-report = "monoprop_bench_tools.report:main"
 monoprop-bench-bmf = "monoprop_bench_tools.bmf:main"
+monoprop-bench-rung = "monoprop_bench_tools.rungs:run_main"
+monoprop-bench-ladder = "monoprop_bench_tools.rungs:ladder_main"
 
 
 [dependency-groups]

--- a/packages/monoprop-bench-tools/src/monoprop_bench_tools/bmf.py
+++ b/packages/monoprop-bench-tools/src/monoprop_bench_tools/bmf.py
@@ -24,17 +24,22 @@ Bencher accepts one adapter per report, so timings and memory are merged here an
 uploaded together under ``--adapter json``; the stock ``python_pytest`` adapter
 would keep the timings and drop everything else.
 
-Four measures are emitted:
+Three measures are emitted:
 
 ``latency`` (nanoseconds)
     Per-operation mean, with the interval one standard deviation either side.
+    The mean is Bencher's contract -- its t-test threshold consumes a mean and a
+    spread. A rung ladder reads the same runs on median and min instead, because
+    these distributions are skewed and a mean tracks stragglers; the two answer
+    different questions and neither substitutes for the other.
 ``peak-memory`` (bytes)
-    Per-operation peak resident footprint, summed across ranks under MPI.
+    Per-operation peak resident footprint, summed across ranks under MPI. The
+    sum bounds the job; ``memhwm_max`` bounds a node and is what a multi-node
+    rung is read on, but CI is single-rank, where the two coincide.
 ``terms`` (count)
     Terms in the evolved operator. Deterministic for a fixed seed and problem
-    size, so it can carry a far tighter threshold than the timing measures.
-``resting-memory`` (bytes)
-    Settled footprint of the built operator + graph.
+    size, so it is held to an exact match: it is the only check that a timing
+    win is not an accuracy change.
 
 Usage::
 
@@ -57,8 +62,8 @@ _NS_PER_S = 1e9
 # describe a built operator rather than one timed call.
 _OPERATOR = "operator"
 
-# ``opsize``/``memrest`` are also keyed by pytest node id (``::``, as report.py reads
-# them) for a private A/B harness; those are not operators, so they are skipped here.
+# ``opsize`` is also keyed by pytest node id (``::``, as report.py reads it) for a
+# private A/B harness; those are not operators, so they are skipped here.
 _NODE_ID_SEP = "::"
 
 Metric = dict[str, float]
@@ -129,10 +134,6 @@ def build_bmf(results_dir: Path, label: str) -> Bmf:
     for key, size in results.get("opsize", {}).items():
         if _NODE_ID_SEP not in key:
             measure(f"{_OPERATOR}[{key}]", "terms", size["terms"])
-
-    for key, resting in results.get("memrest", {}).items():
-        if _NODE_ID_SEP not in key:
-            measure(f"{_OPERATOR}[{key}]", "resting-memory", resting)
 
     return bmf
 

--- a/packages/monoprop-bench-tools/src/monoprop_bench_tools/report.py
+++ b/packages/monoprop-bench-tools/src/monoprop_bench_tools/report.py
@@ -172,8 +172,12 @@ def _picture_of(op_key: str) -> str:
 def _display_op(op_key: str) -> str:
     """Turn a node id into a ``group / op`` label, dropping the picture tag.
 
-    ``...::test_random_energy[heisenberg]`` -> ``random / energy``;
-    ``...::test_model[hubbard]``            -> ``model / hubbard``.
+    ``...::test_random_energy[heisenberg]``  -> ``random / energy``;
+    ``...::test_model_propagate[hubbard]``   -> ``hubbard / propagate``.
+
+    A parameter that is not a picture names the model, and it replaces the group: the
+    fixed-model tests are all called ``test_model_*``, so dropping it would label the
+    hubbard and the pauli row identically and the two would be indistinguishable.
     """
     _file, _, test = op_key.partition("::")
     base, _, param = test.removeprefix("test_").partition("[")
@@ -181,9 +185,9 @@ def _display_op(op_key: str) -> str:
     if param in _PICTURES:
         param = ""  # the section header already states the picture
     group, _, op = base.partition("_")
-    if not op:  # parametrized-only name, e.g. "model" + param "hubbard"
-        return f"{group} / {param}" if param else group
-    return f"{group} / {op}"
+    if param:
+        group = param
+    return f"{group} / {op}" if op else group
 
 
 def _fmt_cpus(meta: dict) -> str:
@@ -272,10 +276,9 @@ def build_report(results_dir: Path) -> str:
     def sec(name: str) -> dict[str, dict]:
         return {lbl: results.get(lbl, {}).get(name, {}) for lbl in labels}
 
-    params, opsize, memrest, memory, memory_max = (
+    params, opsize, memory, memory_max = (
         sec("params"),
         sec("opsize"),
-        sec("memrest"),
         sec("memhwm"),
         sec("memhwm_max"),
     )
@@ -360,15 +363,6 @@ def build_report(results_dir: Path) -> str:
             lambda lbl, p: (
                 f"{opsize[lbl][p]['terms']:,}" if p in opsize.get(lbl, {}) else "—"
             ),
-        ),
-        *_section(
-            "Operator resting footprint (RSS)",
-            "Settled resident memory of the built operator + graph, after the "
-            "build's transient buffers are freed (`gc.collect()` + `heap_trim`).",
-            "Picture",
-            [(p, _PICTURE_NAMES[p]) for p in _pictures_present(memrest, labels)],
-            labels,
-            lambda lbl, p: _fmt_mem(memrest.get(lbl, {}).get(p)),
         ),
         *_model_config_section(labels, results),
         *ops_section("Heisenberg", "heisenberg"),

--- a/packages/monoprop-bench-tools/src/monoprop_bench_tools/rungs.py
+++ b/packages/monoprop-bench-tools/src/monoprop_bench_tools/rungs.py
@@ -1,0 +1,576 @@
+# Copyright 2026 Algorithmiq
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The rung ladder: monoprop's benchmark set as a table, and the runner that executes it.
+
+A *rung* is one cell of the benchmark set -- a picture, a model, a set of operations, a
+geometry and a problem size, with the term count that size is known to produce. The rungs
+live in ``benches/rungs.toml`` rather than in a loop, so that a campaign cannot quietly run
+a different grid and two campaigns' numbers are comparable row for row.
+
+Every rung declares ``expect_terms``, and the runner refuses a result whose term count
+misses it: a mistyped tolerance then fails the cell instead of silently measuring a
+different problem. A row that has never been calibrated declares ``expect_terms = 0`` and
+refuses to run at all.
+
+Nothing here runs automatically. These are the fixed benchmarks; running the ones a change
+could plausibly move, and putting the numbers in the pull request, is the author's job.
+
+Two entry points::
+
+    monoprop-bench-rung <rungs.toml> <rung-id> [--rep N] [--results DIR] [--dry-run]
+    monoprop-bench-ladder <rungs.toml> <results-dir> [--family strong]
+
+The first runs one rung once; repetition comes from repeated invocations, because
+``pytest-benchmark``'s ``pedantic`` builds round k+1's arguments before releasing round k's,
+so more than one round holds two propagators and doubles peak memory. The second collates a
+directory of rung artifacts into a markdown block -- the timings, the peak memory, and the
+resolved parameters of every problem measured -- to paste into the pull request.
+
+Each row also carries what it last cost, in wall seconds and GiB per node, so you can see
+what a rung will take before you spend it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+BYTES_PER_GIB = 1 << 30
+
+# A term count is reproducible to the digit at a fixed seed and tolerance, so this is a
+# guard against a mistyped knob, not a statistical tolerance.
+TERM_TOLERANCE = 0.001
+
+# A size knob nobody has measured yet. It is not spelled 0 because 0 is not neutral --
+# `lower_atol = 0` prunes nothing, so a placeholder 0 is the largest problem the model can
+# pose and would burn the allocation the gate exists to protect.
+UNSET = "TBD"
+
+FAMILIES = frozenset({"size", "strong", "weak"})
+PICTURES = frozenset({"heisenberg", "schrodinger"})
+MODELS = frozenset({"random", "hubbard", "pauli"})
+OPS = ("build_graph", "propagate", "energy", "gradient")
+REQUIRED = frozenset(
+    {
+        "id",
+        "family",
+        "picture",
+        "model",
+        "ops",
+        "nodes",
+        "ranks_per_node",
+        "partitions",
+        "expect_terms",
+        "reps",
+    }
+)
+
+# The random problem is driven from the CLI options in benches/conftest.py and carries the
+# picture axis; the fixed models are Heisenberg-only and carry their own config overrides.
+_BENCH_FILE = {"random": "benches/bench_random.py"}
+_TEST_PREFIX = {"random": "test_random_"}
+_DEFAULT_FILE = "benches/bench_models.py"
+_DEFAULT_PREFIX = "test_model_"
+
+
+@dataclass(frozen=True, slots=True)
+class Rung:
+    """One cell of the benchmark set."""
+
+    id: str
+    family: str
+    picture: str
+    model: str
+    ops: tuple[str, ...]
+    nodes: int
+    ranks_per_node: int
+    partitions: int
+    expect_terms: int
+    reps: int
+    args: tuple[str, ...] = ()
+    cost_seconds: float = 0.0
+    cost_gib_per_node: float = 0.0
+    walltime: str = ""
+    note: str = ""
+
+    @property
+    def ranks(self) -> int:
+        """Return the MPI rank count this rung is launched with."""
+        return self.nodes * self.ranks_per_node
+
+    @property
+    def world(self) -> int:
+        """Return the flat world size, ranks x partitions -- the engine's own ``P``."""
+        return self.ranks * self.partitions
+
+    @property
+    def bench_file(self) -> str:
+        """Return the bench module holding this rung's operations."""
+        return _BENCH_FILE.get(self.model, _DEFAULT_FILE)
+
+    @property
+    def cost(self) -> str:
+        """Return what one rep of this rung last cost, or ``?`` if nobody has measured it."""
+        if not self.cost_seconds:
+            return "?"
+        return f"{self.cost_seconds:.3g}s {self.cost_gib_per_node:.3g}GiB/node"
+
+    @property
+    def calibrated(self) -> bool:
+        """Return whether this rung's size knobs and term count have both been measured."""
+        return self.expect_terms > 0 and not any(
+            a.endswith(f"={UNSET}") for a in self.args
+        )
+
+    def selector(self) -> str:
+        """Return the pytest ``-k`` expression selecting this rung's cells."""
+        prefix = _TEST_PREFIX.get(self.model, _DEFAULT_PREFIX)
+        ops = " or ".join(f"{prefix}{op}" for op in self.ops)
+        # The random tests carry the picture as a parameter id; the fixed models carry
+        # the model name instead and have no picture axis.
+        axis = self.picture if self.model == "random" else self.model
+        return f"({ops}) and {axis}"
+
+
+def _require(cond: bool, msg: str) -> None:  # noqa: FBT001
+    if not cond:
+        raise SystemExit(f"rungs: {msg}")
+
+
+def _one(raw: dict[str, Any], index: int) -> Rung:
+    """Return one validated rung from its table entry."""
+    where = raw.get("id", f"rung #{index}")
+    missing = REQUIRED - set(raw)
+    _require(not missing, f"{where}: missing {sorted(missing)}")
+
+    # Every enum is checked against an exhaustive set: a value nobody validated reaches the
+    # launcher as a selector that matches nothing, and an empty run reads as a clean one.
+    _require(
+        raw["family"] in FAMILIES,
+        f"{where}: family {raw['family']!r} not in {sorted(FAMILIES)}",
+    )
+    _require(
+        raw["picture"] in PICTURES,
+        f"{where}: picture {raw['picture']!r} not in {sorted(PICTURES)}",
+    )
+    _require(
+        raw["model"] in MODELS,
+        f"{where}: model {raw['model']!r} not in {sorted(MODELS)}",
+    )
+    _require(bool(raw["ops"]), f"{where}: ops is empty")
+    unknown = [op for op in raw["ops"] if op not in OPS]
+    _require(
+        not unknown, f"{where}: unknown ops {unknown}, expected a subset of {list(OPS)}"
+    )
+    _require(
+        raw["picture"] == "heisenberg" or raw["model"] == "random",
+        f"{where}: only the random model has a picture axis",
+    )
+    for field in ("nodes", "ranks_per_node", "partitions", "reps"):
+        _require(raw[field] >= 1, f"{where}: {field} must be >= 1, got {raw[field]}")
+    _require(raw["expect_terms"] >= 0, f"{where}: expect_terms must be >= 0")
+    unset = [a for a in raw.get("args", ()) if a.endswith(f"={UNSET}")]
+    _require(
+        not (unset and raw["expect_terms"]),
+        f"{where}: carries {unset} yet declares a term count; a rung whose size knob is "
+        f"unmeasured cannot have a measured size",
+    )
+
+    return Rung(
+        id=raw["id"],
+        family=raw["family"],
+        picture=raw["picture"],
+        model=raw["model"],
+        ops=tuple(raw["ops"]),
+        nodes=raw["nodes"],
+        ranks_per_node=raw["ranks_per_node"],
+        partitions=raw["partitions"],
+        expect_terms=raw["expect_terms"],
+        reps=raw["reps"],
+        args=tuple(raw.get("args", ())),
+        cost_seconds=float(raw.get("cost_seconds", 0.0)),
+        cost_gib_per_node=float(raw.get("cost_gib_per_node", 0.0)),
+        walltime=raw.get("walltime", ""),
+        note=raw.get("note", ""),
+    )
+
+
+def load_rungs(path: Path) -> dict[str, Rung]:
+    """Return the rung table at ``path``, keyed by id."""
+    _require(path.is_file(), f"missing rung table {path}")
+    raw = tomllib.loads(path.read_text())
+    rungs: dict[str, Rung] = {}
+    for index, entry in enumerate(raw.get("rung", [])):
+        rung = _one(entry, index)
+        _require(rung.id not in rungs, f"duplicate rung id {rung.id!r}")
+        rungs[rung.id] = rung
+    _require(bool(rungs), f"{path} declares no rungs")
+    return rungs
+
+
+def pytest_argv(rung: Rung, results_dir: Path, label: str) -> list[str]:
+    """Return the pytest command line measuring one rep of ``rung``."""
+    return [
+        sys.executable,
+        "-m",
+        "pytest",
+        rung.bench_file,
+        "-k",
+        rung.selector(),
+        # Not a default: a second round holds two propagators at once and doubles peak RSS.
+        "--bench-rounds=1",
+        *rung.args,
+        f"--benchmark-json={results_dir / f'time-{label}.json'}",
+        "-o",
+        "filterwarnings=default",
+        "-q",
+        "-p",
+        "no:cacheprovider",
+    ]
+
+
+def bench_env(rung: Rung, results_dir: Path, label: str) -> dict[str, str]:
+    """Return the environment overrides one rep of ``rung`` runs under."""
+    return {
+        "monoprop_BENCH_LABEL": label,
+        "monoprop_BENCH_RESULTS": str(results_dir),
+        "monoprop_NUM_THREADS": str(rung.partitions),
+        "monoprop_PARTITIONS": str(rung.partitions),
+    }
+
+
+def artifact_terms(rung: Rung, results: dict[str, Any]) -> int | None:
+    """Return the term count ``results`` recorded for ``rung``, or ``None`` if it has none."""
+    opsize = results.get("opsize", {})
+    axis = rung.picture if rung.model == "random" else rung.model
+    if axis in opsize:
+        return int(opsize[axis]["terms"])
+    counts = [int(v["terms"]) for k, v in opsize.items() if "::" in k]
+    return max(counts) if counts else None
+
+
+def gate(rung: Rung, results: dict[str, Any]) -> list[str]:
+    """Return the reasons ``results`` must not be kept as a measurement of ``rung``.
+
+    An empty list is the only clean outcome. Each check answers "did this process measure
+    the problem the table names", never "did it look plausible".
+    """
+    reasons: list[str] = []
+    meta = results.get("meta", {})
+
+    for field, want in (("nodes", rung.nodes), ("ranks_per_node", rung.ranks_per_node)):
+        got = meta.get(field)
+        if got != want:
+            reasons.append(f"{field}: ran {got}, table says {want}")
+
+    partitions_env = meta.get("partitions_env")
+    if partitions_env != str(rung.partitions):
+        reasons.append(
+            f"partitions: ran {partitions_env}, table says {rung.partitions}"
+        )
+
+    rounds = results.get("params", {}).get("bench_rounds")
+    if rounds != 1:
+        reasons.append(
+            f"bench_rounds: ran {rounds}, must be 1 or peak memory is doubled"
+        )
+
+    terms = artifact_terms(rung, results)
+    if terms is None:
+        reasons.append("terms: the run recorded no operator size")
+    elif abs(terms - rung.expect_terms) > TERM_TOLERANCE * rung.expect_terms:
+        reasons.append(f"terms: measured {terms:,}, table says {rung.expect_terms:,}")
+
+    return reasons
+
+
+def _run_one(rung: Rung, results_dir: Path, rep: int, *, dry_run: bool) -> int:
+    label = f"{rung.id}-r{rep}"
+    argv = pytest_argv(rung, results_dir, label)
+    env = bench_env(rung, results_dir, label)
+
+    if dry_run:
+        print(f"rung      {rung.id}  ({rung.family}, {rung.picture}, {rung.model})")
+        print(
+            f"geometry  {rung.nodes} nodes x {rung.ranks_per_node} ranks x {rung.partitions} partitions"
+            f"  => R={rung.ranks} P={rung.world}"
+        )
+        print(
+            f"expect    {rung.expect_terms:,} terms, {rung.reps} reps, walltime {rung.walltime or '-'}"
+        )
+        print(f"costs     {rung.cost} per rep, x{rung.reps} reps x {rung.nodes} nodes")
+        print("env       " + " ".join(f"{k}={v}" for k, v in env.items()))
+        print("run       " + " ".join(argv))
+        return 0
+
+    results_dir.mkdir(parents=True, exist_ok=True)
+    completed = subprocess.run(argv, env={**os.environ, **env}, check=False)  # noqa: S603
+    if completed.returncode != 0:
+        print(f"rung {rung.id}: pytest exited {completed.returncode}", file=sys.stderr)
+        return completed.returncode
+
+    artifact = results_dir / f"{label}.json"
+    if not artifact.is_file():
+        print(f"rung {rung.id}: no artifact at {artifact}", file=sys.stderr)
+        return 1
+
+    reasons = gate(rung, json.loads(artifact.read_text()))
+    if reasons:
+        artifact.rename(artifact.with_suffix(".refused.json"))
+        print(f"## REFUSED {rung.id} rep {rep}", file=sys.stderr)
+        for reason in reasons:
+            print(f"  - {reason}", file=sys.stderr)
+        return 1
+
+    print(f"rung {rung.id} rep {rep}: kept {artifact}")
+    return 0
+
+
+def run_main(argv: Sequence[str] | None = None) -> int:
+    """Run one rep of one rung, keeping the result only if it passes the gate."""
+    parser = argparse.ArgumentParser(prog="monoprop-bench-rung", description=__doc__)
+    parser.add_argument("table", type=Path, help="path to rungs.toml")
+    parser.add_argument("rung_id", help="rung to run, or 'list' to print the table")
+    parser.add_argument(
+        "--rep", type=int, default=1, help="rep index, used to name the artifact"
+    )
+    parser.add_argument("--results", type=Path, default=Path("benches/results"))
+    parser.add_argument(
+        "--dry-run", action="store_true", help="print the plan without running it"
+    )
+    args = parser.parse_args(argv)
+
+    rungs = load_rungs(args.table)
+    if args.rung_id == "list":
+        for rung in rungs.values():
+            mark = " " if rung.calibrated else "*"
+            print(
+                f"{mark} {rung.id:<44} {rung.family:<6} N={rung.nodes:<3} P={rung.world:<5} "
+                f"{rung.expect_terms:>14,}  {rung.cost}"
+            )
+        print(
+            "\n* = uncalibrated (no term count, or a TBD size knob); the rung refuses to run."
+            "\nThe last column is what one rep last cost; ? means nobody has timed it."
+        )
+        return 0
+
+    rung = rungs.get(args.rung_id)
+    if rung is None:
+        print(f"rungs: no rung {args.rung_id!r}; try 'list'", file=sys.stderr)
+        return 2
+    if not rung.calibrated:
+        print(
+            f"rungs: {rung.id} is uncalibrated. Measure its size knobs and term count and "
+            f"put them in the table before spending an allocation on it.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return _run_one(rung, args.results, args.rep, dry_run=args.dry_run)
+
+
+@dataclass(frozen=True, slots=True)
+class Cell:
+    """One rung's collated measurement across its reps."""
+
+    rung: Rung
+    seconds: tuple[float, ...]
+    gib_per_node: tuple[float, ...]
+    problem: dict[str, Any]
+
+    @property
+    def reps(self) -> int:
+        """Return how many gate-clean reps were found."""
+        return len(self.seconds)
+
+
+def _artifacts(
+    rung: Rung, results_dir: Path
+) -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
+    for artifact in sorted(results_dir.glob(f"{rung.id}-r*.json")):
+        if artifact.name.endswith(".refused.json"):
+            continue
+        timing = results_dir / f"time-{artifact.stem}.json"
+        if not timing.is_file():
+            continue
+        yield json.loads(artifact.read_text()), json.loads(timing.read_text())
+
+
+def problem(rung: Rung, results: dict[str, Any]) -> dict[str, Any]:
+    """Return the resolved parameters of the problem a rung actually posed.
+
+    Read back from the run rather than from the row's ``args``, because ``args`` names only
+    the overrides: a reader given ``--hubbard-lower-atol=1.25e-05`` cannot tell what the
+    other nine fields were, and a default that changes underneath the table would go unseen.
+    """
+    if rung.model == "random":
+        return dict(results.get("params", {}))
+    return dict(results.get("configs", {}).get(rung.model, {}))
+
+
+def collate(rungs: dict[str, Rung], results_dir: Path) -> list[Cell]:
+    """Return one :class:`Cell` per rung that has at least one gate-clean rep."""
+    cells: list[Cell] = []
+    for rung in rungs.values():
+        seconds: list[float] = []
+        gib: list[float] = []
+        params: dict[str, Any] = {}
+        for results, timing in _artifacts(rung, results_dir):
+            if gate(rung, results):
+                continue
+            benches = timing.get("benchmarks", [])
+            if not benches:
+                continue
+            # The reported cost of a rung is the sum of the operations it selected: one
+            # rung is one workload, not a menu to be read a column at a time.
+            seconds.append(sum(b["stats"]["median"] for b in benches))
+            # Summed over ranks, so ranks peaking at different moments are added as though
+            # they had peaked together -- an upper bound on the node, never an estimate.
+            total = sum(results.get("memhwm", {}).values())
+            gib.append(total / rung.nodes / BYTES_PER_GIB)
+            params = params or problem(rung, results)
+        if seconds:
+            cells.append(Cell(rung, tuple(seconds), tuple(gib), params))
+    return cells
+
+
+_COLUMNS = (
+    "rung",
+    "nodes",
+    "R",
+    "P",
+    "terms",
+    "Mterms/node",
+    "reps",
+    "median s",
+    "min s",
+    "Mterms/s/node",
+    "GiB/node",
+    "declared s",
+    "vs declared",
+)
+
+
+def _row(cell: Cell) -> list[str]:
+    rung = cell.rung
+    median = statistics.median(cell.seconds)
+    per_node = rung.expect_terms / 1e6 / rung.nodes
+    was = rung.cost_seconds
+    return [
+        rung.id,
+        str(rung.nodes),
+        str(rung.ranks),
+        str(rung.world),
+        f"{rung.expect_terms:,}",
+        f"{per_node:.0f}",
+        str(cell.reps),
+        f"{median:.2f}",
+        f"{min(cell.seconds):.2f}",
+        f"{per_node / median:.2f}",
+        f"{statistics.median(cell.gib_per_node):.1f}",
+        f"{was:.2f}" if was else "—",
+        f"{median / was:.3f}x" if was else "—",
+    ]
+
+
+def render(cells: Sequence[Cell]) -> str:
+    """Return the measurement, as a block to paste into a pull request.
+
+    Read on the median and the min. These distributions are skewed -- a straggling rank
+    pulls a mean well off the body of the sample -- so a mean here tracks stragglers rather
+    than the cost of the work. That is also why this does not reuse the mean that
+    :mod:`monoprop_bench_tools.bmf` reports: Bencher's t-test consumes a mean and a spread,
+    and the two statistics answer different questions.
+
+    ``declared s`` is the cost the table carries for that rung, so the ratio says how this
+    run compares to the last one recorded. It is context, not a verdict: it may have been
+    taken on another machine, and nothing here gates on it.
+    """
+    lines: list[str] = []
+    for family in sorted({c.rung.family for c in cells}):
+        lines += [f"## {family}", ""]
+        lines += [
+            "| " + " | ".join(_COLUMNS) + " |",
+            "| --- |" + " ---: |" * (len(_COLUMNS) - 1),
+        ]
+        for cell in sorted(
+            (c for c in cells if c.rung.family == family),
+            # The node count is the last field of the id, so a plain string sort would
+            # print n1, n16, n2 -- a ladder read down the page out of order.
+            key=lambda c: (c.rung.id.rsplit("-n", 1)[0], c.rung.nodes, c.rung.id),
+        ):
+            lines.append("| " + " | ".join(_row(cell)) + " |")
+        lines.append("")
+
+    # A number without its problem is not reproducible, and a reviewer should not have to
+    # resolve the row's overrides against the model's defaults to learn what was measured.
+    lines += ["## Problems measured", ""]
+    for cell in sorted(cells, key=lambda c: c.rung.id):
+        rung = cell.rung
+        lines.append(
+            f"- **{rung.id}** — {rung.model} / {rung.picture}, "
+            f"{', '.join(rung.ops)}, {rung.nodes} x {rung.ranks_per_node} x "
+            f"{rung.partitions} (nodes x ranks/node x partitions)"
+        )
+        if cell.problem:
+            fields = ", ".join(f"{k}={v}" for k, v in sorted(cell.problem.items()))
+            lines.append(f"  - {fields}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def ladder_main(argv: Sequence[str] | None = None) -> int:
+    """Collate a directory of rung artifacts into a block to paste into a pull request."""
+    parser = argparse.ArgumentParser(
+        prog="monoprop-bench-ladder", description=ladder_main.__doc__
+    )
+    parser.add_argument("table", type=Path, help="path to rungs.toml")
+    parser.add_argument(
+        "results", type=Path, help="directory holding the rung artifacts"
+    )
+    parser.add_argument(
+        "--family",
+        action="append",
+        choices=sorted(FAMILIES),
+        help="restrict to one family",
+    )
+    args = parser.parse_args(argv)
+
+    rungs = load_rungs(args.table)
+    if args.family:
+        rungs = {k: v for k, v in rungs.items() if v.family in set(args.family)}
+    cells = collate(rungs, args.results)
+    if not cells:
+        print(
+            f"ladder: no gate-clean rung artifacts in {args.results}", file=sys.stderr
+        )
+        return 1
+    sys.stdout.write(render(cells))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_main())

--- a/packages/monoprop-bench-tools/tests/test_bmf.py
+++ b/packages/monoprop-bench-tools/tests/test_bmf.py
@@ -86,14 +86,10 @@ def test_operator_metrics_are_grouped_per_picture_and_model(tmp_path: Path) -> N
     _write(
         tmp_path,
         opsize={"heisenberg": {"terms": 51450866}, "hubbard": {"terms": 12}},
-        memrest={"heisenberg": 4096},
     )
     result = bmf.build_bmf(tmp_path, "ci")
 
-    assert result["operator[heisenberg]"] == {
-        "terms": {"value": 51450866.0},
-        "resting-memory": {"value": 4096.0},
-    }
+    assert result["operator[heisenberg]"] == {"terms": {"value": 51450866.0}}
     assert result["operator[hubbard]"] == {"terms": {"value": 12.0}}
 
 
@@ -102,7 +98,6 @@ def test_operator_metrics_skip_node_id_keyed_entries(tmp_path: Path) -> None:
     _write(
         tmp_path,
         opsize={"heisenberg": {"terms": 12}, build_graph: {"terms": 34}},
-        memrest={"heisenberg": 4096, build_graph: 8192},
     )
     result = bmf.build_bmf(tmp_path, "ci")
 
@@ -113,10 +108,7 @@ def test_operator_metrics_skip_node_id_keyed_entries(tmp_path: Path) -> None:
         _ENERGY: {
             "latency": {"value": 0.5e9, "lower_value": 0.49e9, "upper_value": 0.51e9}
         },
-        "operator[heisenberg]": {
-            "terms": {"value": 12.0},
-            "resting-memory": {"value": 4096.0},
-        },
+        "operator[heisenberg]": {"terms": {"value": 12.0}},
     }
 
 

--- a/packages/monoprop-bench-tools/tests/test_report.py
+++ b/packages/monoprop-bench-tools/tests/test_report.py
@@ -39,7 +39,10 @@ def test_picture_of_routes_by_tag() -> None:
     key = "bench_random.py::test_random_energy"
     assert report._picture_of(f"{key}[schrodinger]") == "schrodinger"
     assert report._picture_of(f"{key}[heisenberg]") == "heisenberg"
-    assert report._picture_of("bench_models.py::test_model[hubbard]") == "heisenberg"
+    assert (
+        report._picture_of("bench_models.py::test_model_propagate[hubbard]")
+        == "heisenberg"
+    )
 
 
 def test_display_op_strips_picture_and_names_model() -> None:
@@ -52,7 +55,8 @@ def test_display_op_strips_picture_and_names_model() -> None:
         == "random / build_graph"
     )
     assert (
-        report._display_op("bench_models.py::test_model[hubbard]") == "model / hubbard"
+        report._display_op("bench_models.py::test_model_propagate[hubbard]")
+        == "hubbard / propagate"
     )
 
 
@@ -68,7 +72,7 @@ def _write_timings(results_dir: Path, label: str = "np1") -> None:
                 "stats": {"mean": 0.002},
             },
             {
-                "fullname": "benches/bench_models.py::test_model[hubbard]",
+                "fullname": "benches/bench_models.py::test_model_propagate[hubbard]",
                 "stats": {"mean": 1.5},
             },
         ]
@@ -91,8 +95,8 @@ def test_build_report_has_two_sections(tmp_path: Path) -> None:
     heis = md[md.index("## Heisenberg") : md.index("## Schrödinger")]
     schr = md[md.index("## Schrödinger") :]
 
-    assert "model / hubbard" in heis
-    assert "model / hubbard" not in schr
+    assert "hubbard / propagate" in heis
+    assert "hubbard / propagate" not in schr
     assert "random / energy" in heis
     assert "random / energy" in schr
 
@@ -229,18 +233,6 @@ def test_build_report_includes_memory(tmp_path: Path) -> None:
     assert "40.00 MiB" in md
 
 
-def test_build_report_includes_resting(tmp_path: Path) -> None:
-    _write_timings(tmp_path)
-    _write_results(
-        tmp_path,
-        memrest={"heisenberg": 52428800},
-    )
-    md = _collapse(report.build_report(tmp_path))
-
-    assert "## Operator resting footprint (RSS)" in md
-    assert "| Heisenberg | 50.00 MiB |" in md
-
-
 def test_build_report_sorts_labels_numerically(tmp_path: Path) -> None:
     for label in ("np1", "np2", "np10"):
         _write_timings(tmp_path, label)
@@ -253,7 +245,7 @@ def test_build_report_omits_empty_schrodinger_section(tmp_path: Path) -> None:
     data = {
         "benchmarks": [
             {
-                "fullname": "benches/bench_models.py::test_model[pauli]",
+                "fullname": "benches/bench_models.py::test_model_propagate[pauli]",
                 "stats": {"mean": 2.0},
             }
         ]
@@ -262,3 +254,16 @@ def test_build_report_omits_empty_schrodinger_section(tmp_path: Path) -> None:
     md = _collapse(report.build_report(tmp_path))
     assert "## Heisenberg" in md
     assert "## Schrödinger" not in md
+
+
+def test_two_models_do_not_share_a_row_label() -> None:
+    # Every fixed-model test is named test_model_*, so the model lives only in the
+    # parameter. Dropping it labels the hubbard and the pauli row identically and the
+    # report shows two rows nobody can tell apart.
+    keys = [
+        f"bench_models.py::test_model_{op}[{model}]"
+        for op in ("build_graph", "propagate", "energy", "gradient")
+        for model in ("hubbard", "pauli")
+    ]
+    labels = [report._display_op(k) for k in keys]
+    assert len(set(labels)) == len(keys)

--- a/packages/monoprop-bench-tools/tests/test_rungs.py
+++ b/packages/monoprop-bench-tools/tests/test_rungs.py
@@ -1,0 +1,368 @@
+# Copyright 2026 Algorithmiq
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the rung table, its gate, and the ladder collator.
+
+Every gate is tested by being made to fire. A gate that has only ever been seen to pass has
+not been shown to work: "the run was clean" and "the check never ran" are the same
+observation from outside.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+from monoprop_bench_tools import rungs
+
+REPO = Path(__file__).resolve().parents[3]
+TABLE = REPO / "benches" / "rungs.toml"
+
+_CLEAN = {
+    "id": "n1-clean",
+    "family": "size",
+    "picture": "heisenberg",
+    "model": "hubbard",
+    "ops": ["propagate"],
+    "nodes": 1,
+    "ranks_per_node": 8,
+    "partitions": 16,
+    "expect_terms": 1_000_000,
+    "reps": 5,
+}
+
+
+def _table(tmp_path: Path, *entries: dict) -> Path:
+    """Write a rung table holding ``entries`` and return its path."""
+    body = "\n".join(
+        "[[rung]]\n" + "\n".join(f"{k} = {json.dumps(v)}" for k, v in entry.items())
+        for entry in entries
+    )
+    path = tmp_path / "rungs.toml"
+    path.write_text(body + "\n")
+    return path
+
+
+def _results(**overrides) -> dict:
+    """Return an artifact that passes every gate, before ``overrides`` are applied."""
+    results = {
+        "meta": {"nodes": 1, "ranks_per_node": 8, "partitions_env": "16"},
+        "params": {"bench_rounds": 1},
+        "opsize": {"hubbard": {"terms": 1_000_000}},
+    }
+    for section, value in overrides.items():
+        results[section] = {**results.get(section, {}), **value}
+    return results
+
+
+# --------------------------------------------------------------------------- the table
+
+
+def test_the_shipped_table_loads() -> None:
+    table = rungs.load_rungs(TABLE)
+    assert table
+    assert {r.family for r in table.values()} <= rungs.FAMILIES
+
+
+def test_the_shipped_table_carries_the_full_scaling_ladder() -> None:
+    table = rungs.load_rungs(TABLE)
+    scaling = [r for r in table.values() if r.family in {"strong", "weak"}]
+    assert len(scaling) == 38, "the 2026-08-27 campaign is 21 weak and 17 strong rungs"
+    assert all(r.calibrated for r in scaling), (
+        "a ported rung carries its measured term count"
+    )
+
+
+def test_every_scaling_rung_declares_what_it_cost() -> None:
+    """The ported campaign's measured cost travels with the row, not in a second file."""
+    scaling = [r for r in rungs.load_rungs(TABLE).values() if r.family != "size"]
+    assert len(scaling) == 38
+    assert all(r.cost_seconds > 0 and r.cost_gib_per_node > 0 for r in scaling)
+    assert all(r.cost != "?" for r in scaling)
+
+
+def test_duplicate_ids_are_refused(tmp_path: Path) -> None:
+    path = _table(tmp_path, _CLEAN, _CLEAN)
+    with pytest.raises(SystemExit, match="duplicate rung id"):
+        rungs.load_rungs(path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("family", "sizes", "family"),
+        ("picture", "interaction", "picture"),
+        ("model", "heisenberg", "model"),
+        ("ops", ["pare"], "unknown ops"),
+        ("ops", [], "ops is empty"),
+        ("nodes", 0, "nodes must be"),
+    ],
+)
+def test_an_unknown_value_is_refused(
+    tmp_path: Path, field: str, value: object, match: str
+) -> None:
+    path = _table(tmp_path, {**_CLEAN, field: value})
+    with pytest.raises(SystemExit, match=match):
+        rungs.load_rungs(path)
+
+
+def test_a_picture_is_refused_on_a_fixed_model(tmp_path: Path) -> None:
+    path = _table(tmp_path, {**_CLEAN, "picture": "schrodinger"})
+    with pytest.raises(SystemExit, match="only the random model has a picture axis"):
+        rungs.load_rungs(path)
+
+
+def test_a_missing_field_names_itself(tmp_path: Path) -> None:
+    entry = {k: v for k, v in _CLEAN.items() if k != "reps"}
+    path = _table(tmp_path, entry)
+    with pytest.raises(SystemExit, match=r"missing.*reps"):
+        rungs.load_rungs(path)
+
+
+# ----------------------------------------------------------------------- the invocation
+
+
+def test_the_selector_names_the_random_tests_and_the_picture(tmp_path: Path) -> None:
+    entry = {**_CLEAN, "model": "random", "ops": ["energy", "gradient"]}
+    rung = rungs.load_rungs(_table(tmp_path, entry))["n1-clean"]
+    assert rung.bench_file == "benches/bench_random.py"
+    assert (
+        rung.selector() == "(test_random_energy or test_random_gradient) and heisenberg"
+    )
+
+
+def test_the_selector_names_the_model_tests_and_the_model(tmp_path: Path) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, _CLEAN))["n1-clean"]
+    assert rung.bench_file == "benches/bench_models.py"
+    assert rung.selector() == "(test_model_propagate) and hubbard"
+
+
+def test_the_geometry_is_derived_not_stored(tmp_path: Path) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, {**_CLEAN, "nodes": 8}))["n1-clean"]
+    assert (rung.ranks, rung.world) == (64, 1024)
+
+
+def test_one_round_is_forced_on_the_command_line(tmp_path: Path) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, _CLEAN))["n1-clean"]
+    argv = rungs.pytest_argv(rung, tmp_path, "n1-clean-r1")
+    assert "--bench-rounds=1" in argv, (
+        "a second round holds two propagators and doubles peak RSS"
+    )
+
+
+def test_the_partition_count_reaches_the_engine(tmp_path: Path) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, _CLEAN))["n1-clean"]
+    env = rungs.bench_env(rung, tmp_path, "n1-clean-r1")
+    assert env["monoprop_PARTITIONS"] == "16"
+    assert env["monoprop_NUM_THREADS"] == "16"
+
+
+# ------------------------------------------------------------------------------ the gate
+
+
+def test_a_clean_artifact_passes(tmp_path: Path) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, _CLEAN))["n1-clean"]
+    assert rungs.gate(rung, _results()) == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"meta": {"nodes": 2}}, "nodes"),
+        ({"meta": {"ranks_per_node": 4}}, "ranks_per_node"),
+        ({"meta": {"partitions_env": "128"}}, "partitions"),
+        ({"params": {"bench_rounds": 5}}, "bench_rounds"),
+        ({"opsize": {"hubbard": {"terms": 1_002_000}}}, "terms"),
+    ],
+)
+def test_the_gate_fires(tmp_path: Path, overrides: dict, match: str) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, _CLEAN))["n1-clean"]
+    reasons = rungs.gate(rung, _results(**overrides))
+    assert any(match in reason for reason in reasons), reasons
+
+
+def test_a_term_count_inside_the_tolerance_passes(tmp_path: Path) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, _CLEAN))["n1-clean"]
+    assert rungs.gate(rung, _results(opsize={"hubbard": {"terms": 1_000_500}})) == []
+
+
+def test_a_run_that_recorded_no_size_is_refused(tmp_path: Path) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, _CLEAN))["n1-clean"]
+    results = _results()
+    results["opsize"] = {}
+    assert any("no operator size" in r for r in rungs.gate(rung, results))
+
+
+def test_a_node_id_keyed_size_is_read_when_no_axis_key_exists(tmp_path: Path) -> None:
+    rung = rungs.load_rungs(_table(tmp_path, _CLEAN))["n1-clean"]
+    results = _results()
+    results["opsize"] = {
+        "bench_models.py::test_model_propagate[hubbard]": {"terms": 1_000_000}
+    }
+    assert rungs.gate(rung, results) == []
+
+
+def test_an_uncalibrated_rung_refuses_to_run(tmp_path: Path) -> None:
+    path = _table(tmp_path, {**_CLEAN, "expect_terms": 0})
+    assert rungs.run_main([str(path), "n1-clean", "--dry-run"]) == 2
+
+
+def test_an_unmeasured_size_knob_refuses_to_run(tmp_path: Path) -> None:
+    """`TBD` on a knob is uncalibrated even where a term count was somehow filled in."""
+    entry = {**_CLEAN, "args": ["--hubbard-cutoff=10", "--hubbard-lower-atol=TBD"]}
+    path = _table(tmp_path, {**entry, "expect_terms": 0})
+    assert rungs.run_main([str(path), "n1-clean", "--dry-run"]) == 2
+
+
+def test_a_measured_size_with_an_unmeasured_knob_is_refused(tmp_path: Path) -> None:
+    entry = {**_CLEAN, "args": ["--hubbard-lower-atol=TBD"]}
+    with pytest.raises(SystemExit, match="unmeasured cannot have a measured size"):
+        rungs.load_rungs(_table(tmp_path, entry))
+
+
+def test_no_shipped_rung_pairs_a_term_count_with_an_unmeasured_knob() -> None:
+    """The loader enforces it; this states it of the table that ships."""
+    for rung in rungs.load_rungs(TABLE).values():
+        unset = [a for a in rung.args if a.endswith(f"={rungs.UNSET}")]
+        assert not unset or not rung.calibrated, rung.id
+
+
+def test_a_calibrated_rung_dry_runs(tmp_path: Path) -> None:
+    path = _table(tmp_path, _CLEAN)
+    assert rungs.run_main([str(path), "n1-clean", "--dry-run"]) == 0
+
+
+def test_an_unknown_rung_id_is_an_error(tmp_path: Path) -> None:
+    path = _table(tmp_path, _CLEAN)
+    assert rungs.run_main([str(path), "no-such-rung"]) == 2
+
+
+# --------------------------------------------------------------------------- the ladder
+
+
+def _rep(
+    results_dir: Path, rung_id: str, rep: int, seconds: float, peak: int, **overrides
+) -> None:
+    """Write the two artifacts one rep of ``rung_id`` leaves behind."""
+    label = f"{rung_id}-r{rep}"
+    results = _results(**overrides)
+    results["memhwm"] = {"x::y": peak}
+    (results_dir / f"{label}.json").write_text(json.dumps(results))
+    (results_dir / f"time-{label}.json").write_text(
+        json.dumps({"benchmarks": [{"fullname": "x::y", "stats": {"median": seconds}}]})
+    )
+
+
+def test_the_ladder_collates_reps_on_the_median(tmp_path: Path) -> None:
+    table = _table(tmp_path, _CLEAN)
+    for rep, seconds in enumerate([10.0, 11.0, 40.0], start=1):
+        _rep(tmp_path, "n1-clean", rep, seconds, peak=rungs.BYTES_PER_GIB)
+    (cell,) = rungs.collate(rungs.load_rungs(table), tmp_path)
+    assert cell.reps == 3
+    md = rungs.render([cell])
+    assert "| 11.00 | 10.00 |" in md, "median then min, never the mean"
+    assert "| 1.0 | — | — |" in md, "one summed GiB over one node, and no declared cost"
+
+
+def test_the_ladder_drops_a_rep_the_gate_refuses(tmp_path: Path) -> None:
+    table = _table(tmp_path, _CLEAN)
+    _rep(tmp_path, "n1-clean", 1, 10.0, peak=rungs.BYTES_PER_GIB)
+    _rep(
+        tmp_path,
+        "n1-clean",
+        2,
+        10.0,
+        peak=rungs.BYTES_PER_GIB,
+        opsize={"hubbard": {"terms": 9}},
+    )
+    (cell,) = rungs.collate(rungs.load_rungs(table), tmp_path)
+    assert cell.reps == 1
+
+
+def test_the_ladder_shows_the_declared_cost(tmp_path: Path) -> None:
+    table = _table(tmp_path, {**_CLEAN, "cost_seconds": 10.0, "cost_gib_per_node": 4.0})
+    _rep(tmp_path, "n1-clean", 1, 12.0, peak=rungs.BYTES_PER_GIB)
+    cells = rungs.collate(rungs.load_rungs(table), tmp_path)
+    assert "| 10.00 | 1.200x |" in rungs.render(cells)
+
+
+def test_a_rung_nobody_has_timed_shows_no_ratio(tmp_path: Path) -> None:
+    table = _table(tmp_path, _CLEAN)
+    _rep(tmp_path, "n1-clean", 1, 12.0, peak=rungs.BYTES_PER_GIB)
+    md = rungs.render(rungs.collate(rungs.load_rungs(table), tmp_path))
+    assert "| — | — |" in md, "no declared cost must print no ratio, never 0.000x"
+
+
+def test_the_ladder_describes_the_problem_it_measured(tmp_path: Path) -> None:
+    """A number without its parameters is not reproducible from the block alone."""
+    table = _table(tmp_path, _CLEAN)
+    _rep(
+        tmp_path,
+        "n1-clean",
+        1,
+        10.0,
+        peak=rungs.BYTES_PER_GIB,
+        configs={"hubbard": {"num_sites": 12, "cutoff": 10, "lower_atol": 1.25e-05}},
+    )
+    md = rungs.render(rungs.collate(rungs.load_rungs(table), tmp_path))
+    assert "## Problems measured" in md
+    assert "cutoff=10" in md
+    assert "lower_atol=1.25e-05" in md
+    assert "num_sites=12" in md
+
+
+def test_the_random_problem_is_described_from_params(tmp_path: Path) -> None:
+    """The random model's parameters live in `params`, not in `configs`."""
+    entry = {**_CLEAN, "model": "random", "args": []}
+    table = _table(tmp_path, entry)
+    _rep(
+        tmp_path,
+        "n1-clean",
+        1,
+        10.0,
+        peak=rungs.BYTES_PER_GIB,
+        opsize={"heisenberg": {"terms": 1_000_000}},
+        params={"bench_rounds": 1, "num_generators": 1000, "cutoff": 6},
+    )
+    md = rungs.render(rungs.collate(rungs.load_rungs(table), tmp_path))
+    assert "num_generators=1000" in md
+
+
+def test_the_ladder_orders_a_rung_by_node_count(tmp_path: Path) -> None:
+    """A ladder is read down the page, so n2 must not sort between n1 and n16."""
+    counts = (1, 2, 16)
+    entries = [{**_CLEAN, "id": f"strong-n{n}", "nodes": n} for n in counts]
+    table = _table(tmp_path, *entries)
+    for n in counts:
+        _rep(
+            tmp_path,
+            f"strong-n{n}",
+            1,
+            10.0,
+            peak=rungs.BYTES_PER_GIB,
+            meta={"nodes": n},
+        )
+    md = rungs.render(rungs.collate(rungs.load_rungs(table), tmp_path))
+    order = [
+        line.split("|")[1].strip()
+        for line in md.splitlines()
+        if line.startswith("| strong-n")
+    ]
+    assert order == ["strong-n1", "strong-n2", "strong-n16"]
+
+
+def test_the_table_is_valid_toml() -> None:
+    assert tomllib.loads(TABLE.read_text())["rung"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What this is

`benches/` carried three benchmarks nobody asked for and four tracked measures where three are
read. More importantly, the benchmark set that actually matters — the 10M/100M/1B ladder and the
strong/weak scaling rungs — existed only as flags in a shell script on one cluster, so there was
no fixed set a PR author could run and no standard to report against.

This makes the benchmark set a table in the repository, with a runner, a gate on what it
measured, and a paste-ready block of results. **Nothing runs automatically and nothing gates a
PR.** Running the rungs a change could plausibly move, and putting the numbers in the PR, is the
author's job.

## Four operations, everywhere

`build_graph`, `propagate`, `energy`, `gradient` — uniform across both bench modules, both
pictures and both fixed models. Deleted:

| removed | why |
| --- | --- |
| `test_random_pare` | outside the set |
| `test_random_inplace` | `propagate` followed by `energy`, both already benchmarked |
| `test_model` | `test_model_propagate` plus a trailing `expectation_value` |

**Deletions, never renames.** A benchmark name is Bencher's history key; the surviving names are
byte-identical to `main`'s, so no series is orphaned.

## Three measures

Tracked: `latency`, `peak-memory`, `terms` (exact match). `resting-memory` is dropped and its
report section removed. The raw `memrest` / `membase` / `opbytes` / `opmemdelta` / `opmempeak`
recordings **stay** in `conftest.py` — unrendered here, but read by the out-of-tree A/B harness.
`benches/results/README.md` now says so.

## The benchmark set — `benches/rungs.toml`

```bash
monoprop-bench-rung benches/rungs.toml list               # the set, and what each costs
monoprop-bench-rung benches/rungs.toml <id> --dry-run     # the plan, no allocation spent
monoprop-bench-rung benches/rungs.toml <id> --rep 1       # one rep
monoprop-bench-ladder benches/rungs.toml benches/results  # the block to paste here
```

`monoprop-bench-ladder` prints the timings, the peak memory, **and the resolved parameters of
every problem measured** — read back from the run rather than from the row's overrides, so a
reviewer can see what was measured without resolving flags against a model's defaults:

Its actual output, from the tiny two-rep run used to check this end to end:

```
## size

| rung | nodes | R | P | terms | Mterms/node | reps | median s | min s | Mterms/s/node | GiB/node | declared s | vs declared |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| tiny-hubbard-propagate | 1 | 1 | 2 | 137 | 0 | 2 | 0.00 | 0.00 | 0.14 | 0.4 | 0.00 | 0.494x |

## Problems measured

- **tiny-hubbard-propagate** — hubbard / heisenberg, propagate, 1 x 1 x 2 (nodes x ranks/node x partitions)
  - chemical_potential=0.0, cutoff=6, hopping=1.0, interaction=-2.0, lower_atol=0.0001,
    neel_start_spin=down, num_sites=3, observable_site=1, observable_spin=up,
    trotter_dt=0.2, trotter_steps=2
```

### What each row declares

`expect_terms` is a **gate**: a result missing it by more than 0.1% is refused (renamed
`.refused.json`, not deleted), as is one whose node count, rank count, partition count or timing
round count disagrees with the row. A mistyped knob fails the cell instead of quietly measuring a
different problem.

`--bench-rounds=1` is forced, not defaulted: `pedantic` builds round *k+1*'s arguments before
releasing round *k*'s, so a second round holds two propagators and doubles peak RSS. Repetition
is repeated process launches, which is what `--rep` names.

`cost_seconds` and `cost_gib_per_node` are the opposite of a gate — **what one rep last cost**, so
you can see what a rung takes before you spend it, and so a re-run can be shown against the last
one. Documentation only: a timing is noisy and your machine is not the machine they were taken on.
The 38 scaling rungs carry the measured medians of the 2026-08-27 Deucalion campaign, along with
its provenance and the fitted memory law `GiB/node = 3.39 + 0.0634 × Mterms/node`. Folding them
into the table replaced the separate baseline JSON, so there is one file to keep in sync instead
of two.

A row nobody has calibrated says so twice — `expect_terms = 0` **and** `TBD` on every unmeasured
size knob — and refuses to run. `TBD` rather than `0` because `0` is not neutral:
`lower_atol = 0` prunes nothing and is the *largest* problem the model can pose, so a placeholder
`0` would invite exactly the allocation-burning run the gate exists to prevent.

### Why the graph rows stop at one node

`build_graph` extends the graph rather than replacing it, so it retains one layer-set per gate
while `propagate` releases each layer as it contracts. Measured: Hubbard reaches 97M terms through
`propagate` in well under 2 GiB, while four successive `build_graph` calls on the same model
exceed a 242 GiB node. So `propagate` carries the full 10M/100M/1B ladder and the graph-holding
operations cap at a single node. Adding a multi-node graph rung later is one row.

Running a rung needs a machine, a scheduler and an allocation, none of which belong here. **The
table, the runner and the gate are in the repo; the launcher that submits them is not.**

## How to run them — `benches/RUNGS.md`

A new guide covering: what each field of a row declares and which of them gate; **every parameter
of all three models** with its default and its effect; why `lower_atol` is the size knob and the
other axes are saturated; how nodes, ranks and partitions map onto a machine and why `P` is the
number that matters; **example Slurm scripts** for one node, many nodes and a ladder in one
allocation; the pinning and allocation-sizing traps (`--cpu-bind=none` measured a 1.45x penalty;
`MALLOC_ARENA_MAX` set to the partition count cost ~16% of wall); and how to calibrate a `TBD` row
off the gate's own refusal message.

Every shell example in it is syntax-checked and every documented invocation was run.

## The 66 rungs, with their model parameters

The `size` family is the requested matrix exactly: **10M single-thread, 100M and 1B on one node,
1B across eight** — for `propagate` on all three models, and for `build_graph` and
`energy`+`gradient` on the random model at 1000 generators in both pictures. 12 propagate rows +
16 graph/eval rows.

Which of the graph rungs actually fit is a question calibration answers. `build_graph` retains one
layer-set per gate, and at 1000 generators that is an order of magnitude more than the 100-generator
measurement anyone has. A row that does not fit records the node count it needed, or that it
exceeded the machine, and stays uncalibrated — that is a measurement of the graph path's cost, not
a gap.

**System-size ceilings**, which the option list does not show: `monoprop_MAX_NUM_MODES` defaults to
250, so `--num-modes` caps at 250 and `--hubbard-num-sites` at 125. `--pauli-num-qubits` is
effectively fixed at 127 — the circuit is built over a hard-coded IBM Eagle heavy-hex map of 144
pairs whose highest index is 126, so a lower value fails and a higher one only adds idle qubits.
Size the Pauli model with `cutoff`, `num-layers` and `lower-atol` instead.

`cost/rep` is the last measured wall time and peak GiB/node; `?` means nobody has timed it yet.

<details><summary><b>size</b> — the 10M / 100M / 1B / multinode-1B ladder (28 rungs)</summary>

| rung | model / picture | ops | N x R/node x parts | terms | knobs | cost/rep |
| --- | --- | --- | --- | ---: | --- | --- |
| `st-10m-hubbard-propagate` | hubbard / heisenberg | propagate | 1x1x1 | TBD | `hubbard-cutoff=10, hubbard-lower-atol=TBD` | ? |
| `st-10m-pauli-propagate` | pauli / heisenberg | propagate | 1x1x1 | TBD | `pauli-cutoff=12, pauli-lower-atol=TBD` | ? |
| `st-10m-random-propagate` | random / heisenberg | propagate | 1x1x1 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-100m-hubbard-propagate` | hubbard / heisenberg | propagate | 1x8x16 | 96,981,051 | `hubbard-cutoff=10, hubbard-lower-atol=1.25e-05` | ? |
| `n1-100m-pauli-propagate` | pauli / heisenberg | propagate | 1x8x16 | 91,273,861 | `pauli-cutoff=14, pauli-lower-atol=5e-05` | ? |
| `n1-100m-random-propagate` | random / heisenberg | propagate | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-1b-hubbard-propagate` | hubbard / heisenberg | propagate | 1x8x16 | TBD | `hubbard-cutoff=10, hubbard-lower-atol=TBD` | ? |
| `n1-1b-pauli-propagate` | pauli / heisenberg | propagate | 1x8x16 | TBD | `pauli-cutoff=14, pauli-lower-atol=TBD` | ? |
| `n1-1b-random-propagate` | random / heisenberg | propagate | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n8-1b-hubbard-propagate` | hubbard / heisenberg | propagate | 8x8x16 | TBD | `hubbard-cutoff=10, hubbard-lower-atol=TBD` | ? |
| `n8-1b-pauli-propagate` | pauli / heisenberg | propagate | 8x8x16 | TBD | `pauli-cutoff=14, pauli-lower-atol=TBD` | ? |
| `n8-1b-random-propagate` | random / heisenberg | propagate | 8x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `st-10m-random-graph-heisenberg` | random / heisenberg | build_graph | 1x1x1 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `st-10m-random-eval-heisenberg` | random / heisenberg | energy, gradient | 1x1x1 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `st-10m-random-graph-schrodinger` | random / schrodinger | build_graph | 1x1x1 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `st-10m-random-eval-schrodinger` | random / schrodinger | energy, gradient | 1x1x1 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-100m-random-graph-heisenberg` | random / heisenberg | build_graph | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-100m-random-graph-schrodinger` | random / schrodinger | build_graph | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-100m-random-eval-heisenberg` | random / heisenberg | energy, gradient | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-100m-random-eval-schrodinger` | random / schrodinger | energy, gradient | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-1b-random-graph-heisenberg` | random / heisenberg | build_graph | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-1b-random-graph-schrodinger` | random / schrodinger | build_graph | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-1b-random-eval-heisenberg` | random / heisenberg | energy, gradient | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n1-1b-random-eval-schrodinger` | random / schrodinger | energy, gradient | 1x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n8-1b-random-graph-heisenberg` | random / heisenberg | build_graph | 8x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n8-1b-random-graph-schrodinger` | random / schrodinger | build_graph | 8x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n8-1b-random-eval-heisenberg` | random / heisenberg | energy, gradient | 8x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |
| `n8-1b-random-eval-schrodinger` | random / schrodinger | energy, gradient | 8x8x16 | TBD | `num-generators=1000, num-modes=250, cutoff=6, obs-terms=TBD` | ? |

</details>

<details><summary><b>weak</b> — fixed terms per node, 1 to 64 nodes (21 rungs)</summary>

| rung | model / picture | ops | N x R/node x parts | terms | knobs | cost/rep |
| --- | --- | --- | --- | ---: | --- | --- |
| `weak-97m-n1` | hubbard / heisenberg | propagate | 1x8x16 | 96,981,051 | `hubbard-cutoff=10, hubbard-lower-atol=1.25e-05` | 10.8s 10.8GiB/node |
| `weak-97m-n2` | hubbard / heisenberg | propagate | 2x8x16 | 184,124,520 | `hubbard-cutoff=10, hubbard-lower-atol=8.8e-06` | 10.6s 9.6GiB/node |
| `weak-97m-n4` | hubbard / heisenberg | propagate | 4x8x16 | 377,482,074 | `hubbard-cutoff=10, hubbard-lower-atol=5.9e-06` | 13.1s 11.5GiB/node |
| `weak-97m-n8` | hubbard / heisenberg | propagate | 8x8x16 | 781,669,404 | `hubbard-cutoff=10, hubbard-lower-atol=3.9e-06` | 14.5s 10.9GiB/node |
| `weak-97m-n16` | hubbard / heisenberg | propagate | 16x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 18.1s 11GiB/node |
| `weak-97m-n32` | hubbard / heisenberg | propagate | 32x8x16 | 3,104,527,573 | `hubbard-cutoff=10, hubbard-lower-atol=1.73e-06` | 24.4s 11GiB/node |
| `weak-97m-n64` | hubbard / heisenberg | propagate | 64x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 36.6s 11.4GiB/node |
| `weak-385m-n1` | hubbard / heisenberg | propagate | 1x8x16 | 377,482,074 | `hubbard-cutoff=10, hubbard-lower-atol=5.9e-06` | 47.7s 26.6GiB/node |
| `weak-385m-n2` | hubbard / heisenberg | propagate | 2x8x16 | 781,669,404 | `hubbard-cutoff=10, hubbard-lower-atol=3.9e-06` | 50.9s 28GiB/node |
| `weak-385m-n4` | hubbard / heisenberg | propagate | 4x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 53.3s 27.9GiB/node |
| `weak-385m-n8` | hubbard / heisenberg | propagate | 8x8x16 | 3,104,527,573 | `hubbard-cutoff=10, hubbard-lower-atol=1.73e-06` | 54.7s 27.5GiB/node |
| `weak-385m-n16` | hubbard / heisenberg | propagate | 16x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 58s 27.4GiB/node |
| `weak-385m-n32` | hubbard / heisenberg | propagate | 32x8x16 | 12,255,330,837 | `hubbard-cutoff=10, hubbard-lower-atol=7.35e-07` | 64.6s 26.3GiB/node |
| `weak-385m-n64` | hubbard / heisenberg | propagate | 64x8x16 | 24,419,998,198 | `hubbard-cutoff=10, hubbard-lower-atol=4.68e-07` | 79.9s 26.9GiB/node |
| `weak-1529m-n1` | hubbard / heisenberg | propagate | 1x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 216s 99.9GiB/node |
| `weak-1529m-n2` | hubbard / heisenberg | propagate | 2x8x16 | 3,104,527,573 | `hubbard-cutoff=10, hubbard-lower-atol=1.73e-06` | 222s 100GiB/node |
| `weak-1529m-n4` | hubbard / heisenberg | propagate | 4x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 224s 101GiB/node |
| `weak-1529m-n8` | hubbard / heisenberg | propagate | 8x8x16 | 12,255,330,837 | `hubbard-cutoff=10, hubbard-lower-atol=7.35e-07` | 227s 99.9GiB/node |
| `weak-1529m-n16` | hubbard / heisenberg | propagate | 16x8x16 | 24,419,998,198 | `hubbard-cutoff=10, hubbard-lower-atol=4.68e-07` | 236s 102GiB/node |
| `weak-1529m-n32` | hubbard / heisenberg | propagate | 32x8x16 | 48,317,129,677 | `hubbard-cutoff=10, hubbard-lower-atol=2.94e-07` | 250s 101GiB/node |
| `weak-1529m-n64` | hubbard / heisenberg | propagate | 64x8x16 | 94,684,031,363 | `hubbard-cutoff=10, hubbard-lower-atol=1.82e-07` | 257s 84.3GiB/node |

</details>

<details><summary><b>strong</b> — fixed total terms, 1 to 64 nodes (17 rungs)</summary>

| rung | model / picture | ops | N x R/node x parts | terms | knobs | cost/rep |
| --- | --- | --- | --- | ---: | --- | --- |
| `strong-1569m-n1` | hubbard / heisenberg | propagate | 1x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 216s 99.9GiB/node |
| `strong-1569m-n2` | hubbard / heisenberg | propagate | 2x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 106s 51.5GiB/node |
| `strong-1569m-n4` | hubbard / heisenberg | propagate | 4x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 53.3s 28GiB/node |
| `strong-1569m-n8` | hubbard / heisenberg | propagate | 8x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 28.6s 15.9GiB/node |
| `strong-1569m-n16` | hubbard / heisenberg | propagate | 16x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 18.1s 11GiB/node |
| `strong-1569m-n32` | hubbard / heisenberg | propagate | 32x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 16.1s 6.6GiB/node |
| `strong-1569m-n64` | hubbard / heisenberg | propagate | 64x8x16 | 1,569,152,761 | `hubbard-cutoff=10, hubbard-lower-atol=2.6e-06` | 24s 4.1GiB/node |
| `strong-6126m-n2` | hubbard / heisenberg | propagate | 2x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 450s 200GiB/node |
| `strong-6126m-n4` | hubbard / heisenberg | propagate | 4x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 224s 101GiB/node |
| `strong-6126m-n8` | hubbard / heisenberg | propagate | 8x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 110s 51.3GiB/node |
| `strong-6126m-n16` | hubbard / heisenberg | propagate | 16x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 58.8s 27.4GiB/node |
| `strong-6126m-n32` | hubbard / heisenberg | propagate | 32x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 38.1s 16.1GiB/node |
| `strong-6126m-n64` | hubbard / heisenberg | propagate | 64x8x16 | 6,125,805,627 | `hubbard-cutoff=10, hubbard-lower-atol=1.14e-06` | 37s 11.4GiB/node |
| `strong-24420m-n8` | hubbard / heisenberg | propagate | 8x8x16 | 24,419,998,198 | `hubbard-cutoff=10, hubbard-lower-atol=4.68e-07` | 471s 201GiB/node |
| `strong-24420m-n16` | hubbard / heisenberg | propagate | 16x8x16 | 24,419,998,198 | `hubbard-cutoff=10, hubbard-lower-atol=4.68e-07` | 235s 102GiB/node |
| `strong-24420m-n32` | hubbard / heisenberg | propagate | 32x8x16 | 24,419,998,198 | `hubbard-cutoff=10, hubbard-lower-atol=4.68e-07` | 127s 52.2GiB/node |
| `strong-24420m-n64` | hubbard / heisenberg | propagate | 64x8x16 | 24,419,998,198 | `hubbard-cutoff=10, hubbard-lower-atol=4.68e-07` | 79.6s 26.9GiB/node |

</details>


## CI

One workflow change, and it is not a gate: `bench.yml` drops the `resting-memory` threshold and
gains an artifact upload of `bmf.json` and the raw results, so a failed Bencher upload no longer
loses the measurement. `bench_main.yml` and `bench_bare_metal.yml` are untouched and still just
track the main branch.

## Drive-by fix

`report.py`'s `_display_op` collapsed every `test_model_*[hubbard]` and `test_model_*[pauli]` row
to the same label, so the two models were indistinguishable in the report. A parameter that is not
a picture now names the model and replaces the group: `hubbard / propagate`, `pauli / build_graph`.
Regression test updated in both directions.

## Verification

Run on a Deucalion login node against this branch:

- `uv run pytest` — **662 passed, 8 skipped** (the 8 need `--with-mpi`).
- `prek run --from-ref origin/main --to-ref HEAD` — every hook clean on the changed files.
- Bench smoke — 8 benchmarks collect and run after the deletions.
- Full bench run + `monoprop-bench-report` — the resting-footprint section is gone; the hubbard
  and pauli rows are now distinct.
- `monoprop-bench-bmf` — exactly `latency`, `peak-memory`, `terms`; 20 benchmark names, all
  unchanged from `main`.
- Every `args` entry of all 58 rungs checked against `pytest --help`'s option list — no unknown
  flags.
- Two reps of a tiny Hubbard rung end to end: the gate first **refused** a wrong `expect_terms`
  (137 measured vs 2,276 declared), then passed once corrected, and the ladder rendered both the
  table and the resolved model parameters.
- The ladder-ordering fix was mutation-tested — reverting the sort key fails the new test.

## Not done here

The 18 uncalibrated rows need a cluster allocation to measure; they refuse to run until then. The
private harness is updated separately to call `monoprop-bench-rung` instead of its own launchers,
and keeps working unchanged until it is.
