### PR TITLE
fix(bench-tools): 🐛 track every operator's term count, and name series for a legend

### DIFF
--- a/packages/monoprop-bench-tools/README.md
+++ b/packages/monoprop-bench-tools/README.md
@@ -69,6 +69,10 @@ This package deliberately holds no benchmarks. monoprop's own suite lives in the
 repository's `benches/` directory, because its benchmark names are the key
 Bencher's history is stored under and must not move with a library release.
 
+`bmf.benchmark_name` maps a pytest node id to the name a metric is exported
+under, so that mapping is history-bearing for the same reason: changing it
+renames every series it touches.
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).

--- a/packages/monoprop-bench-tools/src/monoprop_bench_tools/bmf.py
+++ b/packages/monoprop-bench-tools/src/monoprop_bench_tools/bmf.py
@@ -62,6 +62,9 @@ _OPERATOR = "operator"
 # id (``::``, as report.py reads it) where a benchmark holds its own.
 _NODE_ID_SEP = "::"
 
+# Stripped from a node id's test name; what follows it is ``<family>_<operation>``.
+_TEST_PREFIX = "test_"
+
 Metric = dict[str, float]
 Bmf = dict[str, dict[str, Metric]]
 
@@ -100,6 +103,28 @@ def _latency(stats: dict[str, float]) -> Metric:
     }
 
 
+def benchmark_name(node_id: str) -> str:
+    """Return the Bencher benchmark name for a pytest ``node_id``.
+
+    ``bench_models.py::test_model_propagate[hubbard]`` becomes
+    ``model/propagate[hubbard]``: a plot legend shows this name, and the module, the
+    ``test_`` prefix and the repeated family word carry nothing a reader of one rung's
+    plot needs. The family is kept as a path segment because it is the only thing
+    separating a fixed model's operation from a random problem's once the parameter
+    alone is left, and Bencher keys history on the name forever.
+
+    Anything not shaped like a parameterised pytest id is returned unchanged, so a
+    name from another producer is never silently rewritten.
+    """
+    _, separator, test = node_id.partition(_NODE_ID_SEP)
+    if not separator or not test.startswith(_TEST_PREFIX):
+        return node_id
+    family, _, operation = test[len(_TEST_PREFIX) :].partition("_")
+    if not operation:
+        return node_id
+    return f"{family}/{operation}"
+
+
 def _timings(results_dir: Path, label: str) -> Iterator[tuple[str, Metric]]:
     """Yield ``(benchmark, latency)`` from ``time-<label>.json``.
 
@@ -109,7 +134,7 @@ def _timings(results_dir: Path, label: str) -> Iterator[tuple[str, Metric]]:
     """
     data = _read_json(results_dir / f"time-{label}.json")
     for bench in data.get("benchmarks", []):
-        yield bench["fullname"].split("/")[-1], _latency(bench["stats"])
+        yield benchmark_name(bench["fullname"].split("/")[-1]), _latency(bench["stats"])
 
 
 def build_bmf(results_dir: Path, label: str) -> Bmf:
@@ -125,14 +150,14 @@ def build_bmf(results_dir: Path, label: str) -> Bmf:
 
     # ``memhwm`` is the kernel's exact peak RSS per operation, summed over ranks under MPI.
     for benchmark, peak in results.get("memhwm", {}).items():
-        measure(benchmark, "peak-memory", peak)
+        measure(benchmark_name(benchmark), "peak-memory", peak)
 
     # A node-id key names the benchmark that built the operator, so its count belongs on
     # that benchmark, beside the latency and peak memory of the same call. Where a shared
     # operator is also counted per picture the two agree by construction, and a run where
     # they disagree is exactly what the exact-match threshold exists to catch.
     for key, size in results.get("opsize", {}).items():
-        name = key if _NODE_ID_SEP in key else f"{_OPERATOR}[{key}]"
+        name = benchmark_name(key) if _NODE_ID_SEP in key else f"{_OPERATOR}[{key}]"
         measure(name, "terms", size["terms"])
 
     return bmf

--- a/packages/monoprop-bench-tools/src/monoprop_bench_tools/bmf.py
+++ b/packages/monoprop-bench-tools/src/monoprop_bench_tools/bmf.py
@@ -34,7 +34,8 @@ Three measures are emitted:
 ``terms`` (count)
     Terms in the evolved operator. Deterministic for a fixed seed and problem
     size, so it is held to an exact match: it is the only check that a timing
-    win is not an accuracy change.
+    win is not an accuracy change. Recorded on the benchmark that owns the
+    operator, or under ``operator[<picture>]`` where several operations share one.
 
 Usage::
 
@@ -57,8 +58,8 @@ _NS_PER_S = 1e9
 # describe a built operator rather than one timed call.
 _OPERATOR = "operator"
 
-# ``opsize`` is also keyed by pytest node id (``::``, as report.py reads it) for a
-# private A/B harness; those are not operators, so they are skipped here.
+# ``opsize`` is keyed by picture where operations share one operator, and by pytest node
+# id (``::``, as report.py reads it) where a benchmark holds its own.
 _NODE_ID_SEP = "::"
 
 Metric = dict[str, float]
@@ -126,9 +127,13 @@ def build_bmf(results_dir: Path, label: str) -> Bmf:
     for benchmark, peak in results.get("memhwm", {}).items():
         measure(benchmark, "peak-memory", peak)
 
+    # A node-id key names the benchmark that built the operator, so its count belongs on
+    # that benchmark, beside the latency and peak memory of the same call. Where a shared
+    # operator is also counted per picture the two agree by construction, and a run where
+    # they disagree is exactly what the exact-match threshold exists to catch.
     for key, size in results.get("opsize", {}).items():
-        if _NODE_ID_SEP not in key:
-            measure(f"{_OPERATOR}[{key}]", "terms", size["terms"])
+        name = key if _NODE_ID_SEP in key else f"{_OPERATOR}[{key}]"
+        measure(name, "terms", size["terms"])
 
     return bmf
 

--- a/packages/monoprop-bench-tools/tests/test_bmf.py
+++ b/packages/monoprop-bench-tools/tests/test_bmf.py
@@ -25,7 +25,9 @@ from monoprop_bench_tools import bmf
 if TYPE_CHECKING:
     from pathlib import Path
 
+# The node id conftest and pytest-benchmark record, and the name it is exported under.
 _ENERGY = "bench_random.py::test_random_energy[heisenberg]"
+_ENERGY_NAME = "random/energy[heisenberg]"
 
 
 def _write(results_dir: Path, label: str = "ci", **sections: object) -> None:
@@ -44,7 +46,7 @@ def _write(results_dir: Path, label: str = "ci", **sections: object) -> None:
 
 def test_latency_is_nanoseconds_with_stddev_bounds(tmp_path: Path) -> None:
     _write(tmp_path)
-    latency = bmf.build_bmf(tmp_path, "ci")[_ENERGY]["latency"]
+    latency = bmf.build_bmf(tmp_path, "ci")[_ENERGY_NAME]["latency"]
 
     assert latency == {
         "value": 0.5e9,
@@ -59,7 +61,7 @@ def test_latency_omits_bounds_without_spread(tmp_path: Path) -> None:
     timings["benchmarks"][0]["stats"]["stddev"] = 0.0
     (tmp_path / "time-ci.json").write_text(json.dumps(timings))
 
-    assert bmf.build_bmf(tmp_path, "ci")[_ENERGY]["latency"] == {"value": 0.5e9}
+    assert bmf.build_bmf(tmp_path, "ci")[_ENERGY_NAME]["latency"] == {"value": 0.5e9}
 
 
 def test_latency_lower_bound_floors_at_zero(tmp_path: Path) -> None:
@@ -68,7 +70,7 @@ def test_latency_lower_bound_floors_at_zero(tmp_path: Path) -> None:
     timings["benchmarks"][0]["stats"]["stddev"] = 2.0
     (tmp_path / "time-ci.json").write_text(json.dumps(timings))
 
-    assert bmf.build_bmf(tmp_path, "ci")[_ENERGY]["latency"]["lower_value"] == 0.0
+    assert bmf.build_bmf(tmp_path, "ci")[_ENERGY_NAME]["latency"]["lower_value"] == 0.0
 
 
 def test_memory_joins_the_benchmark_of_the_same_operation(tmp_path: Path) -> None:
@@ -76,7 +78,7 @@ def test_memory_joins_the_benchmark_of_the_same_operation(tmp_path: Path) -> Non
 
     # conftest keys memhwm by the same node id pytest-benchmark reports, so both
     # measures must land on one benchmark rather than splitting into two.
-    assert bmf.build_bmf(tmp_path, "ci")[_ENERGY] == {
+    assert bmf.build_bmf(tmp_path, "ci")[_ENERGY_NAME] == {
         "latency": {"value": 0.5e9, "lower_value": 0.49e9, "upper_value": 0.51e9},
         "peak-memory": {"value": 1024.0},
     }
@@ -97,6 +99,7 @@ def test_operator_metrics_land_on_the_benchmark_that_owns_the_operator(
     tmp_path: Path,
 ) -> None:
     build_graph = "bench_random.py::test_random_build_graph[heisenberg]"
+    build_graph_name = "random/build_graph[heisenberg]"
     _write(
         tmp_path,
         opsize={"heisenberg": {"terms": 12}, build_graph: {"terms": 34}},
@@ -105,8 +108,8 @@ def test_operator_metrics_land_on_the_benchmark_that_owns_the_operator(
 
     # A node-id key names a benchmark holding its own operator, so dropping it leaves that
     # operator's term count untracked -- at L1 that is both fixed-model `propagate` rows.
-    assert set(result) == {_ENERGY, "operator[heisenberg]", build_graph}
-    assert result[build_graph] == {"terms": {"value": 34.0}}
+    assert set(result) == {_ENERGY_NAME, "operator[heisenberg]", build_graph_name}
+    assert result[build_graph_name] == {"terms": {"value": 34.0}}
     assert result["operator[heisenberg]"] == {"terms": {"value": 12.0}}
 
 
@@ -118,7 +121,7 @@ def test_operator_metrics_join_the_timings_of_the_same_benchmark(
 
     # One benchmark, both measures: Bencher keys history on (benchmark, measure), so the
     # count has to share the name its latency is recorded under.
-    assert result[_ENERGY] == {
+    assert result[_ENERGY_NAME] == {
         "latency": {"value": 0.5e9, "lower_value": 0.49e9, "upper_value": 0.51e9},
         "terms": {"value": 34.0},
     }
@@ -127,7 +130,7 @@ def test_operator_metrics_join_the_timings_of_the_same_benchmark(
 def test_missing_sections_are_skipped(tmp_path: Path) -> None:
     _write(tmp_path)
 
-    assert set(bmf.build_bmf(tmp_path, "ci")) == {_ENERGY}
+    assert set(bmf.build_bmf(tmp_path, "ci")) == {_ENERGY_NAME}
 
 
 def test_missing_artifact_is_fatal(tmp_path: Path) -> None:
@@ -141,3 +144,24 @@ def test_malformed_artifact_is_fatal(tmp_path: Path) -> None:
 
     with pytest.raises(SystemExit, match="malformed artifact"):
         bmf.build_bmf(tmp_path, "ci")
+
+
+@pytest.mark.parametrize(
+    ("node_id", "expected"),
+    [
+        ("bench_models.py::test_model_propagate[hubbard]", "model/propagate[hubbard]"),
+        (
+            "bench_random.py::test_random_build_graph[heisenberg]",
+            "random/build_graph[heisenberg]",
+        ),
+        # Not a parameterised pytest id: left alone rather than rewritten into a name
+        # Bencher would then key its history on forever.
+        ("operator[heisenberg]", "operator[heisenberg]"),
+        ("bench_x.py::helper_thing", "bench_x.py::helper_thing"),
+        ("no_separator_at_all", "no_separator_at_all"),
+    ],
+)
+def test_benchmark_name_drops_the_module_and_test_prefix(
+    node_id: str, expected: str
+) -> None:
+    assert bmf.benchmark_name(node_id) == expected

--- a/packages/monoprop-bench-tools/tests/test_bmf.py
+++ b/packages/monoprop-bench-tools/tests/test_bmf.py
@@ -93,7 +93,9 @@ def test_operator_metrics_are_grouped_per_picture_and_model(tmp_path: Path) -> N
     assert result["operator[hubbard]"] == {"terms": {"value": 12.0}}
 
 
-def test_operator_metrics_skip_node_id_keyed_entries(tmp_path: Path) -> None:
+def test_operator_metrics_land_on_the_benchmark_that_owns_the_operator(
+    tmp_path: Path,
+) -> None:
     build_graph = "bench_random.py::test_random_build_graph[heisenberg]"
     _write(
         tmp_path,
@@ -101,14 +103,24 @@ def test_operator_metrics_skip_node_id_keyed_entries(tmp_path: Path) -> None:
     )
     result = bmf.build_bmf(tmp_path, "ci")
 
-    # record_opsize keys by node id for a private A/B harness; Bencher's history keys
-    # on the name forever, so those entries must not reach it under any name at all.
-    assert set(result) == {_ENERGY, "operator[heisenberg]"}
-    assert result == {
-        _ENERGY: {
-            "latency": {"value": 0.5e9, "lower_value": 0.49e9, "upper_value": 0.51e9}
-        },
-        "operator[heisenberg]": {"terms": {"value": 12.0}},
+    # A node-id key names a benchmark holding its own operator, so dropping it leaves that
+    # operator's term count untracked -- at L1 that is both fixed-model `propagate` rows.
+    assert set(result) == {_ENERGY, "operator[heisenberg]", build_graph}
+    assert result[build_graph] == {"terms": {"value": 34.0}}
+    assert result["operator[heisenberg]"] == {"terms": {"value": 12.0}}
+
+
+def test_operator_metrics_join_the_timings_of_the_same_benchmark(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path, opsize={_ENERGY: {"terms": 34}})
+    result = bmf.build_bmf(tmp_path, "ci")
+
+    # One benchmark, both measures: Bencher keys history on (benchmark, measure), so the
+    # count has to share the name its latency is recorded under.
+    assert result[_ENERGY] == {
+        "latency": {"value": 0.5e9, "lower_value": 0.49e9, "upper_value": 0.51e9},
+        "terms": {"value": 34.0},
     }
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two changes to what the ladder exports, together because both move series identity.

**Untracked counts.** `conftest.py` keys `opsize` by picture where operations share an operator
(`:562`) and by pytest node id where a benchmark holds its own (`record_opsize`, `:461`). The
exporter dropped every node-id key as belonging to "a private A/B harness" — but
`bench_models.py:85`/`:127` use `record_opsize` for a real operator. So at L1, three operators
were measured and one term count was tracked; the two fixed-model `propagate` rows had no
`terms` guard. Counts now land on the benchmark that built the operator.

**Names.** Exported as `family/operation[param]`: `random/build_graph[heisenberg]`, not
`bench_random.py::test_random_build_graph[heisenberg]`. Legends show this name. The family
stays because it is the only thing separating a model's operation from a random problem's once
the parameter alone is left. Non-pytest-shaped names pass through untouched.

Verified against [run 34234911514](https://github.com/Algorithmiq/monoprop/actions/runs/34234911514)'s
artifacts. The two new L1 counts, 9,953,109 and 10,069,308, match `benchmarks.mdx:377`.

At L2a/L2b the new `terms` series duplicates the shared operator's count. Deliberate: they agree
by construction, so disagreement is what the exact-match threshold is for.

## Changes

- `bmf.py`: route node-id `opsize` keys to their own benchmark; add `benchmark_name`, applied to
  timings, peak memory and those counts.
- `test_bmf.py`: invert the test that asserted the old skip; add cases for the shared benchmark
  and the name mapping.
- bench-tools `README.md`: the mapping is history-bearing, like the names its scope note covers.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (Opus 5)
- [x] I used the following tool to generate or modify code: Claude Code (Opus 5)

> [!IMPORTANT]
> Every series is renamed. `PATCH …/benchmarks/{benchmark}` takes `name` and `slug`, so the
> existing benchmarks can be renamed in place — needs running between this merging and the next
> push to `main`, or the point each holds is orphaned beside a duplicate. The nine plots then
> need repointing, and `L1 terms` gains two counts.
