### PR TITLE
feat(ci): 👷 measure propagate at both L2 shapes

### DIFF
--- a/.github/workflows/bench_bare_metal.yml
+++ b/.github/workflows/bench_bare_metal.yml
@@ -26,6 +26,10 @@ jobs:
         L1  1 1        3 | -k "(test_model_propagate and (hubbard or pauli)) or (test_random_gradient and heisenberg)" --hubbard-cutoff=10 --hubbard-lower-atol=4.2e-05 --pauli-cutoff=12 --pauli-lower-atol=1.22e-04 --num-generators=1000 --num-modes=142 --cutoff=6 --obs-terms=295000
         L2a 1 per-rank 1 | -k "(test_random_build_graph or test_random_energy or test_random_gradient) and heisenberg" --num-generators=1000 --num-modes=142 --cutoff=6 --obs-terms=2500000
         L2b 4 per-rank 1 | -k "(test_random_build_graph or test_random_energy or test_random_gradient) and heisenberg" --num-generators=1000 --num-modes=142 --cutoff=6 --obs-terms=2500000
+        # `propagate` owns an operator rather than sharing L2a/L2b's, so it gets the same two
+        # shapes in processes of its own; in theirs the peak would be a sum, not a max.
+        L2c 1 per-rank 1 | -k "test_random_propagate and heisenberg" --num-generators=1000 --num-modes=142 --cutoff=6 --obs-terms=2500000
+        L2d 4 per-rank 1 | -k "test_random_propagate and heisenberg" --num-generators=1000 --num-modes=142 --cutoff=6 --obs-terms=2500000
     secrets: inherit
     permissions:
       contents: read

--- a/docs/content/docs/benchmarks.mdx
+++ b/docs/content/docs/benchmarks.mdx
@@ -350,14 +350,16 @@ Bencher keys history on `(branch, testbed, benchmark, measure)`, so a testbed de
 *and* one shape and the name carries both: `<cpu>-<cores>c-<rung>`, where `<cpu>` is `brand_raw`
 slugified and `<cores>` the physical core count read off the machine. On the pinned `c7i.4xlarge` —
 16 vCPU / **8 physical cores**, 32 GiB nominal (~30 usable), no swap — that gives
-`intel-xeon-platinum-8488c-8c-L1` and `-L2a`, `-L2b`. All three rungs run on one node from one
-MPI-enabled build, so the edges between them move the shape and nothing else.
+`intel-xeon-platinum-8488c-8c-L1` and `-L2a`, `-L2b`, `-L2c`, `-L2d`. Every rung runs on one node
+from one MPI-enabled build, so the edges between them move the shape and nothing else.
 
 | rung | `R` × `P` | launch | `monoprop_PARTITIONS` | rounds |
 |---|---|---|---:|---:|
 | L1 | 1 × 1 | `pytest benches` | 1 | 3 |
 | L2a | 1 × 8 | `pytest benches` | 8 | 1 |
 | L2b | 4 × 2 | `mpiexec -n 4 --map-by slot:PE=2 --bind-to core` | 2 | 1 |
+| L2c | 1 × 8 | `pytest benches` | 8 | 1 |
+| L2d | 4 × 2 | `mpiexec -n 4 --map-by slot:PE=2 --bind-to core` | 2 | 1 |
 
 `R × P` = 8 at L2a and L2b. L2b is 4 × 2 because the per-rank cost is paid `R` times on one node,
 which makes it the memory-worst rung and so the one the size ceiling is set against; `P` = 2 keeps
@@ -404,6 +406,24 @@ the number to provision against and the wrong number to divide.
 The term count is identical at both shapes, which is the geometry-independence check. L2b's node
 sum is 1.24x L2a's peak at this size — the per-rank cost paid four times on one node — against
 1.29x at 1.5M, so the multiplier falls as the operator grows.
+
+#### L2c and L2d — `propagate`, at the same two shapes
+
+`propagate` builds an operator of its own instead of reading the graph `build_graph` publishes, so
+it cannot share L2a and L2b's process: there the rung's peak is the *max* over three operations on
+one operator, and adding a fourth that holds its own would make it a *sum*. At this size that sum
+does not fit — `propagate` is roughly 100 bytes per term at `LADDER.md`'s L2a point, so ~17 GiB for
+this rung's 167M terms, on top of L2a's 18.4 GiB against ~30 usable.
+
+So it takes the same two shapes in processes of its own, which is also what keeps L2a and L2b's
+`terms` equality meaningful: three operations, one operator, one count.
+
+`-k "test_random_propagate and heisenberg"` with L2a and L2b's flags, so the problem is the one
+those rungs measure and only the operation differs.
+
+Only the random Heisenberg row is here. `LADDER.md`'s fixed-model `propagate` rows at their L2
+cutoffs are 60 GiB (hubbard) and 80 GiB (pauli), an order of magnitude past this node, and at L1
+sizes they would only repeat L1.
 
 #### Inputs
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`propagate` was the one L2 operation not measured. `LADDER.md:46` says why: it owns another
operator. L2a/L2b share one across `build_graph`, `energy` and `gradient` (`publish_graph`,
`conftest.py:562`), so their peak is the **max** over three operations — 18.4 GiB at L2a, 20.7
GiB/node at L2b. A fourth holding its own makes it a **sum**, and ≈17 GiB (100 bytes/term at
`LADDER.md:105`, for 167M terms) on top of 18.4 GiB does not fit ~30 usable.

So it takes the same two shapes in its own processes, as `L2c` (1 × 8) and `L2d` (4 × 2). That
also keeps L2a/L2b's `terms` equality meaningful: three operations, one operator, one count.

Random Heisenberg only — `LADDER.md:103-104`'s fixed-model rows are 60 and 80 GiB at their L2
cutoffs, and at L1 sizes would repeat L1. Flags are L2a/L2b's, so only the operation differs.

## Changes

- `bench_bare_metal.yml`: two rungs (two lines).
- `benchmarks.mdx`: the shapes, the two new testbeds, and why this is a rung and not a wider `-k`.

## Verification

Rung loop dry-run under bash 5 with pytest/`mpiexec` stubbed, `BENCH_CORES=8`: five rungs parse,
shapes `1×1`, `1×8`, `4×2`, `1×8`, `4×2`, all `R × P ≤ 8`.

`--obs-terms=2500000` matches L2a/L2b for comparability but is **unmeasured at this shape**. If
the ≈17 GiB estimate is wrong the rung OOMs, and since the ladder is `set -euo pipefail` with no
`if: always()` on the Bencher step, that costs the commit's whole upload, not just this rung —
the raw artifact survives. First `main` run is the real test; the fix is a smaller `--obs-terms`.

## Checklist

- [x] Tests added or updated to cover the changes <!-- CI-only; the dry run above and the first main run -->
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (Opus 5)
- [x] I used the following tool to generate or modify code: Claude Code (Opus 5)

> [!NOTE]
> Testbeds `…-8c-L2c` and `-8c-L2d` are auto-created on the first run and need six plots to match
> the other rungs. Each `main` commit gets ~2-4 min longer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added two benchmark configurations for the `propagate` operation, covering single-process and multi-process execution shapes.

- **Documentation**
  - Expanded benchmark documentation to include the new configurations, execution layouts, partitioning details, and memory considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->