### PR TITLE
fix(ci): :bug: keep a push to main out of the cancelled group

### DIFF
--- a/.github/workflows/qa-analysis.yml
+++ b/.github/workflows/qa-analysis.yml
@@ -10,8 +10,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # A push to `main` uploads to Codecov, so cancelling it loses that commit's report for
-  # good -- and back-to-back merges share the group, the later one cancelling the earlier.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/qa-analysis.yml
+++ b/.github/workflows/qa-analysis.yml
@@ -10,7 +10,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A push to `main` uploads to Codecov, so cancelling it loses that commit's report for
+  # good -- and back-to-back merges share the group, the later one cancelling the earlier.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_COLOR: 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # A push to `main` uploads to Codecov, so cancelling it loses that commit's report for
-  # good -- and back-to-back merges share the group, the later one cancelling the earlier.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A push to `main` uploads to Codecov, so cancelling it loses that commit's report for
+  # good -- and back-to-back merges share the group, the later one cancelling the earlier.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_COLOR: 3


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Both workflows that upload to Codecov run on `push` to `main` under the concurrency group `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. Two merges close together therefore share the group, and the later one cancels the earlier run — dropping that commit's coverage report for good, since nothing re-runs it. It already happened: `d18a459`'s QA run was cancelled 32 seconds after `17825b3`'s started, before the upload step, so `main@d18a459` has no report and every PR based on it gets "no BASE report" from Codecov.

Cancelling stays on for `pull_request`, where superseded runs are genuinely disposable.

## Changes

- `qa-analysis.yml`, `test.yml`: `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.

## Checklist

- [ ] Tests added or updated to cover the changes
- [ ] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

Not applicable: CI-only change, no API or documented behaviour touched.

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: Claude Code (claude-opus-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)