### PR TITLE
fix: make mpi init and finalize visible in dso

### DIFF
--- a/cpp/monoprop/detail/mpi/MPICompat.h
+++ b/cpp/monoprop/detail/mpi/MPICompat.h
@@ -41,8 +41,8 @@
 namespace monoprop::mpi {
 
 #ifdef monoprop_ENABLE_MPI
-auto init(int *argc = nullptr, char ***argv = nullptr) -> void;
-auto finalize() -> void;
+monoprop_EXPORT auto init(int *argc = nullptr, char ***argv = nullptr) -> void;
+monoprop_EXPORT auto finalize() -> void;
 
 namespace detail {
 template <class>


### PR DESCRIPTION
<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

## Summary

<!-- Provide a self-contained description of what this PR does and why.
     Explain the problem being solved and the approach taken. -->

This makes MPI related functions init/finilaze  appear in `libmonoprop.so`'s dynamic symbol table. Similar to fix to PR #290 .

## Changes

<!-- Bullet-point list of the main changes. -->

-

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [x] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
