### PR TITLE
fix(cpp): 🐛 build only world-slot-local Schrodinger paired basis

### DIFF
--- a/cpp/monoprop/algebra/MajoranaAlgebra.h
+++ b/cpp/monoprop/algebra/MajoranaAlgebra.h
@@ -19,6 +19,7 @@
 #include <bit>
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <vector>
@@ -137,10 +138,39 @@ auto monomial_from_selector(const std::vector<bool> &selector, size_t inactive_m
     return current;
 }
 
-// All fully paired Majorana monomials with up to max_ones pairs, over the active logical modes only.
-template <size_t NumModes>
-auto generate_paired_op(size_t max_ones, size_t logical_num_modes) -> MonomialList<NumModes> {
-    MonomialList<NumModes> combinations;
+// How many monomials for_each_paired_monomial emits: sum over k in [0, min(max_ones, n)] of C(n, k).
+// Saturates at SIZE_MAX instead of wrapping — a caller sizing an allocation or rejecting an over-wide
+// cutoff must never be handed a modular residue that reads as small.
+inline auto paired_op_size(size_t max_ones, size_t logical_num_modes) -> size_t {
+    constexpr auto saturated = std::numeric_limits<size_t>::max();
+    max_ones = std::min(max_ones, logical_num_modes);
+    size_t total = 1;
+    size_t binomial = 1; // C(n, k) carried across iterations
+    for (size_t k = 1; k <= max_ones; ++k) {
+        const size_t factor = logical_num_modes - k + 1;
+        if (binomial > saturated / factor) {
+            return saturated;
+        }
+        // Multiply before dividing: C(n,k-1)*(n-k+1) is divisible by k, so this stays exact.
+        binomial = binomial * factor / k;
+        if (total > saturated - binomial) {
+            return saturated;
+        }
+        total += binomial;
+    }
+    return total;
+}
+
+// All fully paired Majorana monomials with up to max_ones pairs, over the active logical modes only,
+// handed to f one at a time. Never materialized: the set is up to 2^logical_num_modes wide, and a
+// distributed build runs one of these walks per world slot concurrently.
+//
+// The emission order is a contract. Ascending pair count, then, within a pair count, ascending
+// lexicographic order of the selected modes' index tuple. A distributed propagator turns this sequence
+// into row indices by keeping the entries it owns and numbering them 0, 1, 2, ..., so reordering the walk
+// renumbers every stored row and stops two runs at one (rank, partition) count from being bit-identical.
+template <size_t NumModes, typename F>
+auto for_each_paired_monomial(size_t max_ones, size_t logical_num_modes, F &&f) -> void {
     // Clamp in pairs, not bits: max_ones counts pairs and bounds the fill over `selector`, one slot per mode.
     max_ones = std::min(max_ones, logical_num_modes);
     auto selector = std::vector(logical_num_modes, false);
@@ -150,13 +180,24 @@ auto generate_paired_op(size_t max_ones, size_t logical_num_modes) -> MonomialLi
         std::fill(selector.begin(), selector.begin() + num_ones, true);
 
         do {
-            combinations.push_back(monomial_from_selector<NumModes>(selector, inactive_mode_prefix));
+            f(monomial_from_selector<NumModes>(selector, inactive_mode_prefix));
         }
         while (std::ranges::prev_permutation(selector).found);
 
         std::ranges::fill(selector, false);
     }
+}
 
+// The materialized form of for_each_paired_monomial, for callers needing random access over a basis small
+// enough to hold. Not for a distributed construction path: this is the whole global basis, so every world
+// slot would hold a copy of all of it.
+template <size_t NumModes>
+auto generate_paired_op(size_t max_ones, size_t logical_num_modes) -> MonomialList<NumModes> {
+    MonomialList<NumModes> combinations;
+    combinations.reserve(paired_op_size(max_ones, logical_num_modes));
+    for_each_paired_monomial<NumModes>(max_ones, logical_num_modes, [&](const Monomial<NumModes> &mono) {
+        combinations.push_back(mono);
+    });
     return combinations;
 }
 

--- a/cpp/monoprop/algebra/MajoranaAlgebra.h
+++ b/cpp/monoprop/algebra/MajoranaAlgebra.h
@@ -139,8 +139,7 @@ auto monomial_from_selector(const std::vector<bool> &selector, size_t inactive_m
 }
 
 // How many monomials for_each_paired_monomial emits: sum over k in [0, min(max_ones, n)] of C(n, k).
-// Saturates at SIZE_MAX instead of wrapping — a caller sizing an allocation or rejecting an over-wide
-// cutoff must never be handed a modular residue that reads as small.
+// Saturates at SIZE_MAX instead of wrapping.
 inline auto paired_op_size(size_t max_ones, size_t logical_num_modes) -> size_t {
     constexpr auto saturated = std::numeric_limits<size_t>::max();
     max_ones = std::min(max_ones, logical_num_modes);

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <format>
 #include <limits>
 #include <numeric>
 #include <stdexcept>

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -24,8 +24,10 @@
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <numeric>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <thread>
 #include <utility>
@@ -161,11 +163,40 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
         }
     }
 
-    auto sc = schrodinger_cutoff.value_or(cutoff + 2);
-    sc = std::min(sc, static_cast<unsigned int>(2 * logical_num_modes_));
-    auto op = schrodinger_ ? generate_paired_op<NumModes>(sc / 2 + sc % 2, logical_num_modes_) : local_heisenberg_terms;
+    // Schrodinger's initial rows are the global paired basis, hash-partitioned over the P = R*S world
+    // slots; Heisenberg's local_heisenberg_terms was already filtered to this slot's share above. Hence the
+    // two reserves: a global count needs its 1/P share, a local one already is the share.
+    size_t max_pairs = 0;
+    size_t expected_local_terms = std::max<size_t>(1, local_heisenberg_terms.size());
+    if (schrodinger_) {
+        // schrodinger_ is schrodinger_cutoff.has_value(), set in the member-init list, so the deref holds.
+        const auto sc = std::min(*schrodinger_cutoff, static_cast<unsigned int>(2 * logical_num_modes_));
+        max_pairs = sc / 2 + sc % 2;
+        const size_t global_terms = paired_op_size(max_pairs, logical_num_modes_);
+        // paired_op_size saturates rather than wrapping, so this is "too large to count", not a size.
+        const bool uncountable = global_terms == std::numeric_limits<size_t>::max();
+        const size_t share = global_terms / std::max<size_t>(1, num_ranks);
+        // A cutoff near the mode count makes the basis 2^logical_num_modes. Two independent ways that
+        // is hopeless, and both are needed: the count does not fit size_t at all, which is
+        // rank-independent because every slot walks the whole global basis however the rows are
+        // divided; or the slot's share of rows cannot be addressed by a term index. Rejected here by
+        // name rather than as a walk that does not finish.
+        if (uncountable || share >= detail::OperatorIndex<NumModes>::kIndexCeiling) {
+            const auto how_many = uncountable ? std::string("more than 2^64") : std::format("{}", global_terms);
+            const auto per_slot = uncountable ? std::string("as many") : std::format("{}", share);
+            throw PropagatorConfigError(
+                std::format("schrodinger_cutoff ({}) admits {} paired basis terms over {} active modes, "
+                            "about {} per world slot — more than can be walked or addressed. Lower "
+                            "schrodinger_cutoff, or raise the rank x partition count (currently {}).",
+                            *schrodinger_cutoff,
+                            how_many,
+                            logical_num_modes_,
+                            per_slot,
+                            num_ranks));
+        }
+        expected_local_terms = std::max<size_t>(1, share);
+    }
 
-    const size_t expected_local_terms = std::max<size_t>(1, op.size() / std::max<size_t>(1, num_ranks));
     // Must run before the store: packed_inline_width_() derives the packed-row width from cutoff_fn_.
     regenerate_cutoff_fn_();
     mp_op_.store = std::make_unique<detail::OperatorIndex<NumModes>>(packed_inline_width_());
@@ -174,12 +205,22 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
     mp_op_.inverted_index_.reset();
 
     size_t i = 0;
-    // The initial monomials are distinct, so emplace (insert-if-absent) is an assigning insert here.
-    for (size_t r = 0; r < op.size(); ++r) {
-        const auto &mono = materialize_row<NumModes>(op, r);
+    // The initial monomials are distinct, so emplace (insert-if-absent) is an assigning insert here. A row
+    // index is a position in the kept subsequence, so the enumeration order below is load-bearing.
+    const auto keep_if_owned = [&](const Monomial<NumModes> &mono) {
         if (my_rank == find_rank<NumModes>(mono, num_ranks)) {
             mp_op_.append_term(mono);
             mp_op_.store->emplace(mono, i++);
+        }
+    };
+    if (schrodinger_) {
+        // Enumerated, never listed: PartitionGroup constructs the S partitions concurrently on their own
+        // masters, so a list here would hold P full copies of the global basis at one instant.
+        for_each_paired_monomial<NumModes>(max_pairs, logical_num_modes_, keep_if_owned);
+    }
+    else {
+        for (const auto &mono : local_heisenberg_terms) { // already this slot's share; the test is a no-op
+            keep_if_owned(mono);
         }
     }
 

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -23,8 +23,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <functional>
 #include <format>
+#include <functional>
 #include <limits>
 #include <numeric>
 #include <stdexcept>

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -170,18 +170,12 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
     size_t max_pairs = 0;
     size_t expected_local_terms = std::max<size_t>(1, local_heisenberg_terms.size());
     if (schrodinger_) {
-        // schrodinger_ is schrodinger_cutoff.has_value(), set in the member-init list, so the deref holds.
         const auto sc = std::min(*schrodinger_cutoff, static_cast<unsigned int>(2 * logical_num_modes_));
         max_pairs = sc / 2 + sc % 2;
         const size_t global_terms = paired_op_size(max_pairs, logical_num_modes_);
         // paired_op_size saturates rather than wrapping, so this is "too large to count", not a size.
         const bool uncountable = global_terms == std::numeric_limits<size_t>::max();
         const size_t share = global_terms / std::max<size_t>(1, num_ranks);
-        // A cutoff near the mode count makes the basis 2^logical_num_modes. Two independent ways that
-        // is hopeless, and both are needed: the count does not fit size_t at all, which is
-        // rank-independent because every slot walks the whole global basis however the rows are
-        // divided; or the slot's share of rows cannot be addressed by a term index. Rejected here by
-        // name rather than as a walk that does not finish.
         if (uncountable || share >= detail::OperatorIndex<NumModes>::kIndexCeiling) {
             const auto how_many = uncountable ? std::string("more than 2^64") : std::format("{}", global_terms);
             const auto per_slot = uncountable ? std::string("as many") : std::format("{}", share);
@@ -215,7 +209,7 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
         }
     };
     if (schrodinger_) {
-        // Enumerated, never listed: PartitionGroup constructs the S partitions concurrently on their own
+        // PartitionGroup constructs the S partitions concurrently on their own
         // masters, so a list here would hold P full copies of the global basis at one instant.
         for_each_paired_monomial<NumModes>(max_pairs, logical_num_modes_, keep_if_owned);
     }

--- a/cpp/tests/majorana_cutoff_tests.cpp
+++ b/cpp/tests/majorana_cutoff_tests.cpp
@@ -21,7 +21,10 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <random>
+#include <unordered_set>
+#include <vector>
 
 #include "monoprop/TypeAliases.h"
 #include "monoprop/algebra/MajoranaAlgebra.h"
@@ -263,5 +266,79 @@ BOOST_AUTO_TEST_CASE(majorana_cutoff_paired_op_saturates_at_one_pair_per_mode) {
         for (size_t i = 0; i < full.size(); ++i) {
             BOOST_TEST(clamped[i] == full[i]);
         }
+    }
+}
+
+// The emission order IS the row numbering of a Schrodinger propagator's store, so it is pinned
+// literally: ascending pair count, then ascending lexicographic order of the selected modes' tuple.
+BOOST_AUTO_TEST_CASE(majorana_cutoff_paired_enumeration_order_is_pinned) {
+    constexpr size_t N = 32;
+    constexpr size_t kLogical = 3;
+
+    const std::vector<VecZ> want_tuples = {{}, {0}, {1}, {2}, {0, 1}, {0, 2}, {1, 2}, {0, 1, 2}};
+    MonomialList<N> want;
+    for (const auto &tuple : want_tuples) {
+        std::vector<bool> selector(kLogical, false);
+        for (const size_t mode : tuple) {
+            selector[mode] = true;
+        }
+        want.push_back(monomial_from_selector<N>(selector, N - kLogical));
+    }
+
+    MonomialList<N> seen;
+    for_each_paired_monomial<N>(kLogical, kLogical, [&](const Monomial<N> &mono) { seen.push_back(mono); });
+
+    BOOST_REQUIRE_EQUAL(seen.size(), want.size());
+    for (size_t i = 0; i < want.size(); ++i) {
+        BOOST_TEST_CONTEXT("position " << i) {
+            BOOST_TEST(seen[i] == want[i]);
+        }
+    }
+}
+
+// paired_op_size is the only input to the store reserve and to the over-wide-cutoff guard, neither of
+// which may enumerate to find out. It has to agree with the walk exactly, over-ask included.
+BOOST_AUTO_TEST_CASE(majorana_cutoff_paired_op_size_agrees_with_the_enumeration) {
+    constexpr size_t N = 32;
+
+    for (const size_t logical : {size_t{1}, size_t{5}, size_t{9}}) {
+        for (size_t max_ones = 0; max_ones <= logical + 2; ++max_ones) {
+            size_t count = 0;
+            size_t previous_pairs = 0;
+            std::unordered_set<Monomial<N>, MonomialHash<N>, MonomialEqual<N>> distinct;
+            for_each_paired_monomial<N>(max_ones, logical, [&](const Monomial<N> &mono) {
+                const size_t pairs = mono.count() / 2;
+                BOOST_TEST(mono.count() % 2 == 0U);               // fully paired
+                BOOST_TEST(pairs <= std::min(max_ones, logical)); // clamped in pairs, not bits
+                BOOST_TEST(pairs >= previous_pairs);              // grouped by pair count, ascending
+                previous_pairs = pairs;
+                distinct.insert(mono);
+                ++count;
+            });
+            BOOST_TEST_CONTEXT("logical=" << logical << " max_ones=" << max_ones) {
+                BOOST_TEST(count == paired_op_size(max_ones, logical));
+                BOOST_TEST(distinct.size() == count); // duplicate-free: the covering argument needs it
+            }
+        }
+    }
+
+    // A cutoff at the mode count admits 2^logical terms: the size must saturate, not wrap to something
+    // small that the guard would then wave through.
+    BOOST_TEST(paired_op_size(64, 64) == std::numeric_limits<size_t>::max());
+    BOOST_TEST(paired_op_size(250, 250) == std::numeric_limits<size_t>::max());
+}
+
+// The materializing wrapper is the other tests' oracle for the walk, so it must emit exactly it.
+BOOST_AUTO_TEST_CASE(majorana_cutoff_generate_paired_op_matches_the_enumeration) {
+    constexpr size_t N = 32;
+    constexpr size_t kLogical = 7;
+
+    MonomialList<N> seen;
+    for_each_paired_monomial<N>(4, kLogical, [&](const Monomial<N> &mono) { seen.push_back(mono); });
+    const auto listed = generate_paired_op<N>(4, kLogical);
+
+    BOOST_REQUIRE_EQUAL(listed.size(), seen.size());
+    for (size_t i = 0; i < seen.size(); ++i) {
+        BOOST_TEST(listed[i] == seen[i]);
     }
 }

--- a/cpp/tests/mpi_utils_tests.cpp
+++ b/cpp/tests/mpi_utils_tests.cpp
@@ -203,3 +203,45 @@ BOOST_AUTO_TEST_CASE(mpi_utils_scan_routing_agrees_with_find_rank) {
     BOOST_TEST(checked > 500U);
     BOOST_TEST(self_checked > 200U);
 }
+
+// A Schrodinger propagator seeds a slot by walking the whole paired basis and keeping find_rank ==
+// my_slot, on every slot independently. Two properties make that a partition of the basis: the kept
+// sets are disjoint and covering, and each slot's kept sequence is a SUBSEQUENCE of the one global
+// walk, so a term's row index is fixed by its owning slot alone. Neither call site can check this.
+BOOST_AUTO_TEST_CASE(mpi_utils_paired_enumeration_partitions_by_find_rank) {
+    constexpr size_t kN = 32;
+    constexpr size_t kLogical = 9;
+    constexpr size_t kMaxPairs = 4;
+
+    MonomialList<kN> full;
+    for_each_paired_monomial<kN>(kMaxPairs, kLogical, [&](const Monomial<kN> &mono) { full.push_back(mono); });
+    BOOST_REQUIRE_EQUAL(full.size(), paired_op_size(kMaxPairs, kLogical));
+
+    for (const size_t slots : {size_t{1}, size_t{2}, size_t{3}, size_t{8}, size_t{128}}) {
+        size_t total = 0;
+        for (size_t slot = 0; slot < slots; ++slot) {
+            MonomialList<kN> kept;
+            for_each_paired_monomial<kN>(kMaxPairs, kLogical, [&](const Monomial<kN> &mono) {
+                if (find_rank<kN>(mono, slots) == slot) {
+                    kept.push_back(mono);
+                }
+            });
+            total += kept.size();
+
+            // kept[r] == full[j_r] with j_0 < j_1 < ... : row r's monomial follows from the global order.
+            size_t cursor = 0;
+            for (const auto &mono : kept) {
+                while (cursor < full.size() && !(full[cursor] == mono)) {
+                    ++cursor;
+                }
+                BOOST_REQUIRE_LT(cursor, full.size());
+                ++cursor;
+            }
+        }
+        // The walk is duplicate-free (pinned in majorana_cutoff_tests), so equal counts mean the slots'
+        // kept sets are disjoint AND cover every term exactly once.
+        BOOST_TEST_CONTEXT("slots=" << slots) {
+            BOOST_CHECK_EQUAL(total, full.size());
+        }
+    }
+}

--- a/cpp/tests/partition_equivalence_tests.cpp
+++ b/cpp/tests/partition_equivalence_tests.cpp
@@ -25,6 +25,7 @@
 #include "PauliTestOracle.h"
 #include "TestUtilities.h"
 #include "monoprop/MonomialPropagator.h"
+#include "monoprop/algebra/MajoranaAlgebra.h"
 #include "monoprop/detail/mpi/MPICompat.h"
 
 // Intra-process partition equivalence: a propagator with partitions>1 (S partition propagators over an in-process
@@ -48,6 +49,24 @@ auto majorana_sim(const CaseData &data, size_t partitions, std::optional<double>
                                          std::nullopt,
                                          MPI_COMM_SELF,
                                          lower_atol,
+                                         std::nullopt,
+                                         CutoffType::Length,
+                                         std::nullopt,
+                                         kNumModes,
+                                         Basis::Majorana,
+                                         partitions);
+}
+
+// Schrodinger's initial rows are the GLOBAL paired basis, hash-partitioned across the partitions --
+// the only construction input that is not already slot-local, and so the only one a mis-sharded seed
+// can break. At kNumModes=8 with sc=kCutoff+2 that is sum C(8,0..3) = 93 terms.
+auto majorana_schrodinger_sim(const CaseData &data, size_t partitions) -> MonomialPropagator<kNumModes> {
+    return MonomialPropagator<kNumModes>(data.hamiltonian,
+                                         kCutoff,
+                                         data.initial_state,
+                                         /*schrodinger_cutoff=*/kCutoff + 2,
+                                         MPI_COMM_SELF,
+                                         std::nullopt,
                                          std::nullopt,
                                          CutoffType::Length,
                                          std::nullopt,
@@ -314,4 +333,36 @@ BOOST_AUTO_TEST_CASE(partition_factory_exception_propagates_without_terminate) {
                                                     /*partitions=*/4),
                       std::runtime_error);
     BOOST_CHECK_NO_THROW(majorana_sim(data, 4));
+}
+
+// Reads the constructor's output with no graph in between: the aggregate initial basis must be every
+// paired term exactly once at any partition count. This is what a seed that keeps the wrong share, or
+// that generates the global set per partition and then over- or under-filters, gets wrong.
+BOOST_AUTO_TEST_CASE(partition_schrodinger_initial_basis_is_partition_count_invariant) {
+    const auto data = load_case_data<kNumModes>("random_exact.msgpack");
+    constexpr unsigned int kSchrodingerCutoff = kCutoff + 2;
+    const size_t expected = paired_op_size(kSchrodingerCutoff / 2 + kSchrodingerCutoff % 2, kNumModes);
+
+    for (const size_t S : {size_t{1}, size_t{2}, size_t{4}}) {
+        BOOST_TEST_CONTEXT("partitions=" << S) {
+            BOOST_CHECK_EQUAL(majorana_schrodinger_sim(data, S).size(), expected);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(partition_schrodinger_energy_matches_across_partition_counts) {
+    const auto data = load_case_data<kNumModes>("random_exact.msgpack");
+    auto ref = majorana_schrodinger_sim(data, 1);
+    ref.build_graph(data.majoranas, data.param_inds, data.gen_coeffs);
+    const double e1 = ref.expectation_value(data.parameters);
+
+    for (const size_t S : {size_t{2}, size_t{4}}) {
+        auto sim = majorana_schrodinger_sim(data, S);
+        sim.build_graph(data.majoranas, data.param_inds, data.gen_coeffs);
+        const double e = sim.expectation_value(data.parameters);
+        BOOST_TEST_CONTEXT("partitions=" << S << " e=" << e << " ref=" << e1) {
+            BOOST_TEST(near(e1, e));
+        }
+        BOOST_CHECK_EQUAL(ref.size(), sim.size());
+    }
 }

--- a/docs/content/docs/features/initialisation.mdx
+++ b/docs/content/docs/features/initialisation.mdx
@@ -25,10 +25,10 @@ For second-quantized Hamiltonians and usual Fermionic circuits coming from varia
 quantum computing, under length truncation the two pictures agree when
 `schrodinger_cutoff = cutoff + 2` (see Appendix of [@chakraborty2026scalablequantumcircuitgeneration]).
 
-`schrodinger_cutoff` also sizes the initial basis, and does so superexponentially: the
+`schrodinger_cutoff` also sizes the initial basis, and can grow extremely quickly: the
 state starts as every fully paired monomial of up to `pairs = ceil(schrodinger_cutoff / 2)`
-pairs, so $\sum_{k \le \mathrm{pairs}} \binom{n}{k}$ monomials over $n$ modes. Raising it
-by one is not a small step -- at 142 modes, `schrodinger_cutoff = 8` gives 16.7M initial
+pairs, so $\sum_{k \le \mathrm{pairs}} \binom{n}{k}$ monomials over $n$ modes (upper-bounded by $2^n$).
+Raising it by one is not a small step -- at 142 modes, `schrodinger_cutoff = 8` gives 16.7M initial
 terms and `10` gives 465M. A value approaching `2 * num_modes` (`num_qubits` for
 [PauliPropagator][]) makes the basis $2^n$ and is refused at construction with a
 `RuntimeError` naming the setting, rather than started.

--- a/docs/content/docs/features/initialisation.mdx
+++ b/docs/content/docs/features/initialisation.mdx
@@ -25,6 +25,14 @@ For second-quantized Hamiltonians and usual Fermionic circuits coming from varia
 quantum computing, under length truncation the two pictures agree when
 `schrodinger_cutoff = cutoff + 2` (see Appendix of [@chakraborty2026scalablequantumcircuitgeneration]).
 
+`schrodinger_cutoff` also sizes the initial basis, and does so superexponentially: the
+state starts as every fully paired monomial of up to `pairs = ceil(schrodinger_cutoff / 2)`
+pairs, so $\sum_{k \le \mathrm{pairs}} \binom{n}{k}$ monomials over $n$ modes. Raising it
+by one is not a small step -- at 142 modes, `schrodinger_cutoff = 8` gives 16.7M initial
+terms and `10` gives 465M. A value approaching `2 * num_modes` (`num_qubits` for
+[PauliPropagator][]) makes the basis $2^n$ and is refused at construction with a
+`RuntimeError` naming the setting, rather than started.
+
 ## Operator updates
 
 The coefficients of the initial operator can be patched after construction

--- a/src/monoprop/majorana_propagator.py
+++ b/src/monoprop/majorana_propagator.py
@@ -66,11 +66,11 @@ class MajoranaPropagator(MonomialPropagator[MajoranaOperator]):
             schrodinger_cutoff: ``None`` (default) keeps the Heisenberg picture; an integer selects
                 the Schrodinger picture and bounds the evolved state -- including its initialization
                 from ``initial_state`` -- by the same notion as ``cutoff_type``. Choose it at least
-                as large as ``cutoff`` for comparable accuracy. It also sizes the initial paired
-                basis, which holds ``sum(C(num_modes, k) for k in range(pairs + 1))`` monomials for
-                ``pairs = ceil(schrodinger_cutoff / 2)`` -- superexponential in the cutoff, so a
-                value approaching ``2 * num_modes`` is rejected with a ``RuntimeError`` rather than
-                started.
+as large as ``cutoff`` for comparable accuracy. It also sizes the initial paired
+basis, which holds ``sum(C(num_modes, k) for k in range(pairs + 1))`` monomials for
+``pairs = ceil(schrodinger_cutoff / 2)`` — combinatorial in the cutoff and
+upper-bounded by ``2**num_modes``, so a value approaching ``2 * num_modes`` is
+rejected with a ``RuntimeError`` rather than started.
             cutoff_type: ``"length"`` (default) bounds the number of Majorana operators in a
                 monomial; ``"support"`` bounds the distinct orbitals it acts on. The fully-paired
                 exception applies on top of either.

--- a/src/monoprop/majorana_propagator.py
+++ b/src/monoprop/majorana_propagator.py
@@ -66,11 +66,11 @@ class MajoranaPropagator(MonomialPropagator[MajoranaOperator]):
             schrodinger_cutoff: ``None`` (default) keeps the Heisenberg picture; an integer selects
                 the Schrodinger picture and bounds the evolved state -- including its initialization
                 from ``initial_state`` -- by the same notion as ``cutoff_type``. Choose it at least
-as large as ``cutoff`` for comparable accuracy. It also sizes the initial paired
-basis, which holds ``sum(C(num_modes, k) for k in range(pairs + 1))`` monomials for
-``pairs = ceil(schrodinger_cutoff / 2)`` — combinatorial in the cutoff and
-upper-bounded by ``2**num_modes``, so a value approaching ``2 * num_modes`` is
-rejected with a ``RuntimeError`` rather than started.
+                as large as ``cutoff`` for comparable accuracy. It also sizes the initial paired
+                basis, which holds ``sum(C(num_modes, k) for k in range(pairs + 1))`` monomials for
+                ``pairs = ceil(schrodinger_cutoff / 2)`` — combinatorial in the cutoff and
+                upper-bounded by ``2**num_modes``, so a value approaching ``2 * num_modes`` is
+                rejected with a ``RuntimeError`` rather than started.
             cutoff_type: ``"length"`` (default) bounds the number of Majorana operators in a
                 monomial; ``"support"`` bounds the distinct orbitals it acts on. The fully-paired
                 exception applies on top of either.

--- a/src/monoprop/majorana_propagator.py
+++ b/src/monoprop/majorana_propagator.py
@@ -66,7 +66,11 @@ class MajoranaPropagator(MonomialPropagator[MajoranaOperator]):
             schrodinger_cutoff: ``None`` (default) keeps the Heisenberg picture; an integer selects
                 the Schrodinger picture and bounds the evolved state -- including its initialization
                 from ``initial_state`` -- by the same notion as ``cutoff_type``. Choose it at least
-                as large as ``cutoff`` for comparable accuracy.
+                as large as ``cutoff`` for comparable accuracy. It also sizes the initial paired
+                basis, which holds ``sum(C(num_modes, k) for k in range(pairs + 1))`` monomials for
+                ``pairs = ceil(schrodinger_cutoff / 2)`` -- superexponential in the cutoff, so a
+                value approaching ``2 * num_modes`` is rejected with a ``RuntimeError`` rather than
+                started.
             cutoff_type: ``"length"`` (default) bounds the number of Majorana operators in a
                 monomial; ``"support"`` bounds the distinct orbitals it acts on. The fully-paired
                 exception applies on top of either.

--- a/src/monoprop/pauli_propagator.py
+++ b/src/monoprop/pauli_propagator.py
@@ -63,7 +63,10 @@ class PauliPropagator(MonomialPropagator[PauliOperator]):
             schrodinger_cutoff: ``None`` (default) keeps the Heisenberg picture; an integer selects
                 the Schrodinger picture and bounds the Pauli weight of the evolved state, including
                 its initialization from ``initial_state``. Choose it at least as large as ``cutoff``
-                for comparable accuracy.
+                for comparable accuracy. It also sizes the initial diagonal basis, which holds
+                ``sum(C(num_qubits, k) for k in range(schrodinger_cutoff + 1))`` Pauli strings --
+                superexponential in the cutoff, so a value approaching ``num_qubits`` is rejected
+                with a ``RuntimeError`` rather than started.
             lower_atol: Monomials with ``|coeff| < lower_atol`` are discarded during evolution.
             upper_atol: Monomials with ``|coeff| > upper_atol`` are kept regardless of weight.
             comm: Optional MPI communicator (must outlive the propagator).

--- a/src/monoprop/pauli_propagator.py
+++ b/src/monoprop/pauli_propagator.py
@@ -63,10 +63,10 @@ class PauliPropagator(MonomialPropagator[PauliOperator]):
             schrodinger_cutoff: ``None`` (default) keeps the Heisenberg picture; an integer selects
                 the Schrodinger picture and bounds the Pauli weight of the evolved state, including
                 its initialization from ``initial_state``. Choose it at least as large as ``cutoff``
-                for comparable accuracy. It also sizes the initial diagonal basis, which holds
-                ``sum(C(num_qubits, k) for k in range(schrodinger_cutoff + 1))`` Pauli strings --
-                superexponential in the cutoff, so a value approaching ``num_qubits`` is rejected
-                with a ``RuntimeError`` rather than started.
+for comparable accuracy. It also sizes the initial diagonal basis, which holds
+``sum(C(num_qubits, k) for k in range(schrodinger_cutoff + 1))`` Pauli strings —
+combinatorial in ``schrodinger_cutoff`` and upper-bounded by ``2**num_qubits``,
+so a value approaching ``num_qubits`` is rejected with a ``RuntimeError`` rather than started.
             lower_atol: Monomials with ``|coeff| < lower_atol`` are discarded during evolution.
             upper_atol: Monomials with ``|coeff| > upper_atol`` are kept regardless of weight.
             comm: Optional MPI communicator (must outlive the propagator).

--- a/src/monoprop/pauli_propagator.py
+++ b/src/monoprop/pauli_propagator.py
@@ -63,10 +63,10 @@ class PauliPropagator(MonomialPropagator[PauliOperator]):
             schrodinger_cutoff: ``None`` (default) keeps the Heisenberg picture; an integer selects
                 the Schrodinger picture and bounds the Pauli weight of the evolved state, including
                 its initialization from ``initial_state``. Choose it at least as large as ``cutoff``
-for comparable accuracy. It also sizes the initial diagonal basis, which holds
-``sum(C(num_qubits, k) for k in range(schrodinger_cutoff + 1))`` Pauli strings —
-combinatorial in ``schrodinger_cutoff`` and upper-bounded by ``2**num_qubits``,
-so a value approaching ``num_qubits`` is rejected with a ``RuntimeError`` rather than started.
+                for comparable accuracy. It also sizes the initial diagonal basis, which holds
+                ``sum(C(num_qubits, k) for k in range(schrodinger_cutoff + 1))`` Pauli strings —
+                combinatorial in ``schrodinger_cutoff`` and upper-bounded by ``2**num_qubits``,
+                so a value approaching ``num_qubits`` is rejected with a ``RuntimeError`` rather than started.
             lower_atol: Monomials with ``|coeff| < lower_atol`` are discarded during evolution.
             upper_atol: Monomials with ``|coeff| > upper_atol`` are kept regardless of weight.
             comm: Optional MPI communicator (must outlive the propagator).

--- a/tests/test_parameter_validation.py
+++ b/tests/test_parameter_validation.py
@@ -54,6 +54,27 @@ class TestConstructorValidation:
                 comm=serial_comm,
             )
 
+    def test_schrodinger_cutoff_beyond_the_term_index_raises(self, serial_comm):
+        """A Schrodinger cutoff near the mode count admits 2**num_modes paired basis terms.
+
+        The basis is enumerated, not listed, so an over-wide cutoff is no longer an
+        allocation failure but a walk that does not finish. It has to be refused up front,
+        naming the setting responsible rather than the ceiling it happens to trip.
+
+        64 modes deliberately: 2**64 does not fit ``size_t``, so the rejection holds
+        whatever the ``TermIndex`` width and however many partitions divide the rows.
+        """
+        num_modes = 64
+        operator = MajoranaOperator({(0, 1): 1.0j}, num_modes=num_modes)
+        with pytest.raises(RuntimeError, match="schrodinger_cutoff"):
+            MajoranaPropagator(
+                operator,
+                [],
+                cutoff=4,
+                schrodinger_cutoff=2 * num_modes,
+                comm=serial_comm,
+            )
+
 
 class TestGraphAndParameterValidation:
     def test_build_graph_accumulates_layers(self, serial_comm):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

In the Schrödinger picture, `MonomialPropagator`'s constructor built the **entire global** paired
monomial basis into a dense `MonomialList` and only then hash-filtered it down to the slot's `1/P`
share:

```cpp
auto op = schrodinger_ ? generate_paired_op<NumModes>(sc / 2 + sc % 2, logical_num_modes_)
                       : local_heisenberg_terms;
...
if (my_rank == find_rank<NumModes>(mono, num_ranks)) { /* keep 1/P of it */ }
```

`PartitionGroup` constructs its S children on their own master threads and waits for all of them, and
the child's `num_ranks` is the flat `P = R·S` world — so **all P full copies of the global basis were
live at the same instant**. Peak was `P × Σ_{k≤K} C(n,k) × sizeof(Monomial)` for
`K = ⌈schrodinger_cutoff/2⌉`.

The Heisenberg arm never had this problem, and the fix is to make Schrödinger behave the same way:
`local_heisenberg_terms` is filtered *as it is built*, so it is O(local). Now both are.

`for_each_paired_monomial` hands the walk to a callback, so each slot keeps only what it owns and
nothing ever materializes the global set. The emission order is moved verbatim, so each slot's kept
subsequence — and therefore every `i++` row index, and therefore every result — is unchanged.

## Changes

- `MajoranaAlgebra.h`: `for_each_paired_monomial` (callback walk) and `paired_op_size` (closed form,
  saturating rather than wrapping). `generate_paired_op` becomes a thin wrapper over the walk, for
  callers that want random access over a basis small enough to hold.
- `MonomialPropagator.inl`: the Schrödinger arm enumerates and inserts; the Heisenberg arm iterates
  its already-local list. One shared insert lambda, so there is a single place a row index is assigned.
- **Second bug, same lines:** the store `reserve` divided by `num_ranks` on both arms. That is right
  for a global count and a **P-fold under-reserve** for Heisenberg, whose list is already local — at
  R·S = 128 it reserved 1/128 of the rows and then reallocated and rehashed through the entire
  initial insert. Each arm now reserves from its own count.
- **Third:** an over-wide `schrodinger_cutoff` admits `2^num_modes` terms. That used to fail as an
  allocation; with the list gone it would be a walk that never finishes, so the basis size is checked
  up front and the error names `schrodinger_cutoff` rather than the ceiling it happens to trip. The
  check has two arms, and both are needed: the count not fitting `size_t` at all (rank-independent,
  because every slot walks the whole global basis however the rows are divided) and the slot's share
  of rows exceeding what a term index can address. Only the first survives a `wide:on` build with
  several partitions, which is why it is there.
- Tests: `partition_equivalence_tests.cpp` had **no** Schrödinger case at all — every case passed
  `std::nullopt` for `schrodinger_cutoff`. It has two now, one of which reads the constructor's output
  with no graph in between. Plus a literal order pin on the walk, `paired_op_size` ≡ emitted count over
  every `n × k` including the clamped over-ask, and a disjoint/covering/subsequence check on the
  hash filter in `mpi_utils_tests.cpp`.

## Results

One 128-core node, 142 modes unless stated, `monoprop_PARTITIONS` explicit, arms interleaved with the
order flipped per rep, 3 reps. Baseline arm = this branch's parent (`_core.so`
`c27cb88371213b820c52adb2c1b6ca99`); fixed arm = this branch (`42f8cdc5add3501bc109f8b9b1004a4c`).
Every number below was reproduced on the final binary after the guard was tightened.

Peak RSS vs partition count, at a fixed problem — the mechanism, directly:

| S | before (GiB) | after (GiB) |
| --- | --- | --- |
| 1 | 2.93 – 2.94 | 2.99 – 3.00 |
| 16 | 11.13 – 11.24 | 3.19 |
| 64 | 41.56 – 41.62 | 3.45 – 3.46 |
| 128 | 79.32 – 80.26 | 3.39 – 3.40 |

Before: **0.61 GiB per partition** (predicted 668.5 MB = 16,711,839 monomials × 40 B — the basis size
`paired_op_size` computes, and the ledger's own `d_state_coeffs_nonzero`). After: flat across a 128×
range, **23.5×** lower at S=128, 12/12 cells in the same direction. All 24 cells agree on `terms` and
on `opmembreak.total_bytes`, so this was pure waste, not a trade.

Two configurations that were `SIGKILL` on a 223 GiB node now simply run:

| case | before | after |
| --- | --- | --- |
| `--cutoff=7` (basis 464,784,177) | `rc=137` | 70.0 GiB, 466.9M terms |
| `--num-modes=180` (basis 43,268,956) | `rc=137` | 8.6 GiB, 45.6M terms |
| `--num-modes=160` | 127.5 GiB | 5.6 GiB |
| `--num-generators=4000` | 80.2 GiB | 14.8 GiB |

These were previously believed to be properties of the problem. They were this bug: one copy of the
`--cutoff=7` basis is 18.6 GB, which fits a node easily; 128 copies is 2.4 TB.

`schrodinger_cutoff` remains superexponential in its own right — 8 → 16.7M initial terms, 10 → 465M at
142 modes — which is now documented rather than discovered.

## Verification

- CTest: **278/278** and **276/276** passed, 0 failed (labels `cxx`/`mpi`/`mpi-2`/`serial`/`unit`),
  including the hybrid `R>1, S>1` partition-equivalence case and the Schrödinger MPI fresh-insert
  equivalence case. All 6 new cases confirmed present and passing by name.
- Python suite on compute nodes across four layouts — `R×S` = 2×1, 2×16, 4×8 and **16×16 (world
  256)**: **601 passed** in each. The 16×16 layout matters here because the over-wide-cutoff check
  reads `num_ranks` as the flat `R·S` off the child communicator, which only a `HybridComm` provides.
- `uvx prek run --from-ref main --to-ref HEAD` — all hooks green.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: Claude Code (claude-opus-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)
