### PR TITLE
fix: compiler warnings

### DIFF
--- a/cpp/monoprop/algebra/AlgebraCommon.h
+++ b/cpp/monoprop/algebra/AlgebraCommon.h
@@ -203,13 +203,21 @@ struct SupportCutoff {
     }
 };
 
+// std::function::target, out of line on purpose: GCC cannot see that the function's manager writes
+// the _Any_data scratch before target() reads it back, so inlining the read into the caller yields a
+// bogus -Wmaybe-uninitialized. The lookup runs once per evaluator, never inside a scan loop.
+template <typename T, typename Fn>
+[[gnu::noinline]] auto cutoff_target(const Fn &cutoff_fn) -> const T * {
+    return cutoff_fn.template target<T>();
+}
+
 template <size_t NumModes>
 class CutoffEvaluator {
 public:
     explicit CutoffEvaluator(const CutoffFn<NumModes> &cutoff_fn)
         : cutoff_fn_(cutoff_fn),
-          length_cutoff_(cutoff_fn.template target<LengthCutoff<NumModes>>()),
-          support_cutoff_(cutoff_fn.template target<SupportCutoff<NumModes>>()) {}
+          length_cutoff_(cutoff_target<LengthCutoff<NumModes>>(cutoff_fn)),
+          support_cutoff_(cutoff_target<SupportCutoff<NumModes>>(cutoff_fn)) {}
 
     auto length_cutoff() const -> const LengthCutoff<NumModes> * { return length_cutoff_; }
 

--- a/cpp/monoprop/detail/evolution/layer_build/Scan.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Scan.h
@@ -180,7 +180,6 @@ template <size_t NumModes, Algebra A, typename PosT, typename GenT>
                                                       const typename A::GenContext &ctx,
                                                       std::span<const GenT> gen_pos,
                                                       std::span<PosT> out_pos) -> PartnerProduct<NumModes> {
-    const size_t gen_pop = gen_pos.size();
     const Monomial<NumModes> &gen = A::generator(ctx);
     PartnerProduct<NumModes> out;
     Monomial<NumModes> mono;

--- a/cpp/monoprop/detail/operator/OperatorIndex.h
+++ b/cpp/monoprop/detail/operator/OperatorIndex.h
@@ -358,7 +358,7 @@ public:
         if (n == 0) {
             return;
         }
-        bulk_insert_hashed(n, base, [this, &key_at](size_t k) { return fold_hash(key_at(k)); });
+        bulk_insert_hashed(n, base, [&key_at](size_t k) { return fold_hash(key_at(k)); });
     }
     // bulk_insert with the hashes already in hand: same precondition (n distinct rows, already written,
     // at consecutive indices) and the same slot assignment. `hashes[k]` must be fold_hash of the key of

--- a/cpp/tests/bitset_tests.cpp
+++ b/cpp/tests/bitset_tests.cpp
@@ -42,7 +42,7 @@ auto make_pair(const std::vector<size_t> &positions) -> std::pair<Bitset<N>, std
 template <size_t N>
 auto expect_equal(const Bitset<N> &bs, const std::bitset<N> &ref) -> void {
     for (size_t i = 0; i < N; ++i) {
-        BOOST_TEST(bs.test(i) == ref.test(i), "bit " << i);
+        BOOST_CHECK_MESSAGE(bs.test(i) == ref.test(i), "bit " << i);
     }
     BOOST_TEST(bs.count() == ref.count());
 }

--- a/cpp/tests/cpu_topology_tests.cpp
+++ b/cpp/tests/cpu_topology_tests.cpp
@@ -46,6 +46,11 @@ struct AffinityGuard {
     cpu_set_t saved_{};
     AffinityGuard() { sched_getaffinity(0, sizeof(saved_), &saved_); }
     ~AffinityGuard() { sched_setaffinity(0, sizeof(saved_), &saved_); }
+#else
+    // Off Linux there is no affinity to restore, but the destructor must still be user-declared:
+    // an empty aggregate makes every `AffinityGuard guard;` look like an unused variable.
+    AffinityGuard() = default;
+    ~AffinityGuard() = default;
 #endif
 };
 

--- a/cpp/tests/link_export_probe/CMakeLists.txt
+++ b/cpp/tests/link_export_probe/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Link-time export-visibility probe: unlike monoprop_unit_tests.x (linked against monoprop-objs, the
 # plain OBJECT library, which never crosses a dynamic-visibility boundary), this target links against
 # the installed "monoprop" SHARED target -- exactly as an external find_package(monoprop CONFIG)
-# consumer would. "-Wl,--no-undefined" (GNU ld) / "-Wl,-undefined,error" (Apple ld64) makes the link
-# step itself fail on any symbol the shared library does not export, instead of deferring the failure
-# to a client's runtime load.
+# consumer would. "-Wl,--no-undefined" (GNU ld) makes the link step itself fail on any symbol the
+# shared library does not export, instead of deferring the failure to a client's runtime load. Apple
+# ld64 errors on undefined symbols by default, so no flag is needed there ("-Wl,-undefined,error" is
+# accepted but deprecated, and warns).
 
 add_executable(monoprop_link_export_probe.x link_export_probe.cpp)
 
@@ -19,13 +20,7 @@ target_link_libraries(
     monoprop
 )
 
-if(APPLE)
-  target_link_options(
-    monoprop_link_export_probe.x
-    PRIVATE
-      "-Wl,-undefined,error"
-  )
-else()
+if(NOT APPLE)
   target_link_options(monoprop_link_export_probe.x PRIVATE "-Wl,--no-undefined")
 endif()
 

--- a/cpp/tests/sparse_query_tests.cpp
+++ b/cpp/tests/sparse_query_tests.cpp
@@ -319,8 +319,9 @@ BOOST_AUTO_TEST_CASE(sparse_record_is_exactly_the_gap_code_it_costed) {
         VecZ buf;
         const size_t w = QW::push(buf, pos, 1);
         const size_t gwid = QW::gap_width(pos);
-        BOOST_TEST(w == QW::words_of(QW::gap_bits(pos.size(), gwid)),
-                   "k=" << k << " wrote " << w << " words, costed " << QW::words_of(QW::gap_bits(pos.size(), gwid)));
+        BOOST_CHECK_MESSAGE(
+            w == QW::words_of(QW::gap_bits(pos.size(), gwid)),
+            "k=" << k << " wrote " << w << " words, costed " << QW::words_of(QW::gap_bits(pos.size(), gwid)));
         BOOST_TEST(w <= QW::words_of(QW::header_bits_for(pos.size()) + (pos.size() * QW::kPosBits)));
     }
 }


### PR DESCRIPTION
<!-- Use "Fixes #<issue>" to auto-close the related issue when this PR is merged. -->

## Summary

Silence a bunch of compiler warnings. They tend to clog the CI job logs, as we instantiate templates many times.

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [ ] I used the following tool to help write this PR description:
- [X] I used the following tool to generate or modify code: GitHub Copilot:claude-opus-5

<!-- Any code generated or substantially modified by an LLM must be noted inline too. -->

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
