### PR TITLE
fix(ci): 🐛 let the C++ MPI test variants oversubscribe under OpenMPI 5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,9 +244,7 @@ jobs:
 
       - name: Run C++ unit tests under MPI
         if: matrix.mpi == 'on'
-        # The mpi variants call `mpiexec -n <n>` themselves, so --map-by cannot reach them and a
-        # runner with fewer cores than ranks refuses to place. OMPI_MCA_* is the OpenMPI 4 spelling,
-        # ignored by 5, so both are set.
+        # set both OpenMPI 4 (ORTE) and OpenMPI 5 (PRRTE) variants of the oversubscription setting
         env:
           PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
           OMPI_MCA_rmaps_base_oversubscribe: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,12 @@ jobs:
 
       - name: Run C++ unit tests under MPI
         if: matrix.mpi == 'on'
+        # The mpi variants call `mpiexec -n <n>` themselves, so --map-by cannot reach them and a
+        # runner with fewer cores than ranks refuses to place. OMPI_MCA_* is the OpenMPI 4 spelling,
+        # ignored by 5, so both are set.
+        env:
+          PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
+          OMPI_MCA_rmaps_base_oversubscribe: "1"
         run: |
           ctest --test-dir build/editable/Release \
             --output-on-failure \

--- a/justfile
+++ b/justfile
@@ -103,8 +103,6 @@ code-coverage-collect MPI BUILD_DIR OUTPUT_DIR:
     if [[ "$mpi" == "on" ]]; then
       export OMPI_ALLOW_RUN_AS_ROOT=1
       export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-      # Reaches the ctest mpi variants below, which spawn their own mpiexec. The OMPI_MCA_ name is
-      # the OpenMPI 4 spelling and is ignored by 5.
       export OMPI_MCA_rmaps_base_oversubscribe=1
       export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
       mpiexec --map-by :OVERSUBSCRIBE -n 2 \

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ test-mpi RANKS='':
         --reinstall-package monoprop --no-cache -v \
         --config-settings-package="monoprop:cmake.define.monoprop_MPI_TEST_PROCS=${ranks}"; \
     export OMPI_MCA_rmaps_base_oversubscribe="1"; \
+    export PRTE_MCA_rmaps_default_mapping_policy=":oversubscribe"; \
     for r in ${ranks//;/ }; \
     do echo "Running full Python test suite with ${r} MPI rank(s)"; \
     mpiexec -n "$r" uv run --no-sync python -m pytest tests --with-mpi -v; \
@@ -102,7 +103,10 @@ code-coverage-collect MPI BUILD_DIR OUTPUT_DIR:
     if [[ "$mpi" == "on" ]]; then
       export OMPI_ALLOW_RUN_AS_ROOT=1
       export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+      # Reaches the ctest mpi variants below, which spawn their own mpiexec. The OMPI_MCA_ name is
+      # the OpenMPI 4 spelling and is ignored by 5.
       export OMPI_MCA_rmaps_base_oversubscribe=1
+      export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
       mpiexec --map-by :OVERSUBSCRIBE -n 2 \
         uv run --no-sync coverage run --parallel-mode \
           -m pytest tests --with-mpi -m mpi


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The C++ `mpi` ctest variants spawn their own `mpiexec -n <n>` from inside the test, so the `--map-by :OVERSUBSCRIBE` that the neighbouring Python steps pass on the command line never reaches them — only the environment can. The variable both justfile recipes already export, `OMPI_MCA_rmaps_base_oversubscribe`, is the **OpenMPI 4** spelling and OpenMPI 5 ignores it.

Measured against OpenMPI 5.0.8, `mpiexec -n 4 --host localhost:2 hostname`:

| env | result |
| --- | --- |
| none | `rc=1` — refuses to place |
| `OMPI_MCA_rmaps_base_oversubscribe=1` | `rc=1` — still refuses |
| `PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe` | `rc=0`, 4 ranks |

This is latent on `main`, where `monoprop_MPI_TEST_PROCS` is `"2"` and every runner can place 2 ranks — CI stays green either way. It bites any branch that widens the sweep: at 4 ranks the `ubuntu-26.04` and `macos-15` lanes fail with `prte-rmaps-base:alloc-error` / "not enough slots", while `ubuntu-26.04-arm` places it. Both `test.yml` and the `Collect coverage [mpi:on]` job are affected, since the coverage recipe runs the same `ctest --label-regex mpi`.

Found while rebasing #296, which widens the sweep to `"2;4"` deliberately — at R=2 the peer plan resolves only one peer, so every `for k in [0, f)` in the sparse transport stays a single iteration and the multi-peer paths never run.

## Changes

- `.github/workflows/test.yml`: set `PRTE_MCA_rmaps_default_mapping_policy` (and keep the OpenMPI 4 name) on the *Run C++ unit tests under MPI* step, which previously set no environment at all.
- `justfile`: add the same export to `test-mpi` and to `code-coverage-collect`, both of which run `ctest --label-regex mpi` after exporting only the OpenMPI 4 name.

## Checklist

- [x] Tests added or updated to cover the changes — n/a; this is CI configuration. Verified by direct measurement against OpenMPI 5.0.8 (table above). Note it cannot be proven by this PR's own CI, because `main` runs the sweep at 2 ranks where the bug is invisible; #296 exercises it at 4.
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed — n/a
- [x] `CHANGELOG` / release notes updated if applicable — n/a

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: Claude Code (claude-opus-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)
