### PR TITLE
ci: :construction_worker: aggregate matrix results into a stable check

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -65,3 +65,21 @@ jobs:
             pkg-config --modversion hwloc
             mpicc --version
           '
+
+  flake-result:
+    # A ruleset can only require a check by name, and the matrix above only ever
+    # reports per-runner names. This job publishes one stable name whose result is
+    # independent of the matrix dimensions.
+    name: All flake checks
+    if: always()
+    needs: flake
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Report the matrix result
+        run: |
+          echo "flake: ${{ needs.flake.result }}"
+          case "${{ needs.flake.result }}" in
+            success|skipped) ;;
+            *) exit 1 ;;
+          esac

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -67,9 +67,6 @@ jobs:
           '
 
   flake-result:
-    # A ruleset can only require a check by name, and the matrix above only ever
-    # reports per-runner names. This job publishes one stable name whose result is
-    # independent of the matrix dimensions.
     name: All flake checks
     if: always()
     needs: flake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,3 +135,22 @@ jobs:
           report_type: test_results
           disable_search: true
           fail_ci_if_error: true
+
+  tests:
+    # A ruleset can only require a check by name, and the matrix above only ever
+    # reports per-combination names. This job publishes one stable name whose result
+    # is independent of the matrix dimensions, so adding or dropping a lane does not
+    # require editing branch protection.
+    name: All tests
+    if: always()
+    needs: package-tests
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Report the matrix result
+        run: |
+          echo "package-tests: ${{ needs.package-tests.result }}"
+          case "${{ needs.package-tests.result }}" in
+            success|skipped) ;;
+            *) exit 1 ;;
+          esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,10 +137,6 @@ jobs:
           fail_ci_if_error: true
 
   tests:
-    # A ruleset can only require a check by name, and the matrix above only ever
-    # reports per-combination names. This job publishes one stable name whose result
-    # is independent of the matrix dimensions, so adding or dropping a lane does not
-    # require editing branch protection.
     name: All tests
     if: always()
     needs: package-tests

--- a/docs/content/docs/testing.mdx
+++ b/docs/content/docs/testing.mdx
@@ -89,6 +89,13 @@ ctest -S tools/ctest-mpi-matrix.cmake -VV
 CI gives every compiler and MPI combination a distinct setup-uv cache suffix,
 because uv's cache key does not include build environment variables.
 
+A matrix job reports one check per combination, so its check names change whenever a
+lane is added or removed. Each matrix workflow therefore ends with a small aggregation
+job — `All tests` in `test.yml`, `All flake checks` in `nix.yml` — that runs with
+`if: always()`, depends on the matrix, and fails unless the matrix succeeded or was
+skipped. Branch protection requires those stable names, so the matrix dimensions can
+change without touching the ruleset.
+
 CTest runs each Boost case as its own process, so an MPI build's `MPI_Init` probes every
 fabric device per case, whether or not the test sends anything. `monoprop_TEST_EXCLUDE_MPI_FABRIC=ON`
 (default) skips that probe for the single-process `serial` variants only; multi-rank variants


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

A matrix job reports one check run per combination, so its check names encode the matrix
dimensions (`Test [mpi:off] ubuntu-26.04 py3.11 default`, `Flake on macos-15`, …). Any
ruleset that requires those checks has to be re-edited whenever a lane is added, dropped
or renamed, and a required check that no longer exists silently stops gating.

This adds the aggregation pattern: each matrix workflow ends with a tiny job that runs
with `if: always()`, `needs` the matrix, and fails unless the matrix result was `success`
or `skipped`. The result is a single stable check name per workflow that branch
protection can require, independent of the matrix dimensions.

## Changes

- `test.yml`: new `tests` job, check name **All tests**, gating `package-tests`.
- `nix.yml`: new `flake-result` job, check name **All flake checks**, gating `flake`.
- Both run on `ubuntu-slim` and only `echo` + `case`, so `check-workflow-commands` is
  satisfied without a new recipe.
- `docs/content/docs/testing.mdx`: documents the pattern and the two names.

## Follow-up needed on the repository settings

The ruleset must be updated to require **All tests** and **All flake checks**, and the
per-combination entries removed — otherwise this only adds two green checks.

Two caveats worth a look before this leaves draft:

- `nix.yml` has a `paths:` filter on `pull_request`. When the filter does not match, the
  whole workflow is skipped and **All flake checks** never reports, which a ruleset treats
  as pending. Either leave that one non-required, or drop the path filter.
- `flake` sets `continue-on-error` for `macos-15`, so a macOS failure still yields a job
  result of `success`. That behaviour is unchanged by this PR, but the aggregate inherits it.

Not touched: `qa-analysis.yml`'s `coverage-run` matrix already feeds `code-coverage`,
which has a stable name, and `deploy.yml`'s wheel matrix does not gate PRs.

## Checklist

- [ ] Tests added or updated to cover the changes — n/a, CI wiring only
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable — n/a

## AI/LLM disclosure

- [x] I used the following tool to help write this PR description: GitHub Copilot (Claude Opus 5)
- [x] I used the following tool to generate or modify code: GitHub Copilot (Claude Opus 5)
