### PR TITLE
fix(ci): 🐛 install MPI for the bare-metal benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,7 +42,11 @@ jobs:
       - name: Set up the build environment
         uses: ./.github/actions/setup
         with:
-          cache-suffix: benchmark
+          # A cache filled by a non-MPI build would restore a monoprop without MPI, which every
+          # rung below then shares.
+          cache-suffix: benchmark-mpi
+          # The build below requires MPI::MPI_CXX, and the multi-rank rungs need mpiexec.
+          mpi: "on"
 
       - name: Install package
         env:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The bare-metal benchmark has been red since #323 merged. That PR turned the job into the
three-rung ladder, which builds with `monoprop_ENABLE_MPI=ON` and launches L2b under
`mpiexec -n 4` — but `bench.yml` sets up its environment with only a `cache-suffix`, and
`.github/actions/setup` installs `tools/packages/apt-mpi.txt` only when it is handed
`mpi: on`. So the runner had no `MPI::MPI_CXX` while the build was told to require it, and
the run stopped in *Install package*:

```
--   Package 'mpi-cxx' not found
CMake Error at .../FindPackageHandleStandardArgs.cmake:290 (message):
*** CMake configuration failed
```

Every bare-metal run before #323 was green because the old workflow built without MPI. The
fix is the one input, plus a cache suffix that moves with the configuration: `benchmark` was
filled by those non-MPI builds, and a `monoprop` restored from it is the binary every rung
shares — `resolve_cores.py` would then stop the run one step later with *"monoprop was built
without MPI"*.

Nothing downstream of the build had ever run in CI, so this was validated end to end rather
than by making the configure step pass: `bench_bare_metal.yml` dispatched on this branch,
all three rungs measured, shape-checked and uploaded. Run linked in a comment below.

## Changes

- `.github/workflows/bench.yml`: pass `mpi: "on"` to the setup action, and move the
  `setup-uv` cache suffix to `benchmark-mpi`.

## Checklist

- [x] Tests added or updated to cover the changes <!-- CI-only change; the workflow is the test -->
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed <!-- docs/content/docs/benchmarks.mdx already describes the ladder and its testbeds; no user-visible behaviour changes -->
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (Opus 5)
- [x] I used the following tool to generate or modify code: Claude Code (Opus 5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark build setup to ensure MPI support is enabled.
  * Improved benchmark environment caching for MPI-enabled builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->