### PR TITLE
perf(operator): ⚡ pool the term store into a chunked, two-tier array

### DIFF
--- a/cpp/include/monoprop/MonomialPropagator.h
+++ b/cpp/include/monoprop/MonomialPropagator.h
@@ -199,6 +199,7 @@ public:
         update_setting_([&](MonomialPropagator &p) {
             p.cutoff_ = new_cutoff;
             p.regenerate_cutoff_fn_();
+            p.follow_cutoff_bound_();
         });
     }
 
@@ -207,6 +208,7 @@ public:
         update_setting_([&](MonomialPropagator &p) {
             p.cutoff_type_ = new_cutoff_type;
             p.regenerate_cutoff_fn_();
+            p.follow_cutoff_bound_();
         });
     }
 
@@ -216,6 +218,7 @@ public:
         update_setting_([&](MonomialPropagator &p) {
             p.basis_change_ = new_basis_change;
             p.regenerate_cutoff_fn_();
+            p.follow_cutoff_bound_();
         });
     }
 
@@ -314,6 +317,12 @@ protected:
     // A perf hint, never a correctness constraint: overflow spills losslessly. Sized to the cutoff's
     // structural position bound when it has one.
     auto packed_inline_width_() const -> size_t;
+    // The width to lay the rows at, which is under the bound wherever the model says most rows are.
+    // A wrong guess costs one restride, never a wrong answer.
+    auto predicted_inline_width_(const MonomialList<NumModes> &op, size_t wide_width) const -> size_t;
+    // Lets the row store's second tier follow a cutoff widened after construction, so the rows the new
+    // cutoff admits are laid out rather than spilled into the side-map an entry at a time.
+    auto follow_cutoff_bound_() -> void { mp_op_.store->raise_bound(packed_inline_width_()); }
 
     // `requested` 0 ⇒ env/auto. Returns 1 for the ordinary single-partition path.
     static auto resolve_partition_count_(size_t requested, mpi::Comm comm) -> size_t;

--- a/cpp/monoprop/detail/evolution/CosineRecompute.h
+++ b/cpp/monoprop/detail/evolution/CosineRecompute.h
@@ -107,13 +107,16 @@ auto make_fold_cache(const InvertedIndex<NumModes> &sc,
     const auto gen_columns = build_even_parity_generator_columns<NumModes>(fold_gen);
 
     // One combine over [0, mask_words): words >= mask_words are never read, so dropping them is exact.
+    // Blocked like every other fold, because a dense column is chunked and no pointer into it spans
+    // more than one fold block. XOR is associative, so the split is bit-identical to a full-width one.
     p.combined.resize(p.fold.mask_words); // combine_columns_block zero-fills
-    if (p.fold.mask_words != 0) {
+    for (size_t bb = 0; bb < p.fold.mask_words; bb += kColumnBlockWords) {
+        const size_t be = std::min(bb + kColumnBlockWords, p.fold.mask_words);
         combine_columns_block<NumModes>(sc,
                                         {gen_columns.indices.data(), gen_columns.count},
-                                        p.combined.data(),
-                                        0,
-                                        p.fold.mask_words);
+                                        p.combined.data() + bb,
+                                        bb,
+                                        be);
     }
     return p;
 }

--- a/cpp/monoprop/detail/evolution/layer_build/Scan.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Scan.h
@@ -100,13 +100,15 @@ inline auto even_parity_scan_pass1(const InvertedIndex<NumModes> &sc,
     n_anti = 0;
     n_foll = 0;
     const bool pivot_dense = sc.column_is_dense(pivot_col);
-    const uint64_t *const pivot_dense_ptr = pivot_dense ? sc.dense_column_data(pivot_col) : nullptr;
     std::vector<uint64_t> &blk = column_block_scratch();
     // A dense pivot is read inline; a sparse pivot is scatter-expanded lazily (only for blocks with a
     // nonzero overlap, so no-anticommuter blocks skip it) via a deferred follower fix-up — bit-identical
     // to eager expansion.
     auto fold_range = [&](size_t bb, size_t be) {
         combine_columns_block<NumModes>(sc, gen_cols, blk.data(), bb, be);
+        // Block-scoped: a dense column is stored in chunks, so its words are contiguous only within
+        // one fold block (InvertedIndex::dense_column_block).
+        const uint64_t *const pivot_dense_ptr = pivot_dense ? sc.dense_column_block(pivot_col, bb, be) : nullptr;
         const size_t nz_block_start = nz.size();
         for (size_t wi = bb; wi < be; ++wi) {
             uint64_t overlap = blk[wi - bb];
@@ -122,7 +124,7 @@ inline auto even_parity_scan_pass1(const InvertedIndex<NumModes> &sc,
             n_anti += static_cast<size_t>(std::popcount(overlap));
             uint64_t foll = 0;
             if (pivot_dense) {
-                foll = overlap & pivot_dense_ptr[wi];
+                foll = overlap & pivot_dense_ptr[wi - bb];
                 n_foll += static_cast<size_t>(std::popcount(foll));
             }
             nz.push_back(EvenParityNzWord{wi * 64, overlap, foll});

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -194,7 +194,11 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
 
     // Must run before the store: packed_inline_width_() derives the packed-row width from cutoff_fn_.
     regenerate_cutoff_fn_();
-    mp_op_.store = std::make_unique<detail::OperatorIndex<NumModes>>(packed_inline_width_());
+    const size_t wide_width = packed_inline_width_();
+    mp_op_.store =
+        std::make_unique<detail::OperatorIndex<NumModes>>(predicted_inline_width_(local_heisenberg_terms, wide_width),
+                                                          0,
+                                                          wide_width);
     mp_op_.store->reserve(expected_local_terms);
     // Store replaced: drop the stale lazy inverted index so it rebuilds against the new store.
     mp_op_.inverted_index_.reset();
@@ -376,6 +380,35 @@ auto MonomialPropagator<NumModes>::partitioned_operator_memory_usage_() const
 template <size_t NumModes>
 auto MonomialPropagator<NumModes>::partitioned_graph_memory_usage_() const -> GraphMemoryBreakdown {
     return sum_partitions_([](const MonomialPropagator &s) { return s.graph_memory_usage(); });
+}
+
+/*! @brief The inline width to build the row store at: the width most rows are expected to need.
+ *
+ *  packed_inline_width_() is the structural *bound*, which real operators sit well under, and the
+ *  inline width is paid for by every row while the wide tier is paid for only by the rows in it.
+ *  Majorana rows are even-parity when the initial operator is and the generators preserve it, so the
+ *  bound is one slot loose at every odd cutoff. For Pauli the measured P99 runs at 0.79-0.88 of the
+ *  bound, and 0.79 takes the largest cut.
+ *
+ *  Either guess being wrong costs one restride and nothing else: the store spills to its wide tier and
+ *  re-lays itself at the bound the first time the tier passes kRestridePercent of the rows.
+ */
+template <size_t NumModes>
+auto MonomialPropagator<NumModes>::predicted_inline_width_(const MonomialList<NumModes> &op, size_t wide_width) const
+    -> size_t {
+    constexpr size_t kPauliP99Numerator = 79;
+    if (schrodinger_ || wide_width == 0) {
+        return wide_width;
+    }
+    if (basis_ == Basis::Pauli) {
+        return std::max<size_t>(1, (wide_width * kPauliP99Numerator + 99) / 100);
+    }
+    for (size_t r = 0; r < op.size(); ++r) {
+        if (materialize_row<NumModes>(op, r).count() % 2 != 0) {
+            return wide_width;
+        }
+    }
+    return std::max<size_t>(1, 2 * (wide_width / 2));
 }
 
 template <size_t NumModes>
@@ -564,10 +597,14 @@ auto MonomialPropagator<NumModes>::extend_coeffs_from_current_picture_if_needed_
         return;
     }
 
+    // One reservation for both the copy and the zero-fill tail, so the caller's array takes a single
+    // growth step at the row store's policy rather than up to two of std::vector's own.
+    detail::reserve_coeffs_geometric(coeffs, mp_op_.size());
     if (coeffs.size() < current.size()) {
         coeffs.insert(coeffs.end(), current.begin() + static_cast<std::ptrdiff_t>(coeffs.size()), current.end());
     }
     coeffs.resize(mp_op_.size(), 0.0);
+    mp_op_.observe_op_coeffs_slack();
 }
 
 template <size_t NumModes>
@@ -759,11 +796,17 @@ template <typename EvolutionFunc>
 auto MonomialPropagator<NumModes>::run_gate_loop_(const std::vector<VecZ> &majoranas,
                                                   std::optional<size_t> only_rotate_len_k,
                                                   EvolutionFunc evolution_func) -> void {
+    mp_op_.reset_op_coeffs_slack_hwm();
     // Serial per partition; parallelism comes from partitioning the operator across cores.
     for (size_t i = 0; i < majoranas.size(); ++i) {
         const auto idx = !schrodinger_ ? majoranas.size() - 1 - i : i;
         const auto &mono = majoranas[idx];
         evolution_func(mono, only_rotate_len_k, i);
+        // Between gates, never inside one: a gate holds spans into the rows it is reading, and the
+        // restride moves every one of them. Row indices survive it, so nothing else has to be rebuilt.
+        if (mp_op_.store->should_restride()) {
+            mp_op_.store->restride_to_bound();
+        }
     }
 
     initialize_operator_caches_();

--- a/cpp/monoprop/detail/operator/CMakeLists.txt
+++ b/cpp/monoprop/detail/operator/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
     FILE_SET headers
       TYPE HEADERS
       FILES
+        "ChunkedArray.h"
         "InvertedIndex.h"
         "MPOperator.h"
         "OperatorIndex.h"

--- a/cpp/monoprop/detail/operator/ChunkedArray.h
+++ b/cpp/monoprop/detail/operator/ChunkedArray.h
@@ -37,12 +37,10 @@ namespace monoprop::detail {
 /*! @brief Arena allocator handing out equally sized chunks to the chunked stores of one owner.
  *
  *  One size class per pool: every chunk is `chunk_bytes()` long, so a freed chunk fits any later
- *  request and the free list needs no search. Chunks are carved from arenas of `arena_bytes()`,
- *  mapped on demand and unmapped as soon as the last chunk in them comes back, so a drained store
- *  returns its memory to the OS rather than to the allocator's retention. Arenas are 2 MiB-aligned
- *  so transparent huge pages can back them.
- *
- *  Not thread-safe: one pool belongs to one partition's stores, driven by that partition's master.
+ *  request and the free list needs no search. Chunks are carved from arenas of `arena_bytes()`, mapped
+ *  on demand and unmapped as soon as the last chunk in them comes back, so a drained store returns its
+ *  memory to the OS rather than to the allocator's retention. Arenas are 2 MiB-aligned, so transparent
+ *  huge pages can back them. Not thread-safe: one pool serves one partition's stores.
  */
 class ChunkPool {
 public:
@@ -252,12 +250,10 @@ private:
  *
  *  Growth appends whole chunks from the pool the array is attached to: nothing is copied and the only
  *  slack is the tail of the last chunk. Elements are default-initialized like DefaultInitVector, so a
- *  caller that needs zeros asks grow_zeroed(); elements past size() are indeterminate.
- *
- *  The chunk length is a power of two, so index -> (chunk, offset) is a shift and a mask. A run of
- *  consecutive indices known not to cross a chunk boundary is readable through contiguous_at().
- *
- *  Move-only: the array owns its chunks and the pool must outlive it.
+ *  caller that needs zeros asks grow_zeroed(); elements past size() are indeterminate. The chunk
+ *  length is a power of two, so index -> (chunk, offset) is a shift and a mask, and a run of
+ *  consecutive indices known not to cross a boundary is readable through contiguous_at(). Move-only:
+ *  the array owns its chunks and the pool must outlive it.
  */
 template <typename T>
     requires std::is_trivially_copyable_v<T>
@@ -425,10 +421,8 @@ private:
  *  The stride is a runtime width (one popcount slot plus the inline positions), so `rows_per_chunk *
  *  stride` is not a power of two and ChunkedArray's element indexing cannot serve it. This keeps the
  *  power of two on the ROW index, which is what every caller has, and multiplies by the stride inside
- *  the chunk.
- *
- *  A row never straddles a chunk, so a span over one row is contiguous. Rows are default-initialized:
- *  every freshly grown row is overwritten by its set() before any read.
+ *  the chunk. A row never straddles a chunk, so a span over one row is contiguous. Rows are
+ *  default-initialized: every freshly grown row is overwritten by its set() before any read.
  */
 template <typename T>
     requires std::is_trivially_copyable_v<T>

--- a/cpp/monoprop/detail/operator/ChunkedArray.h
+++ b/cpp/monoprop/detail/operator/ChunkedArray.h
@@ -1,0 +1,563 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <new>
+#include <numeric>
+#include <type_traits>
+#include <vector>
+
+#if defined(__linux__)
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+namespace monoprop::detail {
+
+/*! @brief Arena allocator handing out equally sized chunks to the chunked stores of one owner.
+ *
+ *  One size class per pool: every chunk is `chunk_bytes()` long, so a freed chunk fits any later
+ *  request and the free list needs no search. Chunks are carved from arenas of `arena_bytes()`,
+ *  mapped on demand and unmapped as soon as the last chunk in them comes back, so a drained store
+ *  returns its memory to the OS rather than to the allocator's retention. Arenas are 2 MiB-aligned
+ *  so transparent huge pages can back them.
+ *
+ *  Not thread-safe: one pool belongs to one partition's stores, driven by that partition's master.
+ */
+class ChunkPool {
+public:
+    //! Default arena size, so a 1 GiB column costs tens of mappings rather than thousands.
+    static constexpr size_t kArenaBytes = size_t{32} << 20;
+    //! Transparent-huge-page granularity on x86-64; the alignment every arena is placed on.
+    static constexpr size_t kHugePageBytes = size_t{2} << 20;
+
+    /*! @brief Builds a pool whose chunks are at least @a chunk_bytes long.
+     *
+     *  The request is rounded up to whole pages and no further, so the chunks tile the arena exactly
+     *  and a chunk carries at most a page of slack. @a arena_bytes is a hint: the arena is sized to a
+     *  whole number of chunks and is never smaller than one.
+     */
+    explicit ChunkPool(size_t chunk_bytes, size_t arena_bytes = kArenaBytes)
+        : chunk_bytes_(round_up_(std::max(chunk_bytes, size_t{1}), page_bytes_())),
+          chunks_per_arena_(std::max(size_t{1}, arena_bytes / chunk_bytes_)),
+          arena_bytes_(chunks_per_arena_ * chunk_bytes_) {}
+
+    ~ChunkPool() {
+        // The owning stores are declared so as to be destroyed first and release their chunks there;
+        // anything still out here would be a leak either way, so unmap regardless.
+        for (auto &arena : arenas_) {
+            release_mapping_(*arena);
+        }
+    }
+
+    ChunkPool(const ChunkPool &) = delete;
+    auto operator=(const ChunkPool &) -> ChunkPool & = delete;
+    // Non-movable: every ChunkedArray holds a bare pointer to its pool, so the pool must not change
+    // address. Owners that are themselves movable hold it through a unique_ptr.
+    ChunkPool(ChunkPool &&) = delete;
+    auto operator=(ChunkPool &&) -> ChunkPool & = delete;
+
+    //! Length of every chunk this pool hands out, page-rounded up from the requested size.
+    [[nodiscard]] auto chunk_bytes() const noexcept -> size_t { return chunk_bytes_; }
+    //! Length of one arena: a whole number of chunks.
+    [[nodiscard]] auto arena_bytes() const noexcept -> size_t { return arena_bytes_; }
+    //! Chunks carved from one arena.
+    [[nodiscard]] auto chunks_per_arena() const noexcept -> size_t { return chunks_per_arena_; }
+    /*! @brief Alignment every chunk satisfies: kHugePageBytes for chunks that are a multiple of it,
+     *  else the largest power of two dividing both the chunk size and the arena's 2 MiB alignment.
+     */
+    [[nodiscard]] auto chunk_alignment() const noexcept -> size_t { return std::gcd(chunk_bytes_, kHugePageBytes); }
+    //! Arenas currently mapped.
+    [[nodiscard]] auto arena_count() const noexcept -> size_t { return arenas_.size(); }
+    //! Bytes currently mapped by this pool, free chunks included.
+    [[nodiscard]] auto mapped_bytes() const noexcept -> size_t { return arenas_.size() * arena_bytes_; }
+    //! Chunks handed out and not yet returned.
+    [[nodiscard]] auto live_chunks() const noexcept -> size_t { return live_chunks_; }
+    //! Of mapped_bytes(): the chunks handed out. The remainder is free space inside partly used arenas.
+    [[nodiscard]] auto live_bytes() const noexcept -> size_t { return live_chunks_ * chunk_bytes_; }
+
+    /*! @brief Hands out one chunk, mapping a new arena when no partly used one has room.
+     *  @throws std::bad_alloc if the mapping fails.
+     *  The chunk's bytes are indeterminate: a fresh mapping reads as zero, a recycled chunk does not.
+     */
+    [[nodiscard]] auto allocate() -> void * {
+        if (partial_.empty()) {
+            map_arena_();
+        }
+        Arena &arena = *partial_.back();
+        std::byte *chunk = nullptr;
+        if (!arena.free_chunks.empty()) {
+            chunk = arena.free_chunks.back();
+            arena.free_chunks.pop_back();
+        }
+        else {
+            chunk = arena.base + (arena.next_unused * chunk_bytes_);
+            ++arena.next_unused;
+        }
+        ++arena.live;
+        ++live_chunks_;
+        if (arena.free_chunks.empty() && arena.next_unused == chunks_per_arena_) {
+            arena.in_partial = false;
+            partial_.pop_back();
+        }
+        return chunk;
+    }
+
+    //! Returns a chunk from allocate(); unmaps its arena once every chunk in it is back.
+    auto deallocate(void *chunk) noexcept -> void {
+        if (chunk == nullptr) {
+            return;
+        }
+        Arena *arena = arena_of_(static_cast<std::byte *>(chunk));
+        assert(arena != nullptr && "chunk does not belong to this pool");
+        --arena->live;
+        --live_chunks_;
+        if (arena->live == 0) {
+            drop_arena_(*arena);
+            return;
+        }
+        arena->free_chunks.push_back(static_cast<std::byte *>(chunk));
+        if (!arena->in_partial) {
+            arena->in_partial = true;
+            partial_.push_back(arena);
+        }
+    }
+
+private:
+    //! One mapping, carved into chunks_per_arena_ chunks handed out in address order then recycled.
+    struct Arena {
+        std::byte *base = nullptr;              //!< 2 MiB-aligned start of the usable region
+        std::byte *raw = nullptr;               //!< what the platform allocator returned (fallback path only)
+        size_t next_unused = 0;                 //!< chunks never yet handed out start here
+        size_t live = 0;                        //!< chunks handed out and not returned
+        std::vector<std::byte *> free_chunks{}; //!< returned chunks, ready to hand out again
+        bool in_partial = false;                //!< mirrors membership of ChunkPool::partial_
+    };
+
+    static auto round_up_(size_t value, size_t alignment) noexcept -> size_t {
+        return (value + alignment - 1) & ~(alignment - 1);
+    }
+
+    //! The platform page size, read once. Powers the rounding above, so it must be a power of two.
+    static auto page_bytes_() noexcept -> size_t {
+#if defined(__linux__)
+        static const size_t page = static_cast<size_t>(::sysconf(_SC_PAGESIZE));
+        return page;
+#else
+        return size_t{4096};
+#endif
+    }
+
+    auto map_arena_() -> void {
+        auto arena = std::make_unique<Arena>();
+#if defined(__linux__)
+        // Over-map by one huge page and trim, so the arena starts on a 2 MiB boundary and is left as
+        // exactly one VMA: THP can back it, and its footprint is one line of /proc/self/maps.
+        const size_t requested = arena_bytes_ + kHugePageBytes;
+        void *raw = ::mmap(nullptr, requested, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (raw == MAP_FAILED) {
+            throw std::bad_alloc();
+        }
+        auto *start = static_cast<std::byte *>(raw);
+        auto *base = reinterpret_cast<std::byte *>(round_up_(reinterpret_cast<uintptr_t>(start), kHugePageBytes));
+        const size_t head = static_cast<size_t>(base - start);
+        if (head != 0) {
+            ::munmap(start, head);
+        }
+        const size_t tail = requested - head - arena_bytes_;
+        if (tail != 0) {
+            ::munmap(base + arena_bytes_, tail);
+        }
+#if defined(MADV_HUGEPAGE)
+        ::madvise(base, arena_bytes_, MADV_HUGEPAGE); // advisory: a refusal costs nothing but page size
+#endif
+        arena->base = base;
+#else
+        // Off Linux there is no unmap to make: posix_memalign gives the same alignment, and returning
+        // the block to the platform allocator is the closest equivalent of dropping the mapping.
+        void *raw = nullptr;
+        if (::posix_memalign(&raw, kHugePageBytes, arena_bytes_) != 0) {
+            throw std::bad_alloc();
+        }
+        arena->base = static_cast<std::byte *>(raw);
+        arena->raw = arena->base;
+#endif
+        Arena *inserted = arena.get();
+        // arenas_ stays sorted by base so arena_of_ is a binary search rather than a scan.
+        const auto at = std::ranges::upper_bound(arenas_, inserted->base, {}, [](const auto &a) { return a->base; });
+        arenas_.insert(at, std::move(arena));
+        inserted->in_partial = true;
+        partial_.push_back(inserted);
+    }
+
+    //! Gives @a arena's memory back to the OS. Leaves the bookkeeping object for the caller to erase.
+    auto release_mapping_(Arena &arena) noexcept -> void {
+#if defined(__linux__)
+        ::munmap(arena.base, arena_bytes_);
+#else
+        std::free(arena.raw);
+#endif
+    }
+
+    //! Drops @a arena's mapping and forgets it. The caller has already accounted for its chunks.
+    auto drop_arena_(Arena &arena) noexcept -> void {
+        if (arena.in_partial) {
+            std::erase(partial_, &arena);
+        }
+        release_mapping_(arena);
+        const auto at = std::ranges::lower_bound(arenas_, arena.base, {}, [](const auto &a) { return a->base; });
+        assert(at != arenas_.end() && at->get() == &arena);
+        arenas_.erase(at);
+    }
+
+    //! The arena containing @a chunk, or nullptr if no arena of this pool does.
+    [[nodiscard]] auto arena_of_(std::byte *chunk) const noexcept -> Arena * {
+        const auto at = std::ranges::upper_bound(arenas_, chunk, {}, [](const auto &a) { return a->base; });
+        if (at == arenas_.begin()) {
+            return nullptr;
+        }
+        Arena *arena = std::prev(at)->get();
+        return chunk < arena->base + arena_bytes_ ? arena : nullptr;
+    }
+
+    size_t chunk_bytes_;
+    size_t chunks_per_arena_;
+    size_t arena_bytes_;
+    size_t live_chunks_ = 0;
+    std::vector<std::unique_ptr<Arena>> arenas_{}; //!< every mapped arena, ascending by base
+    std::vector<Arena *> partial_{};               //!< arenas with a chunk available, each listed once
+};
+
+/*! @brief An append-only array of trivially copyable @a T held as a list of equally sized chunks.
+ *
+ *  Growth appends whole chunks from the pool the array is attached to: nothing is copied and the only
+ *  slack is the tail of the last chunk. Elements are default-initialized like DefaultInitVector, so a
+ *  caller that needs zeros asks grow_zeroed(); elements past size() are indeterminate.
+ *
+ *  The chunk length is a power of two, so index -> (chunk, offset) is a shift and a mask. A run of
+ *  consecutive indices known not to cross a chunk boundary is readable through contiguous_at().
+ *
+ *  Move-only: the array owns its chunks and the pool must outlive it.
+ */
+template <typename T>
+    requires std::is_trivially_copyable_v<T>
+class ChunkedArray {
+public:
+    //! An unattached, empty array. attach() binds it to a pool before it can grow.
+    ChunkedArray() noexcept = default;
+    //! Binds directly to @a pool with @a elems_per_chunk elements per chunk (a power of two).
+    ChunkedArray(ChunkPool &pool, size_t elems_per_chunk) { attach(pool, elems_per_chunk); }
+
+    ChunkedArray(const ChunkedArray &) = delete;
+    auto operator=(const ChunkedArray &) -> ChunkedArray & = delete;
+
+    ChunkedArray(ChunkedArray &&other) noexcept { swap_(other); }
+    auto operator=(ChunkedArray &&other) noexcept -> ChunkedArray & {
+        if (this != &other) {
+            reset();
+            swap_(other);
+        }
+        return *this;
+    }
+    ~ChunkedArray() { reset(); }
+
+    /*! @brief Binds an empty array to @a pool.
+     *  @pre The array holds no chunks, and @a elems_per_chunk is a power of two that fits a chunk.
+     */
+    auto attach(ChunkPool &pool, size_t elems_per_chunk) -> void {
+        assert(chunks_.empty() && "attach() rebinds only an empty array");
+        assert(std::has_single_bit(elems_per_chunk));
+        assert(elems_per_chunk * sizeof(T) <= pool.chunk_bytes());
+        pool_ = &pool;
+        elems_per_chunk_ = elems_per_chunk;
+        shift_ = static_cast<size_t>(std::countr_zero(elems_per_chunk));
+        mask_ = elems_per_chunk - 1;
+    }
+
+    //! Whether a pool has been bound, i.e. whether the array may grow.
+    [[nodiscard]] auto attached() const noexcept -> bool { return pool_ != nullptr; }
+    //! Elements per chunk, as bound by attach().
+    [[nodiscard]] auto elems_per_chunk() const noexcept -> size_t { return elems_per_chunk_; }
+    //! Live elements: indices [0, size()) are readable, the rest are not.
+    [[nodiscard]] auto size() const noexcept -> size_t { return size_; }
+    //! Whether the array holds no live elements.
+    [[nodiscard]] auto empty() const noexcept -> bool { return size_ == 0; }
+    //! Elements the chunks already hold room for: size() rounded up to a whole chunk.
+    [[nodiscard]] auto capacity() const noexcept -> size_t { return chunks_.size() * elems_per_chunk_; }
+    //! Chunks currently held.
+    [[nodiscard]] auto chunk_count() const noexcept -> size_t { return chunks_.size(); }
+    //! Bytes held: the page-rounded chunks plus the chunk index that addresses them.
+    [[nodiscard]] auto bytes() const noexcept -> size_t {
+        return (pool_ == nullptr ? 0 : chunks_.size() * pool_->chunk_bytes()) + (chunks_.capacity() * sizeof(T *));
+    }
+    //! The bytes of the last chunk that lie past size(): the array's whole growth slack.
+    [[nodiscard]] auto slack_bytes() const noexcept -> size_t { return (capacity() - size_) * sizeof(T); }
+
+    //! Element @a i. @pre i < size().
+    [[nodiscard]] auto operator[](size_t i) noexcept -> T & { return chunks_[i >> shift_][i & mask_]; }
+    //! @copydoc operator[]
+    [[nodiscard]] auto operator[](size_t i) const noexcept -> const T & { return chunks_[i >> shift_][i & mask_]; }
+
+    //! First element of the chunk holding @a i, so chunk_base(i)[i % elems_per_chunk()] is element @a i.
+    [[nodiscard]] auto chunk_base(size_t i) noexcept -> T * { return chunks_[i >> shift_]; }
+    //! @copydoc chunk_base
+    [[nodiscard]] auto chunk_base(size_t i) const noexcept -> const T * { return chunks_[i >> shift_]; }
+
+    //! Element @a i as a bare pointer, valid for the elems_left_in_chunk(i) elements from there on.
+    [[nodiscard]] auto contiguous_at(size_t i) noexcept -> T * { return chunks_[i >> shift_] + (i & mask_); }
+    //! @copydoc contiguous_at
+    [[nodiscard]] auto contiguous_at(size_t i) const noexcept -> const T * {
+        return chunks_[i >> shift_] + (i & mask_);
+    }
+    //! Elements from @a i to the end of its chunk: the length contiguous_at(i) is good for.
+    [[nodiscard]] auto elems_left_in_chunk(size_t i) const noexcept -> size_t { return elems_per_chunk_ - (i & mask_); }
+
+    //! Makes room for @a n elements without changing size(). Chunks already held are kept.
+    auto reserve(size_t n) -> void { reserve_(n); }
+
+    /*! @brief Grows to @a n elements, appending whole chunks. New elements are indeterminate.
+     *  A request at or below the current size is ignored: the array is append-only.
+     */
+    auto grow(size_t n) -> void {
+        if (n <= size_) {
+            return;
+        }
+        reserve_(n);
+        size_ = n;
+    }
+
+    //! Grows to @a n elements as grow() does, with the new elements [size(), n) set to zero.
+    auto grow_zeroed(size_t n) -> void {
+        if (n <= size_) {
+            return;
+        }
+        reserve_(n);
+        // Only up to n: the tail of the last chunk is slack, not storage, and zeroing it would fault in
+        // pages the caller may never touch.
+        for (size_t i = size_; i < n;) {
+            const size_t run = std::min(elems_left_in_chunk(i), n - i);
+            std::memset(contiguous_at(i), 0, run * sizeof(T));
+            i += run;
+        }
+        size_ = n;
+    }
+
+    //! Releases every chunk back to the pool and empties the array, keeping it attached.
+    auto reset() noexcept -> void {
+        for (T *chunk : chunks_) {
+            pool_->deallocate(chunk);
+        }
+        chunks_.clear();
+        chunks_.shrink_to_fit();
+        size_ = 0;
+    }
+
+    //! A deep copy taking its chunks from the same pool.
+    [[nodiscard]] auto clone() const -> ChunkedArray { return pool_ == nullptr ? ChunkedArray{} : clone_into(*pool_); }
+
+    /*! @brief A deep copy taking its chunks from @a pool, for an owner that carries its own pool.
+     *  @pre @a pool's chunks are at least as long as this array's.
+     */
+    [[nodiscard]] auto clone_into(ChunkPool &pool) const -> ChunkedArray {
+        ChunkedArray copy;
+        if (pool_ == nullptr) {
+            return copy;
+        }
+        copy.attach(pool, elems_per_chunk_);
+        copy.grow(size_);
+        // Only the live prefix: the slack past size_ is indeterminate and copying it would report as a
+        // read of uninitialized memory.
+        for (size_t i = 0; i < size_; i += elems_per_chunk_) {
+            std::memcpy(copy.chunks_[i >> shift_],
+                        chunks_[i >> shift_],
+                        std::min(elems_per_chunk_, size_ - i) * sizeof(T));
+        }
+        return copy;
+    }
+
+private:
+    auto reserve_(size_t n) -> void {
+        assert(pool_ != nullptr && "a ChunkedArray must be attached to a pool before it grows");
+        while (capacity() < n) {
+            chunks_.push_back(static_cast<T *>(pool_->allocate()));
+        }
+    }
+
+    auto swap_(ChunkedArray &other) noexcept -> void {
+        std::swap(pool_, other.pool_);
+        chunks_.swap(other.chunks_);
+        std::swap(size_, other.size_);
+        std::swap(elems_per_chunk_, other.elems_per_chunk_);
+        std::swap(shift_, other.shift_);
+        std::swap(mask_, other.mask_);
+    }
+
+    ChunkPool *pool_ = nullptr;
+    std::vector<T *> chunks_{}; //!< chunk c holds elements [c * elems_per_chunk_, (c+1) * elems_per_chunk_)
+    size_t size_ = 0;
+    size_t elems_per_chunk_ = 0;
+    size_t shift_ = 0;
+    size_t mask_ = 0;
+};
+
+/*! @brief A chunked array of fixed-width rows: chunk c holds `rows_per_chunk` rows of `stride` T each.
+ *
+ *  The stride is a runtime width (one popcount slot plus the inline positions), so `rows_per_chunk *
+ *  stride` is not a power of two and ChunkedArray's element indexing cannot serve it. This keeps the
+ *  power of two on the ROW index, which is what every caller has, and multiplies by the stride inside
+ *  the chunk.
+ *
+ *  A row never straddles a chunk, so a span over one row is contiguous. Rows are default-initialized:
+ *  every freshly grown row is overwritten by its set() before any read.
+ */
+template <typename T>
+    requires std::is_trivially_copyable_v<T>
+class ChunkedRowArray {
+public:
+    ChunkedRowArray() noexcept = default;
+    ChunkedRowArray(const ChunkedRowArray &) = delete;
+    auto operator=(const ChunkedRowArray &) -> ChunkedRowArray & = delete;
+    ChunkedRowArray(ChunkedRowArray &&other) noexcept { swap_(other); }
+    auto operator=(ChunkedRowArray &&other) noexcept -> ChunkedRowArray & {
+        if (this != &other) {
+            reset();
+            swap_(other);
+        }
+        return *this;
+    }
+    ~ChunkedRowArray() { reset(); }
+
+    /*! @brief Binds an empty array to @a pool.
+     *  @pre The array holds no chunks, @a rows_per_chunk is a power of two, and @a pool's chunks are at
+     *  least rows_per_chunk * stride elements long.
+     */
+    auto attach(ChunkPool &pool, size_t rows_per_chunk, size_t stride) -> void {
+        assert(chunks_.empty() && "attach() rebinds only an empty array");
+        assert(std::has_single_bit(rows_per_chunk) && stride != 0);
+        assert(rows_per_chunk * stride * sizeof(T) <= pool.chunk_bytes());
+        pool_ = &pool;
+        rows_per_chunk_ = rows_per_chunk;
+        stride_ = stride;
+        shift_ = static_cast<size_t>(std::countr_zero(rows_per_chunk));
+        mask_ = rows_per_chunk - 1;
+    }
+
+    [[nodiscard]] auto attached() const noexcept -> bool { return pool_ != nullptr; }
+    //! Live rows: indices [0, size()) are readable.
+    [[nodiscard]] auto size() const noexcept -> size_t { return size_; }
+    //! Rows the chunks already hold room for: size() rounded up to a whole chunk.
+    [[nodiscard]] auto capacity() const noexcept -> size_t { return chunks_.size() * rows_per_chunk_; }
+    [[nodiscard]] auto stride() const noexcept -> size_t { return stride_; }
+    [[nodiscard]] auto rows_per_chunk() const noexcept -> size_t { return rows_per_chunk_; }
+    [[nodiscard]] auto chunk_count() const noexcept -> size_t { return chunks_.size(); }
+    //! Row index mask within a chunk: `row & row_mask()` is the row's offset in its own chunk.
+    [[nodiscard]] auto row_mask() const noexcept -> size_t { return mask_; }
+
+    //! Bytes held: the page-rounded chunks plus the chunk index that addresses them.
+    [[nodiscard]] auto bytes() const noexcept -> size_t {
+        return (pool_ == nullptr ? 0 : chunks_.size() * pool_->chunk_bytes()) + (chunks_.capacity() * sizeof(T *));
+    }
+    //! The tail of the last chunk that lies past size(): the array's whole growth slack.
+    [[nodiscard]] auto slack_bytes() const noexcept -> size_t { return (capacity() - size_) * stride_ * sizeof(T); }
+
+    //! First element of the chunk holding row @a row. @pre row < capacity().
+    [[nodiscard]] auto chunk_base(size_t row) noexcept -> T * { return chunks_[row >> shift_]; }
+    //! @copydoc chunk_base
+    [[nodiscard]] auto chunk_base(size_t row) const noexcept -> const T * { return chunks_[row >> shift_]; }
+    //! Row @a row's `stride()` elements. @pre row < capacity().
+    [[nodiscard]] auto at(size_t row) noexcept -> T * { return chunks_[row >> shift_] + ((row & mask_) * stride_); }
+    //! @copydoc at
+    [[nodiscard]] auto at(size_t row) const noexcept -> const T * {
+        return chunks_[row >> shift_] + ((row & mask_) * stride_);
+    }
+
+    //! Makes room for @a n rows without changing size().
+    auto reserve(size_t n) -> void { reserve_(n); }
+
+    //! Grows to @a n rows, appending whole chunks. New rows are indeterminate; shrinking is ignored.
+    auto grow(size_t n) -> void {
+        if (n <= size_) {
+            return;
+        }
+        reserve_(n);
+        size_ = n;
+    }
+
+    //! Releases every chunk back to the pool and empties the array, keeping it attached.
+    auto reset() noexcept -> void {
+        for (T *chunk : chunks_) {
+            pool_->deallocate(chunk);
+        }
+        chunks_.clear();
+        chunks_.shrink_to_fit();
+        size_ = 0;
+    }
+
+    /*! @brief A deep copy taking its chunks from @a pool, for an owner that carries its own pool.
+     *  @pre @a pool's chunks are at least as long as this array's.
+     */
+    [[nodiscard]] auto clone_into(ChunkPool &pool) const -> ChunkedRowArray {
+        ChunkedRowArray copy;
+        if (pool_ == nullptr) {
+            return copy;
+        }
+        copy.attach(pool, rows_per_chunk_, stride_);
+        copy.grow(size_);
+        // Only the live prefix: the rows past size_ are indeterminate and copying them would report as
+        // a read of uninitialized memory.
+        for (size_t row = 0; row < size_; row += rows_per_chunk_) {
+            std::memcpy(copy.chunks_[row >> shift_],
+                        chunks_[row >> shift_],
+                        std::min(rows_per_chunk_, size_ - row) * stride_ * sizeof(T));
+        }
+        return copy;
+    }
+
+private:
+    auto reserve_(size_t n) -> void {
+        assert(pool_ != nullptr && "a ChunkedRowArray must be attached to a pool before it grows");
+        while (capacity() < n) {
+            chunks_.push_back(static_cast<T *>(pool_->allocate()));
+        }
+    }
+
+    auto swap_(ChunkedRowArray &other) noexcept -> void {
+        std::swap(pool_, other.pool_);
+        chunks_.swap(other.chunks_);
+        std::swap(size_, other.size_);
+        std::swap(rows_per_chunk_, other.rows_per_chunk_);
+        std::swap(stride_, other.stride_);
+        std::swap(shift_, other.shift_);
+        std::swap(mask_, other.mask_);
+    }
+
+    ChunkPool *pool_ = nullptr;
+    std::vector<T *> chunks_{}; //!< chunk c holds rows [c * rows_per_chunk_, (c+1) * rows_per_chunk_)
+    size_t size_ = 0;
+    size_t rows_per_chunk_ = 0;
+    size_t stride_ = 0;
+    size_t shift_ = 0;
+    size_t mask_ = 0;
+};
+
+} // namespace monoprop::detail

--- a/cpp/monoprop/detail/operator/InvertedIndex.h
+++ b/cpp/monoprop/detail/operator/InvertedIndex.h
@@ -20,33 +20,147 @@
 #include <cassert>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <span>
 #include <utility>
 #include <vector>
 
 #include "monoprop/TypeAliases.h"
+#include "monoprop/detail/operator/ChunkedArray.h"
 #include "monoprop/detail/operator/RowAccess.h"
 
 namespace monoprop::detail {
+
+//! Fold words per block: an 8 KB block, L1-resident. Every fold walks its word range in blocks of this
+//! size starting at word 0, so a block boundary is always a multiple of it.
+inline constexpr size_t kColumnBlockWords = 1024;
 
 // Lazy transposed operator storage: one bit-vector per column (bit position), bit r set iff term r touches
 // that column. XOR-combining a generator G's columns yields |M ∩ G| mod 2 per term M -- the anticommutation
 // bit for an even generator; odd generators add a per-row parity(|M|) correction, so both parities are
 // served. Columns are stored in two tiers, bit-identical to all-dense: dense (density ≥
 // 1/kPromoteDensityInv) full-height uint64 vectors; sparse an ascending set-row list scatter-expanded at
-// scan time. Promotion is one-way (the operator is append-only).
+// scan time. Dense columns are held in pooled chunks (ChunkedArray.h) rather than one vector each: at a
+// billion terms a column is 125 MB, and a vector's doubling reserve plus the doubled copy it holds while
+// reallocating cost more than the columns' own slack. Promotion is one-way (the operator is append-only).
 template <size_t NumModes>
 struct InvertedIndex {
     static constexpr size_t kNumColumns = Monomial<NumModes>::size();
     static constexpr size_t kPromoteDensityInv = 64;
+    /*! @brief Chunk length of a dense column, in words: between one fold block and eight.
+     *
+     *  A column grown a chunk at a time never reallocates, so it holds neither a growth overshoot nor
+     *  a doubled copy of itself mid-growth.
+     */
+    static constexpr size_t kMinWordsPerChunk = kColumnBlockWords;
+    static constexpr size_t kMaxWordsPerChunk = size_t{1} << 14;
+    //! One chunk size class per power of two in [kMinWordsPerChunk, kMaxWordsPerChunk], and a pool each.
+    static constexpr size_t kChunkSizeClasses =
+        static_cast<size_t>(std::countr_zero(kMaxWordsPerChunk) - std::countr_zero(kMinWordsPerChunk)) + 1;
 
+    /*! @brief Chunk length in words for a dense column first built at @a rows rows.
+     *
+     *  A quarter of the column's height, rounded *down* to a power of two and clamped to the size
+     *  classes. A column overshoots by at most one chunk and a chunk is at most a quarter of it, so its
+     *  slack is under a quarter of the column once the column clears four minimum chunks, and under
+     *  8 KiB below that. It reaches kMaxWordsPerChunk at 4M rows and stops, so a column's slack is
+     *  never more than 128 KiB however large the operator grows.
+     */
+    static auto chunk_words_for_rows(size_t rows) noexcept -> size_t {
+        const size_t quarter = ((rows + 63) / 64) / 4;
+        return std::clamp(std::bit_floor(std::max(quarter, size_t{1})), kMinWordsPerChunk, kMaxWordsPerChunk);
+    }
+
+    /*! @brief One column of the transpose: the rows that touch this bit position, in one of two tiers. */
     struct Column {
-        std::vector<uint64_t> words; // full-height bit-vector; used iff is_dense
+        //! Full-height bit-vector, chunked; used iff is_dense. Words past words() are slack, never read.
+        ChunkedArray<uint64_t> words;
         // Ascending set-row indices (used iff !is_dense). must stay ascending: combine_columns_block
         // lower_bounds these to a word range, and every fill path appends in row order.
         std::vector<TermIndex> set_rows;
-        bool is_dense = false;
+        bool is_dense = false; //!< which of the two tiers holds this column
     };
+
+    /*! @brief An empty index. Its dense columns size their chunks from the height they are built at.
+     *
+     *  @param forced_words_per_chunk 0 to size every column by chunk_words_for_rows(), or a fixed
+     *  length for every column: a power of two and a multiple of kColumnBlockWords, so no fold block
+     *  ever straddles a chunk boundary. A test knob; production always passes 0.
+     */
+    explicit InvertedIndex(size_t forced_words_per_chunk = 0) : forced_words_per_chunk_(forced_words_per_chunk) {
+        assert(forced_words_per_chunk == 0
+               || (std::has_single_bit(forced_words_per_chunk) && forced_words_per_chunk >= kColumnBlockWords
+                   && forced_words_per_chunk % kColumnBlockWords == 0));
+    }
+
+    /*! @brief Deep copy. Each column keeps its own chunk length, taking its chunks from this index's
+     *  pool for that size class, so the two indices share no storage.
+     */
+    InvertedIndex(const InvertedIndex &other) : forced_words_per_chunk_(other.forced_words_per_chunk_) {
+        row_count = other.row_count;
+        row_parity_ = other.row_parity_;
+        for (size_t c = 0; c < kNumColumns; ++c) {
+            cols[c].is_dense = other.cols[c].is_dense;
+            cols[c].set_rows = other.cols[c].set_rows;
+            if (other.cols[c].words.attached()) {
+                cols[c].words = other.cols[c].words.clone_into(pool_for_(other.cols[c].words.elems_per_chunk()));
+            }
+        }
+    }
+
+    // Defaulted: the pool is held by pointer, so it keeps its address and the moved-to columns' bare
+    // pointers into it stay good.
+    InvertedIndex(InvertedIndex &&) noexcept = default;
+
+    /*! @brief Move assignment, which cannot be defaulted: members are assigned in declaration order, so
+     *  a defaulted one would destroy this index's pool while its own columns still held chunks from it.
+     */
+    auto operator=(InvertedIndex &&other) noexcept -> InvertedIndex & {
+        if (this != &other) {
+            for (auto &col : cols) {
+                col.words.reset(); // hand the chunks back while the pool that owns them is still alive
+            }
+            pools_ = std::move(other.pools_);
+            forced_words_per_chunk_ = other.forced_words_per_chunk_;
+            cols = std::move(other.cols);
+            row_count = other.row_count;
+            row_parity_ = std::move(other.row_parity_);
+        }
+        return *this;
+    }
+
+    auto operator=(const InvertedIndex &other) -> InvertedIndex & {
+        if (this != &other) {
+            *this = InvertedIndex(other);
+        }
+        return *this;
+    }
+
+    // Declared before `cols`: members are destroyed in reverse declaration order, so the pools outlive
+    // the columns whose chunks they own.
+    //! One pool per chunk size class, made on first use: a pool serves a single size, and two columns
+    //! built at different heights ask for different ones.
+    std::array<std::unique_ptr<ChunkPool>, kChunkSizeClasses> pools_{};
+    size_t forced_words_per_chunk_ = 0; //!< 0 == size every column from its height (production)
+
+    //! The pool for chunks of @a words_per_chunk words, made on first use. @pre A legal size class.
+    auto pool_for_(size_t words_per_chunk) -> ChunkPool & {
+        assert(std::has_single_bit(words_per_chunk) && words_per_chunk >= kMinWordsPerChunk
+               && words_per_chunk <= kMaxWordsPerChunk);
+        const auto klass = static_cast<size_t>(std::countr_zero(words_per_chunk) - std::countr_zero(kMinWordsPerChunk));
+        if (pools_[klass] == nullptr) {
+            pools_[klass] = std::make_unique<ChunkPool>(words_per_chunk * sizeof(uint64_t));
+        }
+        return *pools_[klass];
+    }
+
+    /*! @brief Binds @a col's dense storage to the pool for the chunk length @a rows asks for.
+     *  @pre The column holds no chunks: a column's chunk length is fixed for as long as it holds any.
+     */
+    auto attach_column_(Column &col, size_t rows) -> void {
+        const size_t w = forced_words_per_chunk_ != 0 ? forced_words_per_chunk_ : chunk_words_for_rows(rows);
+        col.words.attach(pool_for_(w), w);
+    }
 
     std::array<Column, kNumColumns> cols{};
     size_t row_count = 0;
@@ -84,12 +198,25 @@ struct InvertedIndex {
     auto words() const -> size_t { return (row_count + 63) / 64; }
 
     auto column_is_dense(size_t c) const -> bool { return cols[c].is_dense; }
-    auto dense_column_data(size_t c) const -> const uint64_t * { return cols[c].words.data(); }
+    /*! @brief Dense column @a c over fold words [@a bb, @a be), as a plain pointer to word @a bb.
+     *
+     *  Valid for be-bb words and no further. A fold block starts at a multiple of kColumnBlockWords and
+     *  a chunk holds a whole number of blocks, so the requested range never crosses a chunk boundary.
+     *  Ask per block; there is no pointer to the whole column.
+     */
+    auto dense_column_block(size_t c, size_t bb, [[maybe_unused]] size_t be) const -> const uint64_t * {
+        assert(be >= bb && be - bb <= cols[c].words.elems_left_in_chunk(bb)
+               && "a fold block must not straddle a chunk");
+        return cols[c].words.contiguous_at(bb);
+    }
     auto sparse_column_rows(size_t c) const -> const std::vector<TermIndex> & { return cols[c].set_rows; }
 
     auto promote_to_dense(size_t c) -> void {
         Column &col = cols[c];
-        col.words.assign(words(), 0);
+        // A promoted column has no dense storage yet, so this is where its chunk length is chosen.
+        col.words.reset();
+        attach_column_(col, row_count);
+        col.words.grow_zeroed(words());
         for (TermIndex r : col.set_rows) {
             col.words[r >> 6] |= uint64_t{1} << (r & 63U);
         }
@@ -109,7 +236,7 @@ struct InvertedIndex {
         const size_t required_words = (new_total_rows + 63) / 64;
         for (auto &col : cols) {
             if (col.is_dense && col.words.size() < required_words) {
-                col.words.resize(required_words, 0);
+                col.words.grow_zeroed(required_words);
             }
         }
         for (size_t row_idx = base; row_idx < new_total_rows; ++row_idx) {
@@ -138,8 +265,7 @@ struct InvertedIndex {
     auto rebuild(const Rows &op) -> void {
         const size_t size = op.size();
         for (auto &col : cols) {
-            col.words.clear();
-            col.words.shrink_to_fit();
+            col.words.reset();
             col.set_rows.clear();
             col.set_rows.shrink_to_fit();
             col.is_dense = false;
@@ -163,7 +289,8 @@ struct InvertedIndex {
             Column &col = cols[c];
             if (count * kPromoteDensityInv >= size) {
                 col.is_dense = true;
-                col.words.assign(required_words, 0);
+                attach_column_(col, size);
+                col.words.grow_zeroed(required_words);
             }
             else if (count != 0) {
                 col.set_rows.reserve(count);
@@ -196,7 +323,7 @@ struct InvertedIndex {
     auto memory_bytes() const -> size_t {
         size_t total = 0;
         for (const auto &col : cols) {
-            total += col.words.capacity() * sizeof(uint64_t);
+            total += col.words.bytes();
             total += col.set_rows.capacity() * sizeof(TermIndex);
         }
         total += row_parity_.capacity() * sizeof(uint64_t);
@@ -207,15 +334,33 @@ struct InvertedIndex {
     auto tier_memory_bytes() const -> std::array<size_t, 3> {
         std::array<size_t, 3> out{0, 0, 0};
         for (const auto &col : cols) {
-            out[0] += col.words.capacity() * sizeof(uint64_t);
+            out[0] += col.words.bytes();
             out[1] += col.set_rows.capacity() * sizeof(TermIndex);
             out[2] += static_cast<size_t>(col.is_dense);
         }
         return out;
     }
-};
 
-inline constexpr size_t kColumnBlockWords = 1024; // 8 KB block ≈ L1-resident (bench knee)
+    /*! @brief What this index's pools have MAPPED, free chunks included.
+     *
+     *  memory_bytes() prices the chunks the columns hold; a pool maps whole arenas and keeps one as
+     *  long as a single chunk in it is live. Not a subset of any other field.
+     */
+    auto pool_mapped_bytes() const -> size_t { return pool_sum_(&ChunkPool::mapped_bytes); }
+    //! Of pool_mapped_bytes(): the arenas' chunks that are not currently handed out.
+    auto pool_free_chunk_bytes() const -> size_t { return pool_mapped_bytes() - pool_sum_(&ChunkPool::live_bytes); }
+
+    //! @a metric summed over the pools this index owns; an unmade size class contributes nothing.
+    auto pool_sum_(size_t (ChunkPool::*metric)() const noexcept) const -> size_t {
+        size_t total = 0;
+        for (const auto &pool : pools_) {
+            if (pool != nullptr) {
+                total += ((*pool).*metric)();
+            }
+        }
+        return total;
+    }
+};
 
 // Reusable fold blocks (thread_local: each partition master owns its copy). Two independent scratches
 // because the build scan needs the generator fold and a sparse pivot column expanded simultaneously.
@@ -254,7 +399,7 @@ template <size_t NumModes>
         }
     }
     if (dense_init < cols.size()) {
-        std::memcpy(blk, sc.dense_column_data(cols[dense_init]) + bb, nb * sizeof(uint64_t));
+        std::memcpy(blk, sc.dense_column_block(cols[dense_init], bb, be), nb * sizeof(uint64_t));
     }
     else {
         std::memset(blk, 0, nb * sizeof(uint64_t));
@@ -268,9 +413,10 @@ template <size_t NumModes>
         }
         const size_t c = cols[ci];
         if (sc.column_is_dense(c)) {
-            const uint64_t *d = sc.dense_column_data(c);
-            for (size_t wi = bb; wi < be; ++wi) {
-                blk[wi - bb] ^= d[wi];
+            // Block-local: the column is chunked, so the pointer is good for this block and no further.
+            const uint64_t *d = sc.dense_column_block(c, bb, be);
+            for (size_t wi = 0; wi < nb; ++wi) {
+                blk[wi] ^= d[wi];
             }
         }
         else {

--- a/cpp/monoprop/detail/operator/MPOperator.h
+++ b/cpp/monoprop/detail/operator/MPOperator.h
@@ -59,6 +59,21 @@ public:
     using std::runtime_error::runtime_error;
 };
 
+/*! @brief Reserve for a coefficient array that parallels the row store, on the store's own policy.
+ *
+ *  Left to itself std::vector doubles, so a coefficient array appended alongside the rows settles at up
+ *  to 8 B/term more capacity than the rows it parallels -- and never returns it mid-run, only at the
+ *  quiescence shrink_to_fit. Growing at 1.5x keeps the two in step. Capacity is unobservable, so this
+ *  is exactly a memory choice: the array stays one contiguous vector, append-only, with every fresh
+ *  slot zero-filled by the resize that follows.
+ */
+inline auto reserve_coeffs_geometric(VecD &coeffs, size_t new_size) -> void {
+    const size_t cap = coeffs.capacity();
+    if (cap < new_size) {
+        coeffs.reserve(std::max(new_size, cap + (cap / 2) + 1));
+    }
+}
+
 template <size_t NumModes>
 struct MPOperator {
     // The store is non-copyable/non-movable, so it is heap-owned by unique_ptr (keeping MPOperator
@@ -74,6 +89,10 @@ struct MPOperator {
     // The dense state: empty in Heisenberg unless a caller asks dense_state() to cache one; in Schrödinger
     // it is the live coefficient vector evolution mutates in place.
     VecD state_coeffs;
+    // Peak of (capacity - size) * 8 over the current propagate/build_graph call, sampled at the growth
+    // sites. Kept here rather than derived in estimate_memory_usage() because the peak is transient:
+    // the shrink at the end of each call erases it.
+    size_t op_coeffs_slack_hwm_{0uz};
     MonomialMap<NumModes> init_op_map{};
     VecZ initial_state;
     // Set once at propagator construction.
@@ -91,12 +110,27 @@ struct MPOperator {
           state_vals_(other.state_vals_),
           state_scored_rows_(other.state_scored_rows_),
           state_coeffs(other.state_coeffs),
+          op_coeffs_slack_hwm_(other.op_coeffs_slack_hwm_),
           init_op_map(other.init_op_map),
           initial_state(other.initial_state),
           basis(other.basis),
           inverted_index_(other.inverted_index_) {}
 
     auto size() const -> size_t { return store->size(); }
+
+    /*! @brief Records op_coeffs' current growth slack into the per-call high-water mark.
+     *
+     *  Called right after every growth, because that is the only moment the slack exists to be seen:
+     *  the array is shrunk to fit at the end of each propagate or build_graph call, so a caller reading
+     *  the ledger between calls finds nothing left of it.
+     */
+    auto observe_op_coeffs_slack() -> void {
+        op_coeffs_slack_hwm_ =
+            std::max(op_coeffs_slack_hwm_, (op_coeffs.capacity() - op_coeffs.size()) * sizeof(double));
+    }
+
+    //! Opens a new measurement window for observe_op_coeffs_slack(): one propagate or build_graph call.
+    auto reset_op_coeffs_slack_hwm() -> void { op_coeffs_slack_hwm_ = 0uz; }
 
     // Does not keep the lazy inverted index in sync: appends happen during setup, before the index is
     // first materialized, so a later append just makes inverted_index() rebuild via its staleness guard.
@@ -123,7 +157,9 @@ struct MPOperator {
             return op_coeffs;
         }
 
+        reserve_coeffs_geometric(op_coeffs, size());
         op_coeffs.resize(size(), 0.0);
+        observe_op_coeffs_slack();
 
         if (init_op_map.empty()) {
             return op_coeffs;
@@ -173,6 +209,7 @@ struct MPOperator {
             return state_coeffs;
         }
         const size_t cur_len = state_coeffs.size();
+        reserve_coeffs_geometric(state_coeffs, size());
         state_coeffs.resize(size(), 0.0);
         scatter_state_rows_from_(cur_len, state_coeffs);
         return state_coeffs;
@@ -296,7 +333,22 @@ struct MPOperatorMemoryBreakdown final {
     size_t inverted_index_dense_bytes{0uz};  // of inverted_index_bytes: full-height bitmap columns
     size_t inverted_index_sparse_bytes{0uz}; // of inverted_index_bytes: ascending set-row lists
     size_t inverted_index_dense_columns{0uz};
-    size_t operator_terms_slack_bytes{0uz}; // of operator_terms_bytes: unused geometric-growth capacity
+    size_t operator_terms_slack_bytes{0uz}; // of operator_terms_bytes: unused capacity (a chunk's tail)
+    // The row store's two tiers: how many rows are too wide for the inline slot, the inline width they
+    // are measured against, and how often the store has had to re-lay itself at a wider one. Together
+    // they say whether the width guessed from the model's cutoff held.
+    size_t row_wide_rows{0uz};
+    size_t row_inline_width{0uz};
+    size_t row_restrides{0uz};
+    // What the chunk pools have mapped, and how much of that is chunks they have not handed out. Not a
+    // subset of any field above: a pool maps whole arenas and keeps one while a single chunk is live,
+    // so these bytes are what the kernel charges even where no named field prices them.
+    size_t pool_mapped_bytes{0uz};
+    size_t pool_free_chunk_bytes{0uz};
+    // of op_coeffs_bytes: the most capacity the coefficient array held beyond its live rows at any
+    // point in the last propagate or build_graph call. A high-water mark, not a resting figure: the
+    // array is shrunk to fit at the end of every call, so measured at quiescence the slack is always 0.
+    size_t op_coeffs_slack_bytes{0uz};
     // of state_coeffs_bytes: entries of the state that are not exactly 0.0
     size_t state_coeffs_nonzero{0uz};
     // Live entries behind init_operator_bytes, which is bucket_count(): bytes with no entries are dead buckets.
@@ -320,6 +372,15 @@ struct MPOperatorMemoryBreakdown final {
         inverted_index_sparse_bytes += o.inverted_index_sparse_bytes;
         inverted_index_dense_columns += o.inverted_index_dense_columns;
         operator_terms_slack_bytes += o.operator_terms_slack_bytes;
+        row_wide_rows += o.row_wide_rows;
+        row_restrides += o.row_restrides;
+        // Every partition sizes its rows from the same cutoff, so the width is shared, not summed.
+        row_inline_width = std::max(row_inline_width, o.row_inline_width);
+        pool_mapped_bytes += o.pool_mapped_bytes;
+        pool_free_chunk_bytes += o.pool_free_chunk_bytes;
+        // Summed, not maxed, across partitions: the partitions grow together within a call, so the sum
+        // is the figure a per-process footprint wants. An upper bound, and it errs the safe way.
+        op_coeffs_slack_bytes += o.op_coeffs_slack_bytes;
         state_coeffs_nonzero += o.state_coeffs_nonzero;
         init_operator_entries += o.init_operator_entries;
         return *this;
@@ -330,6 +391,11 @@ template <size_t NumModes>
 inline auto estimate_memory_usage(const MPOperator<NumModes> &op) -> MPOperatorMemoryBreakdown<NumModes> {
     MPOperatorMemoryBreakdown<NumModes> breakdown;
     breakdown.operator_terms_bytes = op.store->memory_bytes();
+    breakdown.row_wide_rows = op.store->wide_size();
+    breakdown.row_inline_width = op.store->inline_width();
+    breakdown.row_restrides = op.store->restrides();
+    breakdown.pool_mapped_bytes = op.store->pool_mapped_bytes();
+    breakdown.pool_free_chunk_bytes = op.store->pool_free_chunk_bytes();
     breakdown.op_coeffs_bytes = op.op_coeffs.capacity() * sizeof(double);
     // Every representation of the state at once: the sparse scored set plus the dense vector.
     breakdown.state_coeffs_bytes = op.state_coeffs.capacity() * sizeof(double)
@@ -345,8 +411,11 @@ inline auto estimate_memory_usage(const MPOperator<NumModes> &op) -> MPOperatorM
         breakdown.inverted_index_dense_bytes = tiers[0];
         breakdown.inverted_index_sparse_bytes = tiers[1];
         breakdown.inverted_index_dense_columns = tiers[2];
+        breakdown.pool_mapped_bytes += op.inverted_index_->pool_mapped_bytes();
+        breakdown.pool_free_chunk_bytes += op.inverted_index_->pool_free_chunk_bytes();
     }
     breakdown.operator_terms_slack_bytes = op.store->slack_bytes();
+    breakdown.op_coeffs_slack_bytes = op.op_coeffs_slack_hwm_;
     // State phases are unit-magnitude, so at rest the scored count IS the nonzero count; a live vector needs a scan.
     breakdown.state_coeffs_nonzero =
         op.state_coeffs.empty()

--- a/cpp/monoprop/detail/operator/OperatorIndex.h
+++ b/cpp/monoprop/detail/operator/OperatorIndex.h
@@ -87,11 +87,17 @@ public:
     // cutoffs (2*cutoff <= 32 for cutoff <= 16).
     static constexpr size_t kMaxInlinePositions = 32;
     static constexpr PosT kOverflowMarker = std::numeric_limits<PosT>::max();
+    //! Header of a row held in the wide tier; its inline slots carry the tier slot instead of positions.
+    static constexpr PosT kWideMarker = static_cast<PosT>(std::numeric_limits<PosT>::max() - 1);
+    //! A wide row's slot is a uint32 written over the inline positions, so the narrow row needs 4 of them.
+    static constexpr size_t kMinInlineForWideTier = sizeof(uint32_t);
+    //! Wide rows above this share of the store and the inline width was guessed too narrow: restride.
+    static constexpr size_t kRestridePercent = 3;
 
     static_assert((2 * NumModes) - 1 <= std::numeric_limits<PosT>::max(),
                   "OperatorIndex PosT too narrow for 2*NumModes positions");
-    static_assert(kMaxInlinePositions < std::numeric_limits<PosT>::max(),
-                  "kOverflowMarker sentinel must not collide with a valid popcount");
+    static_assert(kMaxInlinePositions < std::numeric_limits<PosT>::max() - 1,
+                  "the marker sentinels must not collide with a valid popcount");
 
     // Valid term indices are < kIndexCeiling (check_append_fits refuses the append that would reach
     // it, check_index_fits the index itself), so the all-ones TermIndex is free to mark an empty slot.
@@ -107,13 +113,84 @@ public:
      *  @param forced_rows_per_chunk 0 to size the chunks from that height (production), or a fixed
      *  length: a power of two and a multiple of 64. A test knob, so chunk boundaries can be driven
      *  with a few hundred rows instead of a million.
+     *  @param wide_width the structural bound: rows over @a inline_width but no wider than this get a
+     *  fixed-stride second tier instead of the side-map. 0, or anything below @a inline_width, means
+     *  no tier.
      */
-    explicit OperatorIndex(size_t inline_width = kDefaultInlinePositions, size_t forced_rows_per_chunk = 0)
+    explicit OperatorIndex(size_t inline_width = kDefaultInlinePositions,
+                           size_t forced_rows_per_chunk = 0,
+                           size_t wide_width = 0)
         : inline_width_(std::clamp<size_t>(inline_width, 1, kMaxInlinePositions)),
           stride_(1 + inline_width_),
+          wide_width_(std::clamp<size_t>(wide_width, inline_width_, kMaxInlinePositions)),
           forced_rows_per_chunk_(forced_rows_per_chunk) {
         assert(forced_rows_per_chunk == 0
                || (std::has_single_bit(forced_rows_per_chunk) && forced_rows_per_chunk % 64 == 0));
+    }
+    //! Rows wider than the inline width but within the structural bound: the second tier's population.
+    [[nodiscard]] auto wide_size() const -> size_t { return wide_size_; }
+    [[nodiscard]] auto inline_width() const -> size_t { return inline_width_; }
+    [[nodiscard]] auto wide_width() const -> size_t { return wide_width_; }
+    //! How many times this store has re-laid its rows at a wider inline width.
+    [[nodiscard]] auto restrides() const -> size_t { return restrides_; }
+
+    /*! @brief Whether the inline width was guessed too narrow to be worth keeping.
+     *
+     *  The inline saving is paid by every row and the tier only by the rows in it, so a few per cent
+     *  of wide rows is the price of a much narrower row for the rest; past kRestridePercent it is not.
+     *  Only ever true while a tier exists, so a store restrides at most once.
+     */
+    [[nodiscard]] auto should_restride() const -> bool {
+        return wide_tier_live_() && wide_size_ * 100 > kRestridePercent * size_;
+    }
+
+    /*! @brief Widens the structural bound, so rows a raised cutoff admits get a tier, not the map.
+     *
+     *  Draining the current tier first leaves the rows laid out at the old bound and a fresh tier
+     *  spanning old bound to new, which is the shape a store built at the new cutoff would have taken.
+     *  Rows already in the side-map stay there: they are stored losslessly.
+     */
+    auto raise_bound(size_t new_wide_width) -> void {
+        if (new_wide_width <= wide_width_) {
+            return;
+        }
+        restride_to_bound();
+        wide_width_ = std::clamp<size_t>(new_wide_width, inline_width_, kMaxInlinePositions);
+    }
+
+    /*! @brief Re-lays every row at the structural bound, emptying the wide tier. Between gates only.
+     *
+     *  Only the byte layout changes: row indices, the hash index, the overflow map and every TermIndex
+     *  the rest of the engine holds are untouched, so nothing has to be rebuilt. A caller holding a
+     *  span into a row must not span this call -- restriding moves every row.
+     */
+    auto restride_to_bound() -> void {
+        if (!wide_tier_live_()) {
+            return;
+        }
+        const size_t new_stride = 1 + wide_width_;
+        auto new_pool = std::make_unique<ChunkPool>(rows_.rows_per_chunk() * new_stride * sizeof(PosT));
+        ChunkedRowArray<PosT> new_rows;
+        new_rows.attach(*new_pool, rows_.rows_per_chunk(), new_stride);
+        new_rows.grow(size_);
+        for (size_t i = 0; i < size_; ++i) {
+            PosT *const dst = new_rows.at(i);
+            const StoredRow src = stored_(rows_.at(i));
+            if (src.pos == nullptr) {
+                dst[0] = kOverflowMarker; // stays in the side-map: it is over the bound, not under it
+                continue;
+            }
+            dst[0] = static_cast<PosT>(src.count);
+            std::copy_n(src.pos, src.count, dst + 1);
+        }
+        rows_ = std::move(new_rows);
+        row_pool_ = std::move(new_pool);
+        inline_width_ = wide_width_;
+        stride_ = new_stride;
+        wide_ = {};
+        wide_pool_.reset();
+        wide_size_ = 0;
+        ++restrides_;
     }
     OperatorIndex(const OperatorIndex &) = delete;
     OperatorIndex &operator=(const OperatorIndex &) = delete;
@@ -122,7 +199,13 @@ public:
 
     // Called only on an idle store, so it needs no synchronization.
     [[nodiscard]] auto clone() const -> std::unique_ptr<OperatorIndex> {
-        auto out = std::make_unique<OperatorIndex>(inline_width_, forced_rows_per_chunk_);
+        auto out = std::make_unique<OperatorIndex>(inline_width_, forced_rows_per_chunk_, wide_width_);
+        if (wide_.attached()) {
+            out->attach_wide_();
+            out->wide_ = wide_.clone_into(*out->wide_pool_);
+            out->wide_size_ = wide_size_;
+        }
+        out->restrides_ = restrides_;
         if (rows_.attached()) {
             // The clone takes this store's settled length, not one re-derived from its size: the two
             // must agree row for row, and attach_(0) would round a small store down differently.
@@ -175,8 +258,16 @@ public:
         const size_t c = mono.count();
         PosT *row = rows_.at(i);
         if (c > inline_width_) {
-            row[0] = kOverflowMarker;
-            overflow_[i] = mono;
+            PosT *const wide = spill_(row, c);
+            if (wide == nullptr) {
+                overflow_[i] = mono;
+                return;
+            }
+            PosT *w = wide + 1;
+            for (size_t b = mono.find_first(); b < mono.size(); b = mono.find_next(b)) {
+                *w++ = static_cast<PosT>(b);
+            }
+            drop_stale_overflow_(i);
             return;
         }
         drop_stale_overflow_(i);
@@ -197,8 +288,13 @@ public:
         assert((count == 0 || static_cast<size_t>(pos[count - 1]) < 2 * NumModes) && "row position out of range");
         PosT *row = rows_.at(i);
         if (count > inline_width_) {
-            // The spill path has no position array, so build the dense form -- only here.
-            row[0] = kOverflowMarker;
+            if (PosT *const wide = spill_(row, count); wide != nullptr) {
+                std::copy_n(pos.data(), count, wide + 1);
+                drop_stale_overflow_(i);
+                return;
+            }
+            // Over the structural bound, so the side-map takes it. Only this path has no position
+            // array to hand it, so it is the one place that builds the dense form.
             value_type mono;
             for (size_t j = 0; j < count; ++j) {
                 mono.set(pos[j]);
@@ -254,7 +350,7 @@ public:
         return {std::span<const PosT>(r.pos, r.count)};
     }
     [[nodiscard]] auto memory_bytes() const -> size_t {
-        size_t total = rows_.bytes();
+        size_t total = rows_.bytes() + wide_.bytes();
         total += overflow_.size() * (sizeof(value_type) + sizeof(size_t) + 24);
         return total;
     }
@@ -436,12 +532,10 @@ public:
      *  long as a single chunk in it is live, so the two differ by whatever a partly used arena has not
      *  handed out. Not a subset of any other field.
      */
-    [[nodiscard]] auto pool_mapped_bytes() const -> size_t {
-        return row_pool_ == nullptr ? 0 : row_pool_->mapped_bytes();
-    }
+    [[nodiscard]] auto pool_mapped_bytes() const -> size_t { return pool_sum_(&ChunkPool::mapped_bytes); }
     //! Of pool_mapped_bytes(): the arenas' chunks that are not currently handed out.
     [[nodiscard]] auto pool_free_chunk_bytes() const -> size_t {
-        return row_pool_ == nullptr ? 0 : row_pool_->mapped_bytes() - row_pool_->live_bytes();
+        return pool_mapped_bytes() - pool_sum_(&ChunkPool::live_bytes);
     }
 
     auto index_estimated_memory_bytes() const -> size_t {
@@ -449,10 +543,23 @@ public:
     }
 
 private:
-    /*! @brief A row's stored positions. @a pos == nullptr means the row spilled to the side-map.
+    //! @a metric summed over the pools this store owns; an unmade pool contributes nothing.
+    [[nodiscard]] auto pool_sum_(size_t (ChunkPool::*metric)() const noexcept) const -> size_t {
+        size_t total = 0;
+        for (const ChunkPool *pool : {row_pool_.get(), wide_pool_.get()}) {
+            if (pool != nullptr) {
+                total += (pool->*metric)();
+            }
+        }
+        return total;
+    }
+
+    /*! @brief A row's stored positions, whichever tier holds them.
      *
      *  One unsigned compare carries the common case: a header at or below the inline width is the
-     *  row's own popcount and its positions follow it. The sentinel is above kMaxInlinePositions.
+     *  row's own popcount and its positions follow it. Both sentinels are above kMaxInlinePositions,
+     *  so the branch is never a table lookup. @a pos == nullptr means the row is over the structural
+     *  bound and lives in the side-map.
      */
     struct StoredRow {
         const PosT *pos;
@@ -463,7 +570,48 @@ private:
         if (c <= inline_width_) [[likely]] {
             return {src + 1, c};
         }
+        if (c == kWideMarker) {
+            const PosT *const w = wide_.at(wide_slot_(src));
+            return {w + 1, static_cast<size_t>(w[0])};
+        }
         return {nullptr, 0};
+    }
+    //! A wide row's tier slot, written unaligned over the narrow row's inline positions.
+    [[nodiscard]] static auto wide_slot_(const PosT *src) noexcept -> size_t {
+        uint32_t slot = 0;
+        std::memcpy(&slot, src + 1, sizeof(slot));
+        return slot;
+    }
+    //! The tier is worth having only while it is narrower than the bound and the slot fits inline.
+    [[nodiscard]] auto wide_tier_live_() const noexcept -> bool {
+        return wide_width_ > inline_width_ && inline_width_ >= kMinInlineForWideTier;
+    }
+    auto attach_wide_() -> void {
+        if (!wide_.attached()) {
+            wide_pool_ = std::make_unique<ChunkPool>(kWideRowsPerChunk * (1 + wide_width_) * sizeof(PosT));
+            wide_.attach(*wide_pool_, kWideRowsPerChunk, 1 + wide_width_);
+        }
+    }
+
+    /*! @brief Marks @a row as wide and returns its tier row, or nullptr if it belongs in the side-map.
+     *
+     *  Slots are appended, never reclaimed: a row is written once in every engine path, and a store
+     *  whose tier grows past kRestridePercent is re-laid wide anyway, which frees the tier entirely.
+     */
+    auto spill_(PosT *row, size_t count) -> PosT * {
+        if (count > wide_width_ || !wide_tier_live_()) {
+            row[0] = kOverflowMarker;
+            return nullptr;
+        }
+        attach_wide_();
+        const auto slot = static_cast<uint32_t>(wide_.size());
+        wide_.grow(wide_.size() + 1);
+        ++wide_size_;
+        row[0] = kWideMarker;
+        std::memcpy(row + 1, &slot, sizeof(slot));
+        PosT *const out = wide_.at(slot);
+        out[0] = static_cast<PosT>(count);
+        return out;
     }
 
     //! Drops a side-map entry left by a previous value at @a i; the map is empty on every hot path.
@@ -688,12 +836,23 @@ private:
     // outlives the store whose chunks it owns.
     size_t inline_width_ = kMaxInlinePositions;
     size_t stride_ = 1 + kMaxInlinePositions;
-    size_t forced_rows_per_chunk_ = 0; //!< 0 == size the chunks from the first height asked for
+    size_t wide_width_ = kMaxInlinePositions; //!< the structural bound: the second tier's fixed width
+    size_t forced_rows_per_chunk_ = 0;        //!< 0 == size the chunks from the first height asked for
     std::unique_ptr<ChunkPool> row_pool_;
+    std::unique_ptr<ChunkPool> wide_pool_;
 
     ChunkedRowArray<PosT> rows_ = {};
     size_t size_ = 0;
-    // Lossless side-map for rows whose popcount exceeds inline_width_.
+    /*! @brief Rows wider than the inline width but no wider than the structural bound, at a fixed
+     *  stride of 1 + wide_width_. A few thousand rows per chunk: the tier is a few per cent of the
+     *  store by construction, and past kRestridePercent the store re-lays itself and drops it.
+     */
+    ChunkedRowArray<PosT> wide_ = {};
+    static constexpr size_t kWideRowsPerChunk = size_t{1} << 12;
+    size_t wide_size_ = 0;
+    size_t restrides_ = 0;
+    // Lossless side-map for rows over the structural bound: impossible while the cutoff holds, and
+    // kept so that a raised one is still stored losslessly until the next restride.
     std::unordered_map<size_t, value_type> overflow_ = {};
     Table table_ = {};
 };

--- a/cpp/monoprop/detail/operator/OperatorIndex.h
+++ b/cpp/monoprop/detail/operator/OperatorIndex.h
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <format>
 #include <limits>
 #include <memory>
@@ -32,6 +33,7 @@
 
 #include "monoprop/TypeAliases.h"
 #include "monoprop/core/Monomial.h"
+#include "monoprop/detail/operator/ChunkedArray.h"
 
 namespace monoprop::detail {
 
@@ -40,11 +42,16 @@ public:
     using std::runtime_error::runtime_error;
 };
 
-// Operator-term store: entropy-packed position-list rows plus a keyless open-addressing hash index over
-// those rows. Row layout: slot 0 = popcount c (or kOverflowMarker if c > inline_width_), slots 1..c =
-// ascending set-bit positions; stride_ is fixed for the container's life so row offsets stay stable.
-// inline_width_ is a free parameter -- any width is correct, over-long rows spill losslessly to overflow.
-// Single-writer: one partition, one thread; parallelism is cross-partition.
+/*! @brief Operator-term store: entropy-packed position-list rows in pooled chunks, plus a keyless
+ *  open-addressing hash index over those rows.
+ *
+ *  Row layout: slot 0 = popcount c (or kOverflowMarker if c > inline_width_), slots 1..c = ascending
+ *  set-bit positions. inline_width_ is a free parameter -- any width is correct, over-long rows spill
+ *  losslessly to overflow. Rows live in ChunkedRowArray chunks, so growth appends a chunk and never
+ *  moves a row; row indices are handed out consecutively by grow_rows_geometric and never change.
+ *
+ *  Single-writer: one partition, one thread; parallelism is cross-partition.
+ */
 template <size_t NumModes>
 class OperatorIndex {
 public:
@@ -56,6 +63,26 @@ public:
         conditional_t<(2 * NumModes <= 256), uint8_t, std::conditional_t<(2 * NumModes <= 65536), uint16_t, uint32_t>>;
 
     static constexpr size_t kDefaultInlinePositions = 11;
+    /*! @brief Rows per chunk of the row store, chosen from the height the store is built at.
+     *
+     *  Both bounds are powers of two and multiples of 64, so every chunk length is: the 64 rows an
+     *  inverted-index word names always sit in one chunk. A row never straddles a chunk either, so a
+     *  span over one row stays contiguous.
+     */
+    static constexpr size_t kMinRowsPerChunk = size_t{1} << 12;
+    static constexpr size_t kMaxRowsPerChunk = size_t{1} << 18;
+
+    /*! @brief The chunk length for a store of @a rows rows: a quarter of it, rounded down to a power
+     *  of two and clamped to [kMinRowsPerChunk, kMaxRowsPerChunk].
+     *
+     *  The store overshoots by at most one chunk, so a quarter bounds its slack under a quarter of
+     *  itself once it clears four minimum chunks, and under one 4096-row chunk below that. Rounding
+     *  down costs only chunk count, which is pooled. It reaches kMaxRowsPerChunk at 1M rows and stops,
+     *  so the tail is never more than 2^18 rows however large the operator grows.
+     */
+    static auto chunk_rows_for_rows(size_t rows) noexcept -> size_t {
+        return std::clamp(std::bit_floor(std::max(rows / 4, size_t{1})), kMinRowsPerChunk, kMaxRowsPerChunk);
+    }
     // A weight-w Pauli needs 2w positions; 32 covers the common case inline at the supported Pauli
     // cutoffs (2*cutoff <= 32 for cutoff <= 16).
     static constexpr size_t kMaxInlinePositions = 32;
@@ -74,9 +101,20 @@ public:
     // operator store must not depend on evolution headers).
     static constexpr size_t kNotFound = std::numeric_limits<size_t>::max();
 
-    explicit OperatorIndex(size_t inline_width = kDefaultInlinePositions)
+    /*! @brief An empty store. Its chunk length is settled by the first reserve() or growth, from the
+     *  height asked for there, and rises with the store thereafter.
+     *
+     *  @param forced_rows_per_chunk 0 to size the chunks from that height (production), or a fixed
+     *  length: a power of two and a multiple of 64. A test knob, so chunk boundaries can be driven
+     *  with a few hundred rows instead of a million.
+     */
+    explicit OperatorIndex(size_t inline_width = kDefaultInlinePositions, size_t forced_rows_per_chunk = 0)
         : inline_width_(std::clamp<size_t>(inline_width, 1, kMaxInlinePositions)),
-          stride_(1 + inline_width_) {}
+          stride_(1 + inline_width_),
+          forced_rows_per_chunk_(forced_rows_per_chunk) {
+        assert(forced_rows_per_chunk == 0
+               || (std::has_single_bit(forced_rows_per_chunk) && forced_rows_per_chunk % 64 == 0));
+    }
     OperatorIndex(const OperatorIndex &) = delete;
     OperatorIndex &operator=(const OperatorIndex &) = delete;
     OperatorIndex(OperatorIndex &&) = delete;
@@ -84,8 +122,13 @@ public:
 
     // Called only on an idle store, so it needs no synchronization.
     [[nodiscard]] auto clone() const -> std::unique_ptr<OperatorIndex> {
-        auto out = std::make_unique<OperatorIndex>(inline_width_);
-        out->rows_ = rows_;
+        auto out = std::make_unique<OperatorIndex>(inline_width_, forced_rows_per_chunk_);
+        if (rows_.attached()) {
+            // The clone takes this store's settled length, not one re-derived from its size: the two
+            // must agree row for row, and attach_(0) would round a small store down differently.
+            out->attach_(rows_.rows_per_chunk());
+            out->rows_ = rows_.clone_into(*out->row_pool_); // a deep copy; the two share no chunk
+        }
         out->size_ = size_;
         out->overflow_ = overflow_;
         out->reserve_index(table_.count);
@@ -106,18 +149,20 @@ public:
         reserve_rows(n);
         reserve_index(n);
     }
-    // Returns the pre-growth size (the caller's insert base). Growth is geometric (1.5×), never
-    // exact-fit: an exact fit would realloc the whole operator every layer.
+    /*! @brief Grows by @a n rows and returns the pre-growth size, the caller's insert base.
+     *
+     *  Indices are consecutive from that base and are never reassigned: the store appends whole chunks
+     *  and never moves a row, so there is no reallocation to amortise and the only slack is one
+     *  chunk's tail. Refused at the TermIndex ceiling before anything grows.
+     *
+     *  Freshly grown rows are default-initialized, not zeroed: every one is overwritten by its set()
+     *  before any read.
+     */
     auto grow_rows_geometric(size_t n) -> size_t {
         const size_t base = size_;
         check_append_fits(base, n);
-        if (capacity() < base + n) {
-            const size_t cap = capacity();
-            reserve_rows(std::max(base + n, cap + (cap / 2) + 1));
-        }
-        // Default-init grow, not a zeroing resize: every freshly grown row is overwritten by set()
-        // before any read, so a tail zero-fill would be wasted bandwidth.
-        rows_.resize((base + n) * stride_);
+        ensure_capacity_(base + n);
+        rows_.grow(base + n);
         size_ = base + n;
         return base;
     }
@@ -128,15 +173,13 @@ public:
     // (freshly grown headers are indeterminate); a stale overflow entry at i, if any, is dropped.
     auto set(size_t i, const value_type &mono) -> void {
         const size_t c = mono.count();
-        PosT *row = &rows_[i * stride_];
+        PosT *row = rows_.at(i);
         if (c > inline_width_) {
             row[0] = kOverflowMarker;
             overflow_[i] = mono;
             return;
         }
-        if (!overflow_.empty()) {
-            overflow_.erase(i);
-        }
+        drop_stale_overflow_(i);
         row[0] = static_cast<PosT>(c);
         PosT *out = row + 1;
         for (size_t b = mono.find_first(); b < mono.size(); b = mono.find_next(b)) {
@@ -152,7 +195,7 @@ public:
     auto set_positions(size_t i, std::span<const PosT> pos) -> void {
         const size_t count = pos.size();
         assert((count == 0 || static_cast<size_t>(pos[count - 1]) < 2 * NumModes) && "row position out of range");
-        PosT *row = &rows_[i * stride_];
+        PosT *row = rows_.at(i);
         if (count > inline_width_) {
             // The spill path has no position array, so build the dense form -- only here.
             row[0] = kOverflowMarker;
@@ -163,45 +206,39 @@ public:
             overflow_[i] = mono;
             return;
         }
-        if (!overflow_.empty()) {
-            overflow_.erase(i);
-        }
+        drop_stale_overflow_(i);
         row[0] = static_cast<PosT>(count);
         std::copy_n(pos.data(), count, row + 1);
     }
 
     [[nodiscard]] auto row(size_t i) const -> value_type {
-        const PosT c = rows_[i * stride_];
-        if (c == kOverflowMarker) {
+        const StoredRow r = stored_(rows_.at(i));
+        if (r.pos == nullptr) {
             return overflow_.at(i);
         }
         value_type mono;
-        const PosT *pos = &rows_[(i * stride_) + 1];
-        for (size_t j = 0; j < c; ++j) {
-            mono.set(pos[j]);
+        for (size_t j = 0; j < r.count; ++j) {
+            mono.set(r.pos[j]);
         }
         return mono;
     }
     template <typename Fn>
     auto for_each_position(size_t i, Fn &&fn) const -> void {
-        const PosT c = rows_[i * stride_];
-        if (c == kOverflowMarker) {
+        const StoredRow r = stored_(rows_.at(i));
+        if (r.pos == nullptr) {
             const auto &m = overflow_.at(i);
             for (size_t b = m.find_first(); b < m.size(); b = m.find_next(b)) {
                 fn(b);
             }
             return;
         }
-        const PosT *pos = &rows_[(i * stride_) + 1];
-        for (size_t j = 0; j < c; ++j) {
-            fn(static_cast<size_t>(pos[j]));
+        for (size_t j = 0; j < r.count; ++j) {
+            fn(static_cast<size_t>(r.pos[j]));
         }
     }
     [[nodiscard]] auto popcount(size_t i) const -> size_t {
-        if (const PosT c = rows_[i * stride_]; c != kOverflowMarker) {
-            return c;
-        }
-        return overflow_.at(i).count();
+        const StoredRow r = stored_(rows_.at(i));
+        return r.pos == nullptr ? overflow_.at(i).count() : r.count;
     }
     /*! @brief The row's stored ascending positions, empty for a spilled row. Invalidated by any insert. */
     struct RowPositions {
@@ -210,14 +247,14 @@ public:
         [[nodiscard]] auto inlined() const -> bool { return pos.data() != nullptr; }
     };
     [[nodiscard]] auto row_positions(size_t i) const -> RowPositions {
-        const PosT c = rows_[i * stride_];
-        if (c == kOverflowMarker) {
+        const StoredRow r = stored_(rows_.at(i));
+        if (r.pos == nullptr) {
             return {};
         }
-        return {std::span<const PosT>(&rows_[(i * stride_) + 1], static_cast<size_t>(c))};
+        return {std::span<const PosT>(r.pos, r.count)};
     }
     [[nodiscard]] auto memory_bytes() const -> size_t {
-        size_t total = rows_.capacity() * sizeof(PosT);
+        size_t total = rows_.bytes();
         total += overflow_.size() * (sizeof(value_type) + sizeof(size_t) + 24);
         return total;
     }
@@ -261,7 +298,7 @@ public:
                 }
                 cand[j] = probe_hash_match_(hh[j], sp[j] & table_.mask);
                 if (cand[j] != kEmptySlot) {
-                    __builtin_prefetch(&rows_[static_cast<size_t>(cand[j]) * stride_], 0, 0);
+                    __builtin_prefetch(rows_.at(static_cast<size_t>(cand[j])), 0, 0);
                 }
             }
             for (size_t j = 0; j < g; ++j) {
@@ -308,7 +345,7 @@ public:
                 }
                 cand[j] = probe_hash_match_(hh[j], sp[j] & table_.mask);
                 if (cand[j] != kEmptySlot) {
-                    __builtin_prefetch(&rows_[static_cast<size_t>(cand[j]) * stride_], 0, 0);
+                    __builtin_prefetch(rows_.at(static_cast<size_t>(cand[j])), 0, 0);
                 }
             }
             for (size_t j = 0; j < g; ++j) {
@@ -390,9 +427,21 @@ public:
             }
         }
     }
-    // Diagnostic: the part of memory_bytes() that is unused geometric-growth capacity.
-    [[nodiscard]] auto slack_bytes() const -> size_t {
-        return (rows_.capacity() * sizeof(PosT)) - (std::min(rows_.capacity(), size_ * stride_) * sizeof(PosT));
+    // Diagnostic: the part of memory_bytes() that is unused capacity -- the tail of the last chunk.
+    [[nodiscard]] auto slack_bytes() const -> size_t { return rows_.slack_bytes(); }
+
+    /*! @brief What this store's pool has MAPPED, free chunks included.
+     *
+     *  memory_bytes() prices the chunks the array holds; a pool maps whole arenas and keeps one as
+     *  long as a single chunk in it is live, so the two differ by whatever a partly used arena has not
+     *  handed out. Not a subset of any other field.
+     */
+    [[nodiscard]] auto pool_mapped_bytes() const -> size_t {
+        return row_pool_ == nullptr ? 0 : row_pool_->mapped_bytes();
+    }
+    //! Of pool_mapped_bytes(): the arenas' chunks that are not currently handed out.
+    [[nodiscard]] auto pool_free_chunk_bytes() const -> size_t {
+        return row_pool_ == nullptr ? 0 : row_pool_->mapped_bytes() - row_pool_->live_bytes();
     }
 
     auto index_estimated_memory_bytes() const -> size_t {
@@ -400,6 +449,30 @@ public:
     }
 
 private:
+    /*! @brief A row's stored positions. @a pos == nullptr means the row spilled to the side-map.
+     *
+     *  One unsigned compare carries the common case: a header at or below the inline width is the
+     *  row's own popcount and its positions follow it. The sentinel is above kMaxInlinePositions.
+     */
+    struct StoredRow {
+        const PosT *pos;
+        size_t count;
+    };
+    [[nodiscard]] auto stored_(const PosT *src) const noexcept -> StoredRow {
+        const size_t c = src[0];
+        if (c <= inline_width_) [[likely]] {
+            return {src + 1, c};
+        }
+        return {nullptr, 0};
+    }
+
+    //! Drops a side-map entry left by a previous value at @a i; the map is empty on every hot path.
+    auto drop_stale_overflow_(size_t i) -> void {
+        if (!overflow_.empty()) {
+            overflow_.erase(i);
+        }
+    }
+
     struct Slot {
         TermIndex idx = kEmptySlot;
         uint32_t h = 0;
@@ -474,8 +547,59 @@ private:
     // Slot count for `n` entries at ≤0.7 load.
     static auto slots_for_(size_t n) -> size_t { return std::bit_ceil(std::max<size_t>(kMinSlots, (n * 10 / 7) + 1)); }
 
-    [[nodiscard]] auto capacity() const -> size_t { return rows_.capacity() / stride_; }
-    auto reserve_rows(size_t n) -> void { rows_.reserve(n * stride_); }
+    [[nodiscard]] auto capacity() const -> size_t { return rows_.capacity(); }
+    auto reserve_rows(size_t n) -> void {
+        ensure_capacity_(n);
+        rows_.reserve(n);
+    }
+
+    /*! @brief Makes the pool and binds the row array at @a rows_per_chunk. @pre Not yet attached. */
+    auto attach_(size_t rows_per_chunk) -> void {
+        assert(!rows_.attached() && "attach_ binds an unbound store");
+        row_pool_ = std::make_unique<ChunkPool>(rows_per_chunk * stride_ * sizeof(PosT));
+        rows_.attach(*row_pool_, rows_per_chunk, stride_);
+    }
+
+    /*! @brief Re-lays the live rows into chunks of @a new_rows_per_chunk and drops the old pool.
+     *
+     *  Only the chunk geometry moves: row indices and the overflow map are untouched, so every
+     *  TermIndex the rest of the engine holds stays valid. @a new_rows_per_chunk is a multiple of the
+     *  current length (both are powers of two and it only ever grows), so one old chunk lands whole
+     *  inside one new chunk and each move is a single memcpy.
+     */
+    auto rechunk_(size_t new_rows_per_chunk) -> void {
+        const size_t old_rows_per_chunk = rows_.rows_per_chunk();
+        assert(new_rows_per_chunk > old_rows_per_chunk && new_rows_per_chunk % old_rows_per_chunk == 0);
+        auto new_pool = std::make_unique<ChunkPool>(new_rows_per_chunk * stride_ * sizeof(PosT));
+        ChunkedRowArray<PosT> new_rows;
+        new_rows.attach(*new_pool, new_rows_per_chunk, stride_);
+        new_rows.grow(size_);
+        for (size_t first = 0; first < size_; first += old_rows_per_chunk) {
+            const size_t n = std::min(old_rows_per_chunk, size_ - first);
+            std::memcpy(new_rows.at(first), rows_.at(first), n * stride_ * sizeof(PosT));
+        }
+        // The array releases its chunks to its own pool before that pool is replaced.
+        rows_ = std::move(new_rows);
+        row_pool_ = std::move(new_pool);
+    }
+
+    /*! @brief Keeps the chunk length in step with the height the store is heading for.
+     *
+     *  The store cannot be told its final height -- the propagator reserves the *initial* operator's
+     *  size, a handful of terms even for a run that ends at millions -- so the length is re-derived on
+     *  every growth. It only ever rises and stops at kMaxRowsPerChunk, so a store crossing 2^20 rows
+     *  migrates six times, while one that stays small keeps chunks proportional to it. A forced length
+     *  never moves.
+     */
+    auto ensure_capacity_(size_t rows) -> void {
+        const size_t want = forced_rows_per_chunk_ != 0 ? forced_rows_per_chunk_ : chunk_rows_for_rows(rows);
+        if (!rows_.attached()) {
+            attach_(want);
+        }
+        else if (want > rows_.rows_per_chunk()) {
+            rechunk_(want);
+        }
+    }
     auto reserve_index(size_t n) -> void { table_.rehash_to(slots_for_(n + 1)); }
 
     // Insert (idx, h) into the table with no duplicate probe — callers on this path insert provably distinct
@@ -493,16 +617,15 @@ private:
     // Compare row i against key q without materializing the row (the find confirm). Reads the
     // popcount byte first, so a false h prefilter match usually costs one byte compare.
     [[nodiscard]] auto row_eq_key(size_t i, const key_type &q) const -> bool {
-        const PosT c = rows_[i * stride_];
-        if (c == kOverflowMarker) {
+        const StoredRow r = stored_(rows_.at(i));
+        if (r.pos == nullptr) [[unlikely]] {
             return overflow_.at(i) == q;
         }
-        if (q.count() != static_cast<size_t>(c)) {
+        if (q.count() != r.count) {
             return false;
         }
-        const PosT *pos = &rows_[(i * stride_) + 1];
-        for (size_t j = 0; j < c; ++j) {
-            if (!q.test(pos[j])) {
+        for (size_t j = 0; j < r.count; ++j) {
+            if (!q.test(r.pos[j])) {
                 return false;
             }
         }
@@ -511,18 +634,18 @@ private:
 
     // Compare row i against an ascending position list; a spilled row falls back to a dense compare.
     [[nodiscard]] auto row_eq_positions(size_t i, std::span<const PosT> q) const -> bool {
-        const PosT c = rows_[i * stride_];
-        if (c == kOverflowMarker) {
+        const StoredRow r = stored_(rows_.at(i));
+        if (r.pos == nullptr) [[unlikely]] {
             key_type mono;
             for (size_t j = 0; j < q.size(); ++j) {
                 mono.set(q[j]);
             }
             return overflow_.at(i) == mono;
         }
-        if (q.size() != static_cast<size_t>(c)) {
+        if (q.size() != r.count) {
             return false;
         }
-        return std::equal(q.begin(), q.end(), &rows_[(i * stride_) + 1]);
+        return std::equal(q.begin(), q.end(), r.pos);
     }
 
     // find()'s chain walk for a position-list key, hash already folded; only the collision arm reaches it.
@@ -561,10 +684,15 @@ private:
         }
     }
 
-    DefaultInitVector<PosT> rows_ = {};
-    size_t size_ = 0;
+    // Declared before the array: members are destroyed in reverse declaration order, so the pool
+    // outlives the store whose chunks it owns.
     size_t inline_width_ = kMaxInlinePositions;
     size_t stride_ = 1 + kMaxInlinePositions;
+    size_t forced_rows_per_chunk_ = 0; //!< 0 == size the chunks from the first height asked for
+    std::unique_ptr<ChunkPool> row_pool_;
+
+    ChunkedRowArray<PosT> rows_ = {};
+    size_t size_ = 0;
     // Lossless side-map for rows whose popcount exceeds inline_width_.
     std::unordered_map<size_t, value_type> overflow_ = {};
     Table table_ = {};

--- a/cpp/tests/README.md
+++ b/cpp/tests/README.md
@@ -91,10 +91,18 @@ name and cannot address suite-nested cases, tests use flat
   scan routing agreement), `evolution_detail_tests.cpp` (MatchedEpochSet +
   CutoffContext),
   `row_accessor_tests.cpp` (dense vs OperatorIndex row accessors).
-- **Operator store**: `operator_index_tests.cpp`, `inverted_index_tests.cpp`,
-  `mp_operator_tests.cpp` (MPOperator get_state Pauli/Majorana scoring,
+- **Operator store**: `chunked_array_tests.cpp` (the pooled chunk allocator and
+  the chunked arrays on it: arena reuse, unmapping read from
+  `/proc/self/maps`, chunk alignment, indexing and cloning across boundaries),
+  `operator_index_tests.cpp` (row round-trip and the hash index, plus the
+  chunked storage: reads and finds across chunk boundaries, the chunk length
+  selected from the row count, the wide tier vs the side-map, and an
+  index-preserving restride), `inverted_index_tests.cpp` (the two column tiers
+  and the blocked fold, including that a fold is bit-identical across chunk
+  sizes), `mp_operator_tests.cpp` (MPOperator get_state Pauli/Majorana scoring,
   get_operator init-map drain, update_initial_operator picture branches,
-  insert_absent_terms, inverted-index sync, memory estimate, deep copy),
+  insert_absent_terms, inverted-index sync, coefficient growth policy, memory
+  estimate and its row-tier and pool fields, deep copy),
   `bulk_insert_tests.cpp` (the grouped-prefetch insert vs a one-key-at-a-time
   reference: table state and enumeration order).
 - **Layer build / evolution**: `build_graph_tests.cpp`,

--- a/cpp/tests/chunked_array_tests.cpp
+++ b/cpp/tests/chunked_array_tests.cpp
@@ -1,0 +1,306 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <utility>
+#include <vector>
+
+#include "monoprop/detail/operator/ChunkedArray.h"
+
+// The pooled chunk allocator and the chunked array built on it: that an arena is carved, reused and
+// given back to the OS when it empties, that chunks land on the alignment the pool advertises, and
+// that indexing, growth and cloning behave across chunk boundaries.
+
+using monoprop::detail::ChunkedArray;
+using monoprop::detail::ChunkPool;
+
+namespace {
+
+// Small arenas keep the tests cheap and make "one more chunk needs another arena" reachable in a few
+// allocations. 4096 is the page size the pool rounds to anyway, so nothing is rounded away here.
+constexpr size_t kChunkBytes = 4096;
+constexpr size_t kChunksPerArena = 4;
+constexpr size_t kArenaBytes = kChunkBytes * kChunksPerArena;
+
+// Whether `addr` falls inside any mapping of this process, read straight from /proc/self/maps. This is
+// what distinguishes "the pool stopped counting the arena" from "the pool actually unmapped it".
+auto address_is_mapped(const void *addr) -> bool {
+    const auto target = reinterpret_cast<uintptr_t>(addr);
+    std::FILE *maps = std::fopen("/proc/self/maps", "re");
+    if (maps == nullptr) {
+        return false;
+    }
+    char line[512];
+    bool found = false;
+    while (!found && std::fgets(line, sizeof(line), maps) != nullptr) {
+        unsigned long long lo = 0;
+        unsigned long long hi = 0;
+        if (std::sscanf(line, "%llx-%llx", &lo, &hi) == 2) {
+            found = target >= lo && target < hi;
+        }
+    }
+    std::fclose(maps);
+    return found;
+}
+
+} // namespace
+
+// The pool rounds the requested chunk size up to whole pages and then tiles an arena with an exact
+// number of them, so no arena byte is unreachable and no chunk straddles two arenas.
+BOOST_AUTO_TEST_CASE(chunk_pool_tiles_its_arena_with_page_rounded_chunks) {
+    ChunkPool pool(kChunkBytes - 1, kArenaBytes);
+    BOOST_CHECK_EQUAL(pool.chunk_bytes(), kChunkBytes);
+    BOOST_CHECK_EQUAL(pool.chunks_per_arena(), kChunksPerArena);
+    BOOST_CHECK_EQUAL(pool.arena_bytes(), pool.chunk_bytes() * pool.chunks_per_arena());
+    BOOST_CHECK_EQUAL(pool.arena_count(), 0U); // nothing is mapped before the first allocation
+    BOOST_CHECK_EQUAL(pool.mapped_bytes(), 0U);
+
+    // A big chunk is rounded to a page and no further, so a chunk that is not a multiple of a huge
+    // page advertises only the alignment it does have.
+    ChunkPool over(ChunkPool::kHugePageBytes + 1, 8 * ChunkPool::kHugePageBytes);
+    BOOST_CHECK_EQUAL(over.chunk_bytes(), ChunkPool::kHugePageBytes + kChunkBytes);
+    BOOST_CHECK_EQUAL(over.chunk_alignment(), kChunkBytes);
+
+    // One that IS a multiple of a huge page still lands on one, because the arena does.
+    ChunkPool huge(2 * ChunkPool::kHugePageBytes, 8 * ChunkPool::kHugePageBytes);
+    BOOST_CHECK_EQUAL(huge.chunk_bytes(), 2 * ChunkPool::kHugePageBytes);
+    BOOST_CHECK_EQUAL(huge.chunk_alignment(), ChunkPool::kHugePageBytes);
+}
+
+// Every chunk sits on the alignment the pool advertises: arenas start on a 2 MiB boundary and the
+// chunks tile them, so transparent huge pages can back the big ones.
+BOOST_AUTO_TEST_CASE(chunk_pool_hands_out_chunks_on_its_advertised_alignment) {
+    ChunkPool pool(kChunkBytes, kArenaBytes);
+    std::vector<void *> chunks;
+    for (size_t i = 0; i < 2 * kChunksPerArena; ++i) {
+        chunks.push_back(pool.allocate());
+        BOOST_REQUIRE(chunks.back() != nullptr);
+        BOOST_CHECK_EQUAL(reinterpret_cast<uintptr_t>(chunks.back()) % pool.chunk_alignment(), 0U);
+    }
+    BOOST_CHECK_EQUAL(pool.arena_count(), 2U);
+    // The arena itself is huge-page-aligned even when the chunks are only page-aligned.
+    BOOST_CHECK_EQUAL(reinterpret_cast<uintptr_t>(chunks.front()) % ChunkPool::kHugePageBytes, 0U);
+    for (void *chunk : chunks) {
+        pool.deallocate(chunk);
+    }
+
+    ChunkPool huge(ChunkPool::kHugePageBytes, 4 * ChunkPool::kHugePageBytes);
+    void *big = huge.allocate();
+    BOOST_CHECK_EQUAL(reinterpret_cast<uintptr_t>(big) % ChunkPool::kHugePageBytes, 0U);
+    huge.deallocate(big);
+}
+
+// A returned chunk is handed out again before a new arena is mapped, so a store that shrinks and
+// regrows -- as the index does on every rebuild -- costs no new mappings.
+BOOST_AUTO_TEST_CASE(chunk_pool_reuses_a_freed_chunk_before_mapping_another_arena) {
+    ChunkPool pool(kChunkBytes, kArenaBytes);
+    std::vector<void *> chunks;
+    for (size_t i = 0; i < kChunksPerArena; ++i) {
+        chunks.push_back(pool.allocate());
+    }
+    BOOST_REQUIRE_EQUAL(pool.arena_count(), 1U);
+    BOOST_CHECK_EQUAL(pool.live_chunks(), kChunksPerArena);
+
+    void *const returned = chunks[1];
+    pool.deallocate(returned);
+    BOOST_CHECK_EQUAL(pool.live_chunks(), kChunksPerArena - 1);
+    BOOST_CHECK_EQUAL(pool.arena_count(), 1U); // the arena still holds three live chunks
+
+    void *const again = pool.allocate();
+    BOOST_CHECK_EQUAL(again, returned);
+    BOOST_CHECK_EQUAL(pool.arena_count(), 1U);
+    chunks[1] = again;
+
+    // One chunk past the arena's capacity, and only then does a second arena appear.
+    chunks.push_back(pool.allocate());
+    BOOST_CHECK_EQUAL(pool.arena_count(), 2U);
+    for (void *chunk : chunks) {
+        pool.deallocate(chunk);
+    }
+    BOOST_CHECK_EQUAL(pool.arena_count(), 0U);
+}
+
+// The arena goes back to the OS the moment its last chunk returns -- not to a free list the process
+// keeps. /proc/self/maps is the witness: the ledger's bytes are only believable if the mapping is gone.
+BOOST_AUTO_TEST_CASE(chunk_pool_unmaps_an_arena_once_its_last_chunk_returns) {
+    ChunkPool pool(kChunkBytes, kArenaBytes);
+    std::vector<void *> first;
+    for (size_t i = 0; i < kChunksPerArena; ++i) {
+        first.push_back(pool.allocate());
+    }
+    std::vector<void *> second;
+    for (size_t i = 0; i < kChunksPerArena; ++i) {
+        second.push_back(pool.allocate());
+    }
+    BOOST_REQUIRE_EQUAL(pool.arena_count(), 2U);
+    BOOST_CHECK_EQUAL(pool.mapped_bytes(), 2 * pool.arena_bytes());
+    const void *const witness = second.front();
+    BOOST_CHECK(address_is_mapped(witness));
+
+    // Drain the second arena only: the first must keep its mapping.
+    for (void *chunk : second) {
+        pool.deallocate(chunk);
+    }
+    BOOST_CHECK_EQUAL(pool.arena_count(), 1U);
+    BOOST_CHECK_EQUAL(pool.mapped_bytes(), pool.arena_bytes());
+    BOOST_CHECK(!address_is_mapped(witness));
+    BOOST_CHECK(address_is_mapped(first.front()));
+
+    for (void *chunk : first) {
+        pool.deallocate(chunk);
+    }
+    BOOST_CHECK_EQUAL(pool.arena_count(), 0U);
+    BOOST_CHECK_EQUAL(pool.mapped_bytes(), 0U);
+    BOOST_CHECK_EQUAL(pool.live_chunks(), 0U);
+    BOOST_CHECK(!address_is_mapped(first.front()));
+}
+
+// Indexing is the whole contract: element i must round-trip whichever chunk it fell in, and the three
+// accessors (operator[], chunk_base, contiguous_at) must name the same byte.
+BOOST_AUTO_TEST_CASE(chunked_array_indexes_across_chunk_boundaries) {
+    constexpr size_t kElemsPerChunk = 8;
+    constexpr size_t kElems = 3 * kElemsPerChunk + 3; // deliberately not a whole number of chunks
+    ChunkPool pool(kChunkBytes, kArenaBytes);
+    ChunkedArray<uint64_t> array(pool, kElemsPerChunk);
+    BOOST_CHECK(array.attached());
+    BOOST_CHECK_EQUAL(array.size(), 0U);
+    BOOST_CHECK_EQUAL(array.bytes(), 0U);
+
+    array.grow(kElems);
+    BOOST_CHECK_EQUAL(array.size(), kElems);
+    BOOST_CHECK_EQUAL(array.chunk_count(), 4U);
+    BOOST_CHECK_EQUAL(array.capacity(), 4 * kElemsPerChunk);
+    BOOST_CHECK_EQUAL(array.slack_bytes(), (4 * kElemsPerChunk - kElems) * sizeof(uint64_t));
+    BOOST_CHECK_GE(array.bytes(), 4 * pool.chunk_bytes());
+
+    for (size_t i = 0; i < kElems; ++i) {
+        array[i] = 0x1000U + i;
+    }
+    for (size_t i = 0; i < kElems; ++i) {
+        BOOST_CHECK_EQUAL(array[i], 0x1000U + i);
+        BOOST_CHECK_EQUAL(array.chunk_base(i)[i % kElemsPerChunk], 0x1000U + i);
+        BOOST_CHECK_EQUAL(*array.contiguous_at(i), 0x1000U + i);
+        BOOST_CHECK_EQUAL(array.elems_left_in_chunk(i), kElemsPerChunk - (i % kElemsPerChunk));
+    }
+    // A run that starts on a chunk boundary is readable as a plain array for the whole chunk.
+    const uint64_t *run = array.contiguous_at(kElemsPerChunk);
+    for (size_t j = 0; j < kElemsPerChunk; ++j) {
+        BOOST_CHECK_EQUAL(run[j], 0x1000U + kElemsPerChunk + j);
+    }
+
+    // Growth appends chunks and never disturbs what is already there.
+    array.grow(kElems + kElemsPerChunk);
+    BOOST_CHECK_EQUAL(array.chunk_count(), 5U);
+    for (size_t i = 0; i < kElems; ++i) {
+        BOOST_CHECK_EQUAL(array[i], 0x1000U + i);
+    }
+    // Append-only: a request at or below the current size changes nothing.
+    array.grow(1);
+    BOOST_CHECK_EQUAL(array.size(), kElems + kElemsPerChunk);
+}
+
+// Chunks come back from the pool dirty, so grow_zeroed() must clear exactly the range it adds --
+// nothing before it, and (so it never faults in slack) nothing past it.
+BOOST_AUTO_TEST_CASE(chunked_array_grow_zeroed_clears_recycled_chunks) {
+    constexpr size_t kElemsPerChunk = 8;
+    ChunkPool pool(kChunkBytes, kArenaBytes);
+    {
+        ChunkedArray<uint64_t> dirty(pool, kElemsPerChunk);
+        dirty.grow(2 * kElemsPerChunk);
+        for (size_t i = 0; i < 2 * kElemsPerChunk; ++i) {
+            dirty[i] = 0xdeadbeefU;
+        }
+    } // chunks return to the pool still carrying 0xdeadbeef
+
+    ChunkedArray<uint64_t> array(pool, kElemsPerChunk);
+    array.grow_zeroed(kElemsPerChunk + 1);
+    BOOST_REQUIRE_EQUAL(pool.arena_count(), 1U); // it did reuse the dirty chunks
+    for (size_t i = 0; i < kElemsPerChunk + 1; ++i) {
+        BOOST_CHECK_EQUAL(array[i], 0U);
+    }
+    for (size_t i = 0; i < kElemsPerChunk + 1; ++i) {
+        array[i] = i + 1;
+    }
+    // A second growth zeroes only the new elements, leaving the live prefix alone.
+    array.grow_zeroed(3 * kElemsPerChunk);
+    for (size_t i = 0; i < kElemsPerChunk + 1; ++i) {
+        BOOST_CHECK_EQUAL(array[i], i + 1);
+    }
+    for (size_t i = kElemsPerChunk + 1; i < 3 * kElemsPerChunk; ++i) {
+        BOOST_CHECK_EQUAL(array[i], 0U);
+    }
+}
+
+// A clone owns its own chunks: the operator is copied whenever a propagator is, and a shared chunk
+// would make the copy alias the original's index.
+BOOST_AUTO_TEST_CASE(chunked_array_clone_is_an_independent_deep_copy) {
+    constexpr size_t kElemsPerChunk = 8;
+    constexpr size_t kElems = 2 * kElemsPerChunk + 5;
+    ChunkPool pool(kChunkBytes, kArenaBytes);
+    ChunkedArray<uint64_t> array(pool, kElemsPerChunk);
+    array.grow(kElems);
+    for (size_t i = 0; i < kElems; ++i) {
+        array[i] = i * i;
+    }
+
+    ChunkedArray<uint64_t> same_pool = array.clone();
+    ChunkPool other_pool(kChunkBytes, kArenaBytes);
+    ChunkedArray<uint64_t> other = array.clone_into(other_pool);
+    BOOST_CHECK_EQUAL(same_pool.size(), kElems);
+    BOOST_CHECK_EQUAL(other.size(), kElems);
+    for (size_t i = 0; i < kElems; ++i) {
+        BOOST_CHECK_EQUAL(same_pool[i], i * i);
+        BOOST_CHECK_EQUAL(other[i], i * i);
+    }
+    BOOST_CHECK(same_pool.chunk_base(0) != array.chunk_base(0));
+    BOOST_CHECK_EQUAL(other_pool.live_chunks(), other.chunk_count());
+
+    array[0] = 99;
+    array[kElemsPerChunk] = 99;
+    BOOST_CHECK_EQUAL(same_pool[0], 0U);
+    BOOST_CHECK_EQUAL(same_pool[kElemsPerChunk], kElemsPerChunk * kElemsPerChunk);
+    BOOST_CHECK_EQUAL(other[kElemsPerChunk], kElemsPerChunk * kElemsPerChunk);
+}
+
+// reset() is what a rebuild does to every column: the chunks must reach the pool (and, here, the OS)
+// rather than being retained, and the array must stay attached and usable afterwards.
+BOOST_AUTO_TEST_CASE(chunked_array_reset_and_move_return_every_chunk) {
+    constexpr size_t kElemsPerChunk = 8;
+    ChunkPool pool(kChunkBytes, kArenaBytes);
+    ChunkedArray<uint64_t> array(pool, kElemsPerChunk);
+    array.grow(3 * kElemsPerChunk);
+    BOOST_REQUIRE_EQUAL(pool.live_chunks(), 3U);
+
+    array.reset();
+    BOOST_CHECK_EQUAL(array.size(), 0U);
+    BOOST_CHECK_EQUAL(array.bytes(), 0U);
+    BOOST_CHECK_EQUAL(pool.live_chunks(), 0U);
+    BOOST_CHECK_EQUAL(pool.arena_count(), 0U);
+    BOOST_CHECK(array.attached()); // still bound: a rebuild refills the same array
+
+    array.grow_zeroed(kElemsPerChunk);
+    BOOST_CHECK_EQUAL(pool.live_chunks(), 1U);
+    ChunkedArray<uint64_t> moved = std::move(array);
+    BOOST_CHECK_EQUAL(moved.size(), kElemsPerChunk);
+    BOOST_CHECK_EQUAL(pool.live_chunks(), 1U); // moving transfers the chunks, it does not copy them
+    ChunkedArray<uint64_t> target(pool, kElemsPerChunk);
+    target.grow(2 * kElemsPerChunk);
+    BOOST_REQUIRE_EQUAL(pool.live_chunks(), 3U);
+    target = std::move(moved); // the overwritten chunks must be released, not leaked
+    BOOST_CHECK_EQUAL(target.size(), kElemsPerChunk);
+    BOOST_CHECK_EQUAL(pool.live_chunks(), 1U);
+}

--- a/cpp/tests/inverted_index_tests.cpp
+++ b/cpp/tests/inverted_index_tests.cpp
@@ -15,12 +15,16 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <bit>
 #include <cstdint>
+#include <optional>
 #include <span>
+#include <utility>
 #include <vector>
 
 #include "monoprop/TypeAliases.h"
 #include "monoprop/algebra/MajoranaAlgebra.h" // indices_to_bitset
+#include "monoprop/detail/evolution/CosineRecompute.h"
 #include "monoprop/detail/operator/InvertedIndex.h"
 #include "monoprop/detail/operator/RowAccess.h"
 
@@ -53,10 +57,16 @@ auto rows_of(const Sc &sc, size_t c) -> std::vector<size_t> {
         }
         return out;
     }
-    const uint64_t *words = sc.dense_column_data(c);
-    for (size_t r = 0; r < sc.rows(); ++r) {
-        if (((words[r >> 6] >> (r & 63U)) & 1U) != 0U) {
-            out.push_back(r);
+    // A word at a time: a dense column is chunked, so it is read a fold block at a time and there is
+    // no pointer to the whole of it.
+    for (size_t w = 0; w * 64 < sc.rows(); ++w) {
+        uint64_t bits = *sc.dense_column_block(c, w, w + 1);
+        while (bits != 0U) {
+            const size_t r = (w * 64) + static_cast<size_t>(std::countr_zero(bits));
+            if (r < sc.rows()) {
+                out.push_back(r);
+            }
+            bits &= bits - 1;
         }
     }
     return out;
@@ -260,4 +270,332 @@ BOOST_AUTO_TEST_CASE(combine_columns_block_folds_dense_and_sparse_identically) {
     sparse_expected[5 >> 6] |= uint64_t{1} << (5 & 63U);
     sparse_expected[200 >> 6] |= uint64_t{1} << (200 & 63U);
     BOOST_TEST(sparse_fold == sparse_expected, boost::test_tools::per_element());
+}
+
+// Chunking the dense columns must be invisible: the fold is their only reader, it walks a column in
+// blocks of kColumnBlockWords, and a chunk holds a whole number of those blocks -- so the same words
+// come back whatever the chunk size. These cases pin that down at the smallest legal chunk
+// (kColumnBlockWords words, a boundary every 65536 rows) against the production chunk, which holds this
+// operator in a single piece and is therefore the unchunked reference.
+namespace {
+
+// Enough rows to spill past three chunk boundaries at kColumnBlockWords words per chunk. Cheap: a
+// Monomial<32> is eight bytes.
+constexpr size_t kChunkTestRows = 200'000;
+constexpr size_t kSmallChunkWords = kColumnBlockWords;
+
+// Three tiers' worth of column in one operator: two dense (one dense enough to win the fold's memcpy
+// seed), one sparse with set rows in every chunk, so both fold paths cross a boundary.
+auto build_chunk_test_op() -> std::vector<MSet> {
+    std::vector<MSet> op;
+    op.reserve(kChunkTestRows);
+    for (size_t i = 0; i < kChunkTestRows; ++i) {
+        VecZ pos;
+        if (i % 3 == 0) {
+            pos.push_back(0);
+        }
+        if (i % 7 == 0) {
+            pos.push_back(1);
+        }
+        if (i % 40'009 == 5) { // a handful of rows, one per chunk
+            pos.push_back(2);
+        }
+        if (pos.empty()) {
+            pos.push_back(3); // keep every row non-empty
+        }
+        op.push_back(bs(pos));
+    }
+    return op;
+}
+
+} // namespace
+
+// The fold over a multi-chunk column must equal the fold over the same column held in one piece, word
+// for word -- the memcpy seed included, that being the one read which is not a plain loop.
+BOOST_AUTO_TEST_CASE(dense_columns_fold_identically_across_chunk_boundaries) {
+    const auto op = build_chunk_test_op();
+    Sc chunked(kSmallChunkWords);
+    Sc whole(Sc::kMaxWordsPerChunk);
+    chunked.rebuild(op);
+    whole.rebuild(op);
+
+    const size_t words = (kChunkTestRows + 63) / 64;
+    BOOST_REQUIRE_GT(words, 3 * kSmallChunkWords); // the small-chunk index really is multi-chunk
+    BOOST_REQUIRE(chunked.column_is_dense(col_of(0)));
+    BOOST_REQUIRE(chunked.column_is_dense(col_of(1)));
+    BOOST_REQUIRE(!chunked.column_is_dense(col_of(2)));
+    BOOST_REQUIRE_EQUAL(chunked.column_is_dense(col_of(0)), whole.column_is_dense(col_of(0)));
+
+    const std::vector<size_t> cols{col_of(0), col_of(1), col_of(2)};
+    std::vector<uint64_t> a(words, 0xdeadbeefULL);
+    std::vector<uint64_t> b(words, 0xfeedfaceULL);
+    for (size_t bb = 0; bb < words; bb += kColumnBlockWords) {
+        const size_t be = std::min(bb + kColumnBlockWords, words);
+        combine_columns_block<N>(chunked, cols, a.data() + bb, bb, be);
+        combine_columns_block<N>(whole, cols, b.data() + bb, bb, be);
+    }
+    BOOST_CHECK_EQUAL_COLLECTIONS(a.begin(), a.end(), b.begin(), b.end());
+
+    // And against the authored membership, so a fold that is wrong the same way in both still fails.
+    std::vector<uint64_t> expected(words, 0);
+    for (size_t r = 0; r < kChunkTestRows; ++r) {
+        const bool in_a = r % 3 == 0;
+        const bool in_b = r % 7 == 0;
+        const bool in_sparse = r % 40'009 == 5;
+        if (in_a != (in_b != in_sparse)) { // three-way XOR
+            expected[r >> 6] |= uint64_t{1} << (r & 63U);
+        }
+    }
+    BOOST_CHECK_EQUAL_COLLECTIONS(a.begin(), a.end(), expected.begin(), expected.end());
+}
+
+// make_fold_cache used to combine a whole column in one call; a chunked column has no pointer that
+// wide, so it now walks the same blocks as every other fold. XOR is associative, so the words must come
+// out identical -- and so must the coefficients a fold scales, which is what the engine observes.
+BOOST_AUTO_TEST_CASE(make_fold_cache_is_blocked_and_bit_identical_across_chunk_sizes) {
+    const auto op = build_chunk_test_op();
+    Sc chunked(kSmallChunkWords);
+    Sc whole(Sc::kMaxWordsPerChunk);
+    chunked.rebuild(op);
+    whole.rebuild(op);
+
+    // An even and an odd generator: the odd one also engages the row-parity correction.
+    const std::vector<MSet> gens{bs({0, 1}), bs({0, 1, 2})};
+    for (const auto &gen : gens) {
+        const auto ca = make_fold_cache<N>(chunked, gen, kChunkTestRows, Basis::Majorana);
+        const auto cb = make_fold_cache<N>(whole, gen, kChunkTestRows, Basis::Majorana);
+        BOOST_REQUIRE_EQUAL(ca.combined.size(), cb.combined.size());
+        BOOST_REQUIRE_GT(ca.combined.size(), kSmallChunkWords);
+        BOOST_CHECK_EQUAL_COLLECTIONS(ca.combined.begin(), ca.combined.end(), cb.combined.begin(), cb.combined.end());
+
+        // Distinct, non-degenerate coefficients, so one index scaled twice or not at all shows up.
+        std::vector<double> xa(kChunkTestRows);
+        for (size_t i = 0; i < kChunkTestRows; ++i) {
+            xa[i] = 1.0 + (static_cast<double>(i) * 1e-6);
+        }
+        std::vector<double> xb = xa;
+        const auto ra = make_lazy_fold<N>(chunked, gen, kChunkTestRows, Basis::Majorana);
+        const auto rb = make_lazy_fold<N>(whole, gen, kChunkTestRows, Basis::Majorana);
+        scale_cos_lazy<N>(chunked, ra, xa.data(), 0.6234);
+        scale_cos_lazy<N>(whole, rb, xb.data(), 0.6234);
+        // Exactly equal, not within a tolerance: the whole point of the lever is bit-identity.
+        BOOST_CHECK_EQUAL_COLLECTIONS(xa.begin(), xa.end(), xb.begin(), xb.end());
+    }
+}
+
+// A column promoted mid-fill is rebuilt chunk by chunk, and an index grown by appends extends its
+// chunks rather than the vector it no longer has. Both paths must land on exactly the bits one rebuild
+// over the whole operator does.
+BOOST_AUTO_TEST_CASE(appending_and_promotion_reach_the_same_chunked_columns) {
+    const auto op = build_chunk_test_op();
+    Sc appended(kSmallChunkWords);
+    // Three unequal batches; the boundaries fall inside chunks, not on them.
+    size_t base = 0;
+    for (const size_t n : {size_t{70'000}, size_t{60'000}, kChunkTestRows - 130'000}) {
+        appended.append_rows(op, base, n);
+        base += n;
+    }
+    BOOST_REQUIRE_EQUAL(appended.rows(), kChunkTestRows);
+
+    Sc rebuilt(kSmallChunkWords);
+    rebuilt.rebuild(op);
+    for (size_t c = 0; c < Sc::kNumColumns; ++c) {
+        BOOST_TEST_INFO("column " << c);
+        const auto got = rows_of(appended, c);
+        const auto want = rows_of(rebuilt, c);
+        BOOST_CHECK_EQUAL_COLLECTIONS(got.begin(), got.end(), want.begin(), want.end());
+    }
+}
+
+// The ledger's dense figure is now the pool's page-rounded chunk bytes, so the slack it hides is under
+// one chunk per dense column -- where a doubling vector's could be the column over again.
+BOOST_AUTO_TEST_CASE(chunked_dense_columns_bound_the_index_slack_by_one_chunk) {
+    const auto op = build_chunk_test_op();
+    Sc sc(kSmallChunkWords);
+    sc.rebuild(op);
+    const auto tiers = sc.tier_memory_bytes();
+    const size_t dense_columns = tiers[2];
+    BOOST_REQUIRE_GT(dense_columns, 0U);
+
+    const size_t live = sc.words() * sizeof(uint64_t) * dense_columns;
+    BOOST_CHECK_GE(tiers[0], live);
+    BOOST_CHECK_LT(tiers[0] - live, dense_columns * kSmallChunkWords * sizeof(uint64_t));
+    BOOST_CHECK_LE(tiers[0] + tiers[1], sc.memory_bytes());
+}
+
+// A copied index owns its own chunks: MPOperator deep-copies the index whenever a propagator is copied,
+// and a shared chunk would make the two copies aliases of one bitmap.
+BOOST_AUTO_TEST_CASE(copying_an_index_deep_copies_its_chunked_columns) {
+    const auto op = build_chunk_test_op();
+    Sc original(kSmallChunkWords);
+    original.rebuild(op);
+    Sc copy = original; // NOLINT(performance-unnecessary-copy-initialization)
+
+    BOOST_REQUIRE_EQUAL(copy.rows(), original.rows());
+    const size_t c0 = col_of(0);
+    BOOST_REQUIRE(copy.column_is_dense(c0));
+    BOOST_CHECK(copy.dense_column_block(c0, 0, 1) != original.dense_column_block(c0, 0, 1));
+    for (size_t c = 0; c < Sc::kNumColumns; ++c) {
+        BOOST_TEST_INFO("column " << c);
+        const auto got = rows_of(copy, c);
+        const auto want = rows_of(original, c);
+        BOOST_CHECK_EQUAL_COLLECTIONS(got.begin(), got.end(), want.begin(), want.end());
+    }
+
+    // And moving one through an optional, as MPOperator holds it, must not disturb the storage.
+    std::optional<Sc> moved{std::move(copy)};
+    BOOST_REQUIRE(moved.has_value());
+    const auto got = rows_of(*moved, c0);
+    const auto want = rows_of(original, c0);
+    BOOST_CHECK_EQUAL_COLLECTIONS(got.begin(), got.end(), want.begin(), want.end());
+}
+
+namespace {
+
+// Column 1 is empty for the first batch and dense by the end of the second, so it is built at a height
+// in a different chunk size class from column 0, which is dense from the first batch. Column 2 stays
+// sparse with a set row in every chunk, so the fold's scatter path crosses boundaries too.
+constexpr size_t kMixedFirstRows = 400'000;
+constexpr size_t kMixedRows = 600'000;
+
+auto build_mixed_chunk_op() -> std::vector<MSet> {
+    std::vector<MSet> op;
+    op.reserve(kMixedRows);
+    for (size_t i = 0; i < kMixedRows; ++i) {
+        VecZ pos;
+        if (i % 3 == 0) {
+            pos.push_back(0);
+        }
+        if (i >= kMixedFirstRows && i % 2 == 0) {
+            pos.push_back(1);
+        }
+        if (i % 40'009 == 5) {
+            pos.push_back(2);
+        }
+        if (pos.empty()) {
+            pos.push_back(3); // keep every row non-empty
+        }
+        op.push_back(bs(pos));
+    }
+    return op;
+}
+
+} // namespace
+
+// The chunk length is chosen from the height the column is built at, so that a column shorter than one
+// 128 KiB chunk is not rounded up to one and a billion-row column is not addressed by a hundred
+// thousand pointers.
+BOOST_AUTO_TEST_CASE(chunk_words_follow_the_column_height_and_stop_at_the_ceiling) {
+    const std::vector<std::pair<size_t, size_t>> table{
+        {0, Sc::kMinWordsPerChunk},
+        {1, Sc::kMinWordsPerChunk},
+        {65'536, Sc::kMinWordsPerChunk},
+        {262'144, Sc::kMinWordsPerChunk}, // 4096 words: a quarter is exactly one minimum chunk
+        {300'000, Sc::kMinWordsPerChunk}, // 4688 words: a quarter rounds *down*, so still one
+        {524'288, 2 * Sc::kMinWordsPerChunk},
+        {1'048'576, 4 * Sc::kMinWordsPerChunk},
+        {2'097'152, 8 * Sc::kMinWordsPerChunk},
+        {4'194'304, Sc::kMaxWordsPerChunk}, // the ceiling, first reached at 4M rows
+        {1'000'000'000, Sc::kMaxWordsPerChunk},
+    };
+    for (const auto &[rows, want] : table) {
+        BOOST_TEST_INFO("rows " << rows);
+        BOOST_CHECK_EQUAL(Sc::chunk_words_for_rows(rows), want);
+    }
+
+    // Every choice is a whole number of fold blocks -- which is what keeps a block from straddling a
+    // chunk -- monotone in the height, and never more than a quarter of the column it serves. Since the
+    // overshoot is under one chunk, that is the slack bound: a quarter of the column, or one minimum
+    // chunk on a column too short to have quarters worth taking, rather than a fixed 128 KiB.
+    size_t previous = 0;
+    for (size_t rows = 0; rows < 40'000'000; rows = rows + 1 + rows / 3) {
+        const size_t chunk = Sc::chunk_words_for_rows(rows);
+        const size_t words = (rows + 63) / 64;
+        const size_t chunks = (words + chunk - 1) / chunk;
+        BOOST_TEST_INFO("rows " << rows);
+        BOOST_CHECK(std::has_single_bit(chunk));
+        BOOST_CHECK_EQUAL(chunk % kColumnBlockWords, 0U);
+        BOOST_CHECK_GE(chunk, previous);
+        BOOST_CHECK_LE(chunk, std::max(Sc::kMinWordsPerChunk, words / 4));
+        BOOST_CHECK_LT(chunks * chunk - words, std::max(Sc::kMinWordsPerChunk, words / 4));
+        previous = chunk;
+    }
+}
+
+// Two dense columns of one index can now hold different chunk lengths, because they were promoted at
+// different heights. Nothing in the fold may assume they agree: it asks each column for its own block.
+BOOST_AUTO_TEST_CASE(columns_of_different_chunk_sizes_fold_identically) {
+    const auto op = build_mixed_chunk_op();
+    Sc adaptive;                  // production sizing: each column from the height it is built at
+    Sc uniform(kSmallChunkWords); // every column pinned to one fold block per chunk
+    for (Sc *sc : {&adaptive, &uniform}) {
+        sc->append_rows(op, 0, kMixedFirstRows);
+        sc->append_rows(op, kMixedFirstRows, kMixedRows - kMixedFirstRows);
+    }
+    BOOST_REQUIRE_EQUAL(adaptive.rows(), kMixedRows);
+
+    const size_t c0 = col_of(0);
+    const size_t c1 = col_of(1);
+    BOOST_REQUIRE(adaptive.column_is_dense(c0));
+    BOOST_REQUIRE(adaptive.column_is_dense(c1));
+    BOOST_REQUIRE(!adaptive.column_is_dense(col_of(2)));
+    // The premise of the case: one index, two dense columns, two different chunk lengths.
+    const size_t w0 = adaptive.cols[c0].words.elems_per_chunk();
+    const size_t w1 = adaptive.cols[c1].words.elems_per_chunk();
+    BOOST_CHECK_EQUAL(w0, Sc::chunk_words_for_rows(kMixedFirstRows));
+    BOOST_CHECK_EQUAL(w1, Sc::chunk_words_for_rows(kMixedRows));
+    BOOST_REQUIRE_NE(w0, w1);
+
+    const size_t words = (kMixedRows + 63) / 64;
+    const std::vector<size_t> cols{c0, c1, col_of(2)};
+    std::vector<uint64_t> a(words, 0xdeadbeefULL);
+    std::vector<uint64_t> b(words, 0xfeedfaceULL);
+    for (size_t bb = 0; bb < words; bb += kColumnBlockWords) {
+        const size_t be = std::min(bb + kColumnBlockWords, words);
+        combine_columns_block<N>(adaptive, cols, a.data() + bb, bb, be);
+        combine_columns_block<N>(uniform, cols, b.data() + bb, bb, be);
+    }
+    BOOST_CHECK_EQUAL_COLLECTIONS(a.begin(), a.end(), b.begin(), b.end());
+
+    std::vector<uint64_t> expected(words, 0);
+    for (size_t r = 0; r < kMixedRows; ++r) {
+        const bool in_0 = r % 3 == 0;
+        const bool in_1 = r >= kMixedFirstRows && r % 2 == 0;
+        const bool in_2 = r % 40'009 == 5;
+        if (in_0 != (in_1 != in_2)) { // three-way XOR
+            expected[r >> 6] |= uint64_t{1} << (r & 63U);
+        }
+    }
+    BOOST_CHECK_EQUAL_COLLECTIONS(a.begin(), a.end(), expected.begin(), expected.end());
+
+    // A copy has to carry each column's own length across, not one length for the index.
+    const Sc copy = adaptive;
+    BOOST_CHECK_EQUAL(copy.cols[c0].words.elems_per_chunk(), w0);
+    BOOST_CHECK_EQUAL(copy.cols[c1].words.elems_per_chunk(), w1);
+    for (size_t c = 0; c < Sc::kNumColumns; ++c) {
+        BOOST_TEST_INFO("column " << c);
+        const auto got = rows_of(copy, c);
+        const auto want = rows_of(adaptive, c);
+        BOOST_CHECK_EQUAL_COLLECTIONS(got.begin(), got.end(), want.begin(), want.end());
+    }
+}
+
+// The reason for sizing at all: a fixed 128 KiB chunk is bigger than the whole column on the operators
+// most runs actually have, and rounded the ledger's dense figure up rather than down.
+BOOST_AUTO_TEST_CASE(adaptive_chunks_beat_the_fixed_ceiling_on_a_small_operator) {
+    const auto op = build_chunk_test_op();
+    Sc adaptive;
+    Sc fixed_ceiling(Sc::kMaxWordsPerChunk);
+    adaptive.rebuild(op);
+    fixed_ceiling.rebuild(op);
+
+    const auto tuned = adaptive.tier_memory_bytes();
+    const auto fixed = fixed_ceiling.tier_memory_bytes();
+    BOOST_REQUIRE_GT(tuned[2], 0U);
+    BOOST_REQUIRE_EQUAL(tuned[2], fixed[2]); // the same columns are dense either way
+
+    const size_t live = adaptive.words() * sizeof(uint64_t) * tuned[2];
+    BOOST_CHECK_LT(tuned[0], fixed[0]);
+    BOOST_CHECK_GE(tuned[0], live);
+    BOOST_CHECK_LT(tuned[0] - live, live); // slack is a fraction of the columns, not a multiple of them
 }

--- a/cpp/tests/mp_operator_tests.cpp
+++ b/cpp/tests/mp_operator_tests.cpp
@@ -81,6 +81,20 @@ auto sparse_state_equals(const detail::MPOperator<8>::SparseState &sparse, const
            && std::ranges::equal(sparse.values, expected.second);
 }
 
+// Pairwise-distinct two-position monomials over the 16 slots of Monomial<8>, in colexicographic order.
+// Enough for a capacity ladder that crosses several growth steps.
+inline constexpr size_t kLadderTerms = 100;
+
+auto distinct_term(size_t k) -> Monomial<8> {
+    constexpr size_t kSlots = Monomial<8>::size();
+    size_t first = 0;
+    while (k >= kSlots - 1 - first) {
+        k -= kSlots - 1 - first;
+        ++first;
+    }
+    return indices_to_bitset<8>(VecZ{first, first + 1 + k});
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_CASE(mp_operator_get_state_scores_paired_terms_majorana_and_pauli) {
@@ -416,4 +430,128 @@ BOOST_AUTO_TEST_CASE(mp_operator_copy_constructor_clones_store_and_coeffs) {
     copy.append_term(indices_to_bitset<8>({4, 5}));
     BOOST_CHECK_EQUAL(op.size(), 2U);
     BOOST_CHECK_EQUAL(copy.size(), 3U);
+}
+
+// The coefficient array parallels the row store, so it must grow on the store's 1.5x policy and not on
+// std::vector's doubling. Only capacity is at stake -- the ladder is checked alongside the values.
+BOOST_AUTO_TEST_CASE(mp_operator_get_operator_grows_coeffs_at_the_row_store_policy) {
+    detail::MPOperator<8> op;
+
+    size_t prev_cap = op.op_coeffs.capacity();
+    for (size_t step = 1; step <= kLadderTerms; ++step) {
+        op.append_term(distinct_term(step - 1));
+        const auto &coeffs = op.get_operator();
+        BOOST_REQUIRE_EQUAL(coeffs.size(), op.size());
+
+        const size_t cap = op.op_coeffs.capacity();
+        BOOST_CHECK_GE(cap, coeffs.size());
+        BOOST_CHECK_LE(cap, std::max(coeffs.size(), prev_cap + (prev_cap / 2) + 1));
+        BOOST_CHECK_EQUAL(coeffs.back(), 0.0); // every new slot is written 0.0 before use
+        prev_cap = cap;
+
+        op.op_coeffs[step - 1] = static_cast<double>(step);
+    }
+
+    // Growth never disturbs an already-written coefficient.
+    BOOST_REQUIRE_EQUAL(op.op_coeffs.size(), kLadderTerms);
+    for (size_t i = 0; i < kLadderTerms; ++i) {
+        BOOST_CHECK_EQUAL(op.op_coeffs[i], static_cast<double>(i + 1));
+    }
+}
+
+// dense_state() extends the same way, and its already-scored prefix must survive the growth too.
+BOOST_AUTO_TEST_CASE(mp_operator_dense_state_grows_coeffs_at_the_row_store_policy) {
+    const VecZ initial_state{0, 1};
+    detail::MPOperator<8> op;
+    op.basis = Basis::Majorana;
+    op.initial_state = initial_state;
+
+    size_t prev_cap = op.state_coeffs.capacity();
+    for (size_t step = 1; step <= kLadderTerms; ++step) {
+        op.append_term(distinct_term(step - 1));
+        const auto &state = op.dense_state();
+        BOOST_REQUIRE_EQUAL(state.size(), op.size());
+
+        const size_t cap = op.state_coeffs.capacity();
+        BOOST_CHECK_GE(cap, state.size());
+        BOOST_CHECK_LE(cap, std::max(state.size(), prev_cap + (prev_cap / 2) + 1));
+        prev_cap = cap;
+    }
+
+    BOOST_CHECK(op.dense_state() == expected_state(op, Basis::Majorana, initial_state));
+}
+
+// The coefficient slack is a subset of op_coeffs_bytes, so it accumulates under += like the other d_
+// fields and must never reach total_bytes().
+BOOST_AUTO_TEST_CASE(mp_operator_breakdown_keeps_op_coeffs_slack_out_of_total) {
+    detail::MPOperatorMemoryBreakdown<8> acc;
+    acc.op_coeffs_bytes = 100;
+    acc.op_coeffs_slack_bytes = 24;
+    BOOST_CHECK_EQUAL(acc.total_bytes(), 100U);
+
+    detail::MPOperatorMemoryBreakdown<8> other;
+    other.op_coeffs_bytes = 20;
+    other.op_coeffs_slack_bytes = 8;
+
+    acc += other;
+    BOOST_CHECK_EQUAL(acc.op_coeffs_slack_bytes, 32U);
+    BOOST_CHECK_EQUAL(acc.total_bytes(), 120U);
+}
+
+// A high-water mark over the measurement window, not a reading of the array as it stands: it has to
+// survive the shrink that ends every call, and to reset when a new window opens.
+BOOST_AUTO_TEST_CASE(mp_operator_breakdown_op_coeffs_slack_is_a_high_water_mark) {
+    detail::MPOperator<8> op;
+    BOOST_CHECK_EQUAL(detail::estimate_memory_usage<8>(op).op_coeffs_slack_bytes, 0U); // nothing allocated
+
+    for (size_t k = 0; k < kLadderTerms; ++k) {
+        op.append_term(distinct_term(k));
+    }
+    // The first growth reserves exactly (1.5 * 0 + 1 is below the request), so it leaves no slack.
+    (void)op.get_operator();
+    BOOST_CHECK_EQUAL(detail::estimate_memory_usage<8>(op).op_coeffs_slack_bytes, 0U);
+
+    // The second does grow geometrically, and the mark records what it left over.
+    op.append_term(distinct_term(kLadderTerms));
+    (void)op.get_operator();
+    const auto grown = detail::estimate_memory_usage<8>(op);
+    BOOST_CHECK_EQUAL(grown.op_coeffs_slack_bytes, (op.op_coeffs.capacity() - op.op_coeffs.size()) * sizeof(double));
+    BOOST_CHECK_GT(grown.op_coeffs_slack_bytes, 0U);
+    BOOST_CHECK_LT(grown.op_coeffs_slack_bytes, grown.op_coeffs_bytes); // a subset of the field it breaks down
+
+    // It holds the peak: handing the capacity back does not lower it, which is the whole point -- every
+    // call ends in a shrink_to_fit, so a resting measurement would always read 0.
+    const size_t peak = grown.op_coeffs_slack_bytes;
+    op.op_coeffs.shrink_to_fit();
+    op.observe_op_coeffs_slack();
+    BOOST_CHECK_EQUAL(detail::estimate_memory_usage<8>(op).op_coeffs_slack_bytes, peak);
+
+    // And a new window starts from nothing.
+    op.reset_op_coeffs_slack_hwm();
+    BOOST_CHECK_EQUAL(detail::estimate_memory_usage<8>(op).op_coeffs_slack_bytes, 0U);
+}
+
+// The two-tier row layout and the chunk pools are reported so an A/B can tell a width that held from
+// one that did not, and so the mapped bytes the kernel charges are named somewhere in the ledger.
+BOOST_AUTO_TEST_CASE(mp_operator_breakdown_reports_the_row_tiers_and_the_pools) {
+    detail::MPOperator<8> op;
+    const auto empty = detail::estimate_memory_usage<8>(op);
+    BOOST_CHECK_EQUAL(empty.row_wide_rows, 0U);
+    BOOST_CHECK_EQUAL(empty.row_restrides, 0U);
+    BOOST_CHECK_EQUAL(empty.pool_mapped_bytes, 0U); // nothing has grown, so nothing is mapped
+
+    for (size_t k = 0; k < kLadderTerms; ++k) {
+        op.append_term(distinct_term(k));
+    }
+    (void)op.inverted_index();
+    const auto grown = detail::estimate_memory_usage<8>(op);
+    BOOST_CHECK_EQUAL(grown.row_inline_width, op.store->inline_width());
+    BOOST_CHECK_EQUAL(grown.row_wide_rows, op.store->wide_size());
+    BOOST_CHECK_GT(grown.pool_mapped_bytes, 0U);
+    BOOST_CHECK_LE(grown.pool_free_chunk_bytes, grown.pool_mapped_bytes);
+    // Both are outside total_bytes(): the mapping is not a subset of any named field.
+    auto without = grown;
+    without.pool_mapped_bytes = 0;
+    without.pool_free_chunk_bytes = 0;
+    BOOST_CHECK_EQUAL(grown.total_bytes(), without.total_bytes());
 }

--- a/cpp/tests/operator_index_tests.cpp
+++ b/cpp/tests/operator_index_tests.cpp
@@ -19,6 +19,7 @@
 #include <bit>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -455,4 +456,190 @@ BOOST_AUTO_TEST_CASE(chunked_growth_bounds_the_slack_by_one_chunk) {
     }
     s.set(65, bs({0, 2, 4})); // a row in the second chunk
     BOOST_CHECK(copy->row(65) == boundary_term(65));
+}
+
+namespace {
+
+// A term of exactly `slots` ascending positions, distinct per (i, slots).
+auto term_of_width(size_t i, size_t slots) -> MSet {
+    VecZ pos;
+    for (size_t j = 0; j < slots; ++j) {
+        pos.push_back((i * 3 + j * 5) % (2 * N));
+    }
+    std::sort(pos.begin(), pos.end());
+    pos.erase(std::unique(pos.begin(), pos.end()), pos.end());
+    for (size_t extra = 0; pos.size() < slots && extra < 2 * N; ++extra) {
+        if (std::find(pos.begin(), pos.end(), extra) == pos.end()) {
+            pos.push_back(extra);
+        }
+    }
+    std::sort(pos.begin(), pos.end());
+    return bs(pos);
+}
+
+} // namespace
+
+// A row wider than the inline slot but no wider than the structural bound goes to the fixed-stride wide
+// tier, not the side-map: it reads back the same through every accessor, and the side-map stays empty.
+BOOST_AUTO_TEST_CASE(wide_rows_go_to_the_second_tier_not_the_side_map) {
+    constexpr size_t kInline = 6;
+    constexpr size_t kBound = 10;
+    Store s(kInline, kTinyChunkRows, kBound);
+    BOOST_REQUIRE_EQUAL(s.inline_width(), kInline);
+    BOOST_REQUIRE_EQUAL(s.wide_width(), kBound);
+
+    // Widths on both sides of the inline slot, and one over the bound so the side-map is still used.
+    const std::vector<size_t> widths = {1, kInline - 1, kInline, kInline + 1, kBound - 1, kBound, kBound + 1};
+    std::vector<MSet> want;
+    for (size_t i = 0; i < widths.size(); ++i) {
+        want.push_back(term_of_width(i, widths[i]));
+        s.push_back(want.back());
+    }
+    BOOST_CHECK_EQUAL(s.wide_size(), 3U);     // inline+1, bound-1, bound
+    BOOST_CHECK_EQUAL(s.overflow_size(), 1U); // only the row over the bound
+    BOOST_CHECK_EQUAL(s.restrides(), 0U);
+
+    for (size_t i = 0; i < widths.size(); ++i) {
+        BOOST_TEST_INFO("row " << i << " width " << widths[i]);
+        BOOST_CHECK(s.row(i) == want[i]);
+        BOOST_CHECK_EQUAL(s.popcount(i), widths[i]);
+        // Only the row past the bound loses its position array; a wide row keeps one.
+        const auto rp = s.row_positions(i);
+        BOOST_CHECK_EQUAL(rp.inlined(), widths[i] <= kBound);
+        if (rp.inlined()) {
+            BOOST_CHECK_EQUAL(rp.pos.size(), widths[i]);
+        }
+        std::vector<size_t> seen;
+        s.for_each_position(i, [&](size_t b) { seen.push_back(b); });
+        BOOST_CHECK_EQUAL(seen.size(), widths[i]);
+    }
+
+    // set_positions() takes the same two-tier route as set(), and the index finds either tier.
+    Store t(kInline, kTinyChunkRows, kBound);
+    t.grow_rows_geometric(widths.size());
+    for (size_t i = 0; i < widths.size(); ++i) {
+        const auto rp = s.row_positions(i);
+        if (rp.inlined()) {
+            t.set_positions(i, rp.pos);
+        }
+        else {
+            t.set(i, want[i]);
+        }
+        t.emplace(want[i], i);
+    }
+    BOOST_CHECK_EQUAL(t.wide_size(), s.wide_size());
+    BOOST_CHECK_EQUAL(t.overflow_size(), s.overflow_size());
+    for (size_t i = 0; i < widths.size(); ++i) {
+        BOOST_TEST_INFO("row " << i);
+        BOOST_CHECK(t.row(i) == want[i]);
+        BOOST_CHECK(t.find(want[i]) == std::optional<size_t>{i});
+    }
+}
+
+// The policy: a tier under the threshold is left alone; over it the store re-lays itself at the bound,
+// once. A store with no tier can never trigger it.
+BOOST_AUTO_TEST_CASE(a_store_restrides_once_when_the_wide_tier_grows_past_the_threshold) {
+    constexpr size_t kInline = 6;
+    constexpr size_t kBound = 10;
+    constexpr size_t kRows = 400;
+
+    // One row in fifty is wide: 2 %, under the 3 % threshold, so the guess stands.
+    Store lean(kInline, kTinyChunkRows, kBound);
+    for (size_t i = 0; i < kRows; ++i) {
+        lean.push_back(term_of_width(i, i % 50 == 0 ? kBound : kInline));
+    }
+    BOOST_CHECK_EQUAL(lean.wide_size(), kRows / 50);
+    BOOST_CHECK(!lean.should_restride());
+
+    // One row in ten is wide: over the threshold, so the inline width was the wrong guess.
+    Store fat(kInline, kTinyChunkRows, kBound);
+    std::vector<MSet> want;
+    for (size_t i = 0; i < kRows; ++i) {
+        want.push_back(term_of_width(i, i % 10 == 0 ? kBound : kInline));
+        fat.push_back(want.back());
+        fat.emplace(want.back(), i);
+    }
+    BOOST_REQUIRE(fat.should_restride());
+
+    fat.restride_to_bound();
+    BOOST_CHECK_EQUAL(fat.restrides(), 1U);
+    BOOST_CHECK_EQUAL(fat.inline_width(), kBound);
+    BOOST_CHECK_EQUAL(fat.wide_size(), 0U);
+    BOOST_CHECK(!fat.should_restride()); // the tier is gone, so it can never fire again
+    BOOST_CHECK_EQUAL(fat.size(), kRows);
+
+    // Index-preserving: every row survives at its own index, and the hash index -- which keys on the
+    // row's value, not on its layout -- still resolves each term to the row it was inserted at. This is
+    // what lets the inverted index and the graph's endpoints stand across a restride.
+    for (size_t i = 0; i < kRows; ++i) {
+        BOOST_TEST_INFO("row " << i);
+        BOOST_CHECK(fat.row(i) == want[i]);
+        BOOST_CHECK_EQUAL(fat.popcount(i), i % 10 == 0 ? kBound : kInline);
+        BOOST_CHECK(fat.find(want[i]) == std::optional<size_t>{i});
+    }
+    // A restride is idempotent, and a store built at its bound has no tier to begin with.
+    fat.restride_to_bound();
+    BOOST_CHECK_EQUAL(fat.restrides(), 1U);
+    Store flat(kBound, kTinyChunkRows, kBound);
+    flat.push_back(term_of_width(0, kBound));
+    BOOST_CHECK_EQUAL(flat.wide_size(), 0U);
+    BOOST_CHECK(!flat.should_restride());
+}
+
+// raise_bound follows a cutoff widened after construction: it drains the tier first, so the rows the
+// old bound forbade are laid out rather than spilled into the side-map an entry at a time.
+BOOST_AUTO_TEST_CASE(raising_the_bound_drains_the_tier_and_widens_it) {
+    constexpr size_t kInline = 6;
+    constexpr size_t kBound = 8;
+    Store s(kInline, kTinyChunkRows, kBound);
+    std::vector<MSet> want;
+    for (size_t i = 0; i < 40; ++i) {
+        want.push_back(term_of_width(i, i % 4 == 0 ? kBound : kInline));
+        s.push_back(want.back());
+    }
+    BOOST_REQUIRE_EQUAL(s.wide_size(), 10U);
+
+    s.raise_bound(12);
+    BOOST_CHECK_EQUAL(s.wide_width(), 12U);
+    BOOST_CHECK_EQUAL(s.inline_width(), kBound); // the drain re-laid the rows at the old bound
+    BOOST_CHECK_EQUAL(s.wide_size(), 0U);
+    for (size_t i = 0; i < want.size(); ++i) {
+        BOOST_TEST_INFO("row " << i);
+        BOOST_CHECK(s.row(i) == want[i]);
+    }
+    // A row the old bound would have spilled now takes the fresh tier.
+    s.push_back(term_of_width(100, 11));
+    BOOST_CHECK_EQUAL(s.wide_size(), 1U);
+    BOOST_CHECK_EQUAL(s.overflow_size(), 0U);
+    // Narrowing is a no-op: the rows are already laid out wider than that.
+    s.raise_bound(2);
+    BOOST_CHECK_EQUAL(s.wide_width(), 12U);
+}
+
+// A clone carries the tier, not just the narrow rows, and shares no storage with its source.
+BOOST_AUTO_TEST_CASE(a_clone_carries_the_wide_tier) {
+    constexpr size_t kInline = 6;
+    constexpr size_t kBound = 10;
+    Store s(kInline, kTinyChunkRows, kBound);
+    for (size_t i = 0; i < 40; ++i) {
+        s.push_back(term_of_width(i, i % 4 == 0 ? kBound : kInline));
+    }
+    BOOST_REQUIRE_EQUAL(s.wide_size(), 10U);
+
+    const auto copy = s.clone();
+    BOOST_CHECK_EQUAL(copy->wide_size(), s.wide_size());
+    BOOST_CHECK_EQUAL(copy->inline_width(), s.inline_width());
+    BOOST_CHECK_EQUAL(copy->wide_width(), s.wide_width());
+    for (size_t i = 0; i < s.size(); ++i) {
+        BOOST_TEST_INFO("row " << i);
+        BOOST_CHECK(copy->row(i) == s.row(i));
+    }
+    // Restriding the copy must not disturb the original's tier.
+    copy->restride_to_bound();
+    BOOST_CHECK_EQUAL(copy->wide_size(), 0U);
+    BOOST_CHECK_EQUAL(s.wide_size(), 10U);
+    for (size_t i = 0; i < s.size(); ++i) {
+        BOOST_TEST_INFO("row " << i);
+        BOOST_CHECK(copy->row(i) == s.row(i));
+    }
 }

--- a/cpp/tests/operator_index_tests.cpp
+++ b/cpp/tests/operator_index_tests.cpp
@@ -14,10 +14,13 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <array>
+#include <bit>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "monoprop/TypeAliases.h"
@@ -221,4 +224,235 @@ BOOST_AUTO_TEST_CASE(find_batch_on_empty_store_is_all_missing) {
     for (size_t i = 0; i < keys.size(); ++i) {
         BOOST_TEST(out[i] == Store::kNotFound);
     }
+}
+
+namespace {
+
+// The smallest legal chunk: 64 rows, so a few hundred rows cross several boundaries. Production sizes
+// its chunks from the store's height and tops out at Store::kMaxRowsPerChunk, which no unit test can
+// afford to cross.
+constexpr size_t kTinyChunkRows = 64;
+constexpr size_t kBoundaryTestRows = 200;
+
+// Distinct terms, with the four-position ones landing on and around the chunk boundaries so the spill
+// path is exercised exactly where a row changes chunk.
+auto boundary_term(size_t i) -> MSet {
+    const size_t a = i % 61;
+    const size_t b = (i * 7) % 59;
+    const size_t c = (i * 13) % 53;
+    VecZ pos{a};
+    if (b != a) {
+        pos.push_back(b);
+    }
+    if (c != a && c != b) {
+        pos.push_back(c);
+    }
+    const size_t off = i % kTinyChunkRows;
+    if (off == 0 || off == 1 || off == kTinyChunkRows - 1) {
+        for (size_t extra = 17; extra < 2 * N; ++extra) {
+            if (extra != a && extra != b && extra != c) {
+                pos.push_back(extra);
+                break;
+            }
+        }
+    }
+    std::sort(pos.begin(), pos.end());
+    return bs(pos);
+}
+
+auto fill_boundary_store(Store &s) -> void {
+    s.grow_rows_geometric(kBoundaryTestRows);
+    for (size_t i = 0; i < kBoundaryTestRows; ++i) {
+        s.set(i, boundary_term(i));
+    }
+}
+
+} // namespace
+
+// Every read path has to keep working when the row it wants is in a different chunk from the one before
+// it -- and a row must never straddle, or the span row_positions() hands out would run off the end of a
+// chunk into unrelated memory.
+BOOST_AUTO_TEST_CASE(chunked_rows_read_back_across_chunk_boundaries) {
+    Store s(3, kTinyChunkRows); // inline width 3, so the boundary rows spill
+    fill_boundary_store(s);
+    BOOST_REQUIRE_GT(kBoundaryTestRows, 3 * kTinyChunkRows); // really is multi-chunk
+    BOOST_REQUIRE_GT(s.overflow_size(), 0U);                 // and really does spill
+
+    for (size_t i = 0; i < kBoundaryTestRows; ++i) {
+        BOOST_TEST_INFO("row " << i);
+        const MSet want = boundary_term(i);
+        BOOST_CHECK(s.row(i) == want);
+        BOOST_CHECK_EQUAL(s.popcount(i), want.count());
+
+        std::vector<size_t> seen;
+        s.for_each_position(i, [&](size_t b) { seen.push_back(b); });
+        std::vector<size_t> expected;
+        for (size_t b = want.find_first(); b < want.size(); b = want.find_next(b)) {
+            expected.push_back(b);
+        }
+        BOOST_CHECK_EQUAL_COLLECTIONS(seen.begin(), seen.end(), expected.begin(), expected.end());
+
+        // An inline row's span is the row and nothing more, so it lies inside one chunk.
+        const auto rp = s.row_positions(i);
+        if (rp.inlined()) {
+            BOOST_CHECK_EQUAL(rp.pos.size(), want.count());
+            MSet rebuilt;
+            for (const auto b : rp.pos) {
+                rebuilt.set(b);
+            }
+            BOOST_CHECK(rebuilt == want);
+        }
+        else {
+            BOOST_CHECK_GT(want.count(), 3U); // only a spilled row has no span
+        }
+    }
+}
+
+// The index has to keep finding rows that moved chunk, both by value and through the batch pipeline:
+// a chunk lookup off by a row would confirm against a neighbour.
+BOOST_AUTO_TEST_CASE(the_index_finds_rows_in_every_chunk) {
+    Store s(3, kTinyChunkRows);
+    fill_boundary_store(s);
+    for (size_t i = 0; i < kBoundaryTestRows; ++i) {
+        s.emplace(boundary_term(i), i);
+    }
+
+    std::vector<MSet> keys;
+    std::vector<size_t> want;
+    for (size_t i = 0; i < kBoundaryTestRows; ++i) {
+        keys.push_back(boundary_term(i));
+        want.push_back(i);
+        keys.push_back(bs({0, 1, 2, 4, 6, 8})); // absent at inline width 3: a spilled query
+        want.push_back(Store::kNotFound);
+    }
+    std::vector<size_t> out(keys.size(), 424242);
+    s.find_batch(keys.data(), keys.size(), out.data());
+    for (size_t q = 0; q < keys.size(); ++q) {
+        BOOST_TEST_INFO("query " << q);
+        const auto scalar = s.find(keys[q]);
+        BOOST_CHECK_EQUAL(out[q], scalar ? *scalar : Store::kNotFound);
+        if (want[q] != Store::kNotFound) {
+            BOOST_CHECK_EQUAL(out[q], want[q]);
+        }
+        else {
+            BOOST_CHECK_EQUAL(out[q], Store::kNotFound);
+        }
+    }
+}
+
+// The chunk length is a storage decision and nothing else: the same writes must produce the same store,
+// row for row, at 64 rows per chunk and at the production ceiling of 2^18.
+BOOST_AUTO_TEST_CASE(chunk_size_does_not_change_the_store) {
+    Store tiny(3, kTinyChunkRows);
+    Store production(3, Store::kMaxRowsPerChunk);
+    fill_boundary_store(tiny);
+    fill_boundary_store(production);
+
+    BOOST_REQUIRE_EQUAL(tiny.size(), production.size());
+    BOOST_CHECK_EQUAL(tiny.overflow_size(), production.overflow_size());
+    for (size_t i = 0; i < tiny.size(); ++i) {
+        BOOST_TEST_INFO("row " << i);
+        BOOST_CHECK(tiny.row(i) == production.row(i));
+        BOOST_CHECK_EQUAL(tiny.popcount(i), production.popcount(i));
+        const auto rp = production.row_positions(i);
+        const auto tp = tiny.row_positions(i);
+        BOOST_CHECK_EQUAL(tp.inlined(), rp.inlined());
+        if (rp.inlined()) {
+            BOOST_CHECK_EQUAL_COLLECTIONS(tp.pos.begin(), tp.pos.end(), rp.pos.begin(), rp.pos.end());
+        }
+    }
+}
+
+// The chunk length a store of a given height asks for: a quarter of the height rounded down to a power
+// of two, clamped to [2^12, 2^18].
+BOOST_AUTO_TEST_CASE(chunk_rows_are_selected_from_the_row_count) {
+    const std::vector<std::pair<size_t, size_t>> table = {
+        {0, Store::kMinRowsPerChunk},
+        {1, Store::kMinRowsPerChunk},
+        {Store::kMinRowsPerChunk * 4 - 1, Store::kMinRowsPerChunk},
+        {Store::kMinRowsPerChunk * 4, Store::kMinRowsPerChunk},
+        {Store::kMinRowsPerChunk * 8, Store::kMinRowsPerChunk * 2},
+        {1U << 20U, Store::kMaxRowsPerChunk},
+        {9'259'094, Store::kMaxRowsPerChunk},
+    };
+    for (const auto &[rows, want] : table) {
+        BOOST_TEST_INFO("rows " << rows);
+        BOOST_CHECK_EQUAL(Store::chunk_rows_for_rows(rows), want);
+    }
+    // Every length is a power of two and a multiple of 64, so a 64-row window never straddles a chunk.
+    for (size_t rows = 1; rows < (size_t{1} << 22U); rows *= 3) {
+        const size_t c = Store::chunk_rows_for_rows(rows);
+        BOOST_TEST_INFO("rows " << rows);
+        BOOST_CHECK(std::has_single_bit(c));
+        BOOST_CHECK_EQUAL(c % 64, 0U);
+        // The bound the selector exists for: the tail is under a quarter of the store, or under one
+        // minimum chunk while the store is smaller than four of those.
+        BOOST_CHECK_LT(c, std::max(Store::kMinRowsPerChunk + 1, rows / 4 + 1));
+    }
+}
+
+// The chunk length follows the store's height as it grows, because nobody can tell it that height up
+// front: the propagator reserves the initial operator's size, a handful of terms even for a run ending
+// in millions. Read through slack_bytes(), which is (capacity - size) * stride.
+BOOST_AUTO_TEST_CASE(the_chunk_length_follows_the_row_count) {
+    constexpr size_t kStrideBytes = 4 * sizeof(Store::PosT); // 1 popcount slot + 3 inline positions
+
+    // A store nobody reserved holds nothing at all, and takes the floor on its first growth.
+    Store s(3);
+    BOOST_CHECK_EQUAL(s.memory_bytes(), 0U);
+    BOOST_CHECK_EQUAL(s.slack_bytes(), 0U);
+    s.grow_rows_geometric(100);
+    BOOST_CHECK_EQUAL(s.slack_bytes(), (Store::kMinRowsPerChunk - 100) * kStrideBytes);
+
+    // Rows written before a migration read back through it: the geometry moves, the rows do not.
+    for (size_t i = 0; i < 100; ++i) {
+        s.set(i, boundary_term(i));
+    }
+    s.grow_rows_geometric(8 * Store::kMinRowsPerChunk - 100);
+    BOOST_CHECK_EQUAL(Store::chunk_rows_for_rows(s.size()), Store::kMinRowsPerChunk * 2);
+    BOOST_CHECK_EQUAL(s.slack_bytes() % (Store::kMinRowsPerChunk * 2 * kStrideBytes), 0U);
+    BOOST_CHECK_LE(s.slack_bytes(), Store::kMinRowsPerChunk * 2 * kStrideBytes);
+    for (size_t i = 0; i < 100; ++i) {
+        BOOST_TEST_INFO("row " << i);
+        BOOST_CHECK(s.row(i) == boundary_term(i));
+    }
+
+    // A forced length never moves, whatever the store grows to.
+    Store pinned(3, kTinyChunkRows);
+    pinned.grow_rows_geometric(64 * kTinyChunkRows);
+    BOOST_CHECK_EQUAL(pinned.slack_bytes(), 0U);
+
+    // A clone of a store that never grew is empty too, and one of a grown store keeps its geometry.
+    BOOST_CHECK_EQUAL(Store(3).clone()->memory_bytes(), 0U);
+    BOOST_CHECK_EQUAL(s.clone()->slack_bytes(), s.slack_bytes());
+    BOOST_CHECK_EQUAL(s.clone()->memory_bytes(), s.memory_bytes());
+}
+
+// Growth appends chunks instead of reallocating, so the store never holds more spare than one chunk's
+// tail, and the pool's mapping bounds the chunks it has handed out.
+BOOST_AUTO_TEST_CASE(chunked_growth_bounds_the_slack_by_one_chunk) {
+    Store s(3, kTinyChunkRows);
+    fill_boundary_store(s);
+    const size_t stride_bytes = 4 * sizeof(Store::PosT);
+    BOOST_CHECK_LT(s.slack_bytes(), kTinyChunkRows * stride_bytes);
+    BOOST_CHECK_GE(s.pool_mapped_bytes(), s.memory_bytes() - s.overflow_size() * 64);
+    BOOST_CHECK_LE(s.pool_free_chunk_bytes(), s.pool_mapped_bytes());
+
+    // A row that lands exactly on a boundary leaves no slack at all.
+    Store exact(3, kTinyChunkRows);
+    exact.grow_rows_geometric(2 * kTinyChunkRows);
+    BOOST_CHECK_EQUAL(exact.slack_bytes(), 0U);
+    // And one row past it costs one chunk, not one reallocation of everything.
+    exact.grow_rows_geometric(1);
+    BOOST_CHECK_EQUAL(exact.slack_bytes(), (kTinyChunkRows - 1) * stride_bytes);
+
+    // A clone takes its own chunks: writing through one must not be visible in the other.
+    const auto copy = s.clone();
+    BOOST_REQUIRE_EQUAL(copy->size(), s.size());
+    for (size_t i = 0; i < s.size(); ++i) {
+        BOOST_TEST_INFO("row " << i);
+        BOOST_CHECK(copy->row(i) == s.row(i));
+    }
+    s.set(65, bs({0, 2, 4})); // a row in the second chunk
+    BOOST_CHECK(copy->row(65) == boundary_term(65));
 }

--- a/cpp/tests/operator_index_tests.cpp
+++ b/cpp/tests/operator_index_tests.cpp
@@ -560,6 +560,13 @@ BOOST_AUTO_TEST_CASE(a_store_restrides_once_when_the_wide_tier_grows_past_the_th
         fat.emplace(want.back(), i);
     }
     BOOST_REQUIRE(fat.should_restride());
+    // What the index answered before the layout moved. term_of_width repeats a term every 64 rows, so
+    // these are not all distinct -- which is beside the point: the claim is that the index answers
+    // exactly as it did, whatever it answered.
+    std::vector<size_t> found_before;
+    for (size_t i = 0; i < kRows; ++i) {
+        found_before.push_back(fat.find(want[i]).value_or(Store::kNotFound));
+    }
 
     fat.restride_to_bound();
     BOOST_CHECK_EQUAL(fat.restrides(), 1U);
@@ -575,7 +582,7 @@ BOOST_AUTO_TEST_CASE(a_store_restrides_once_when_the_wide_tier_grows_past_the_th
         BOOST_TEST_INFO("row " << i);
         BOOST_CHECK(fat.row(i) == want[i]);
         BOOST_CHECK_EQUAL(fat.popcount(i), i % 10 == 0 ? kBound : kInline);
-        BOOST_CHECK(fat.find(want[i]) == std::optional<size_t>{i});
+        BOOST_CHECK_EQUAL(fat.find(want[i]).value_or(Store::kNotFound), found_before[i]);
     }
     // A restride is idempotent, and a store built at its bound has no tier to begin with.
     fat.restride_to_bound();

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -44,6 +44,61 @@ larger `lower_atol` (see [Truncation and cutoffs](/features/cutoff)).
 export monoprop_NUM_THREADS=8
 ```
 
+### Where the operator's bytes are
+
+`operator_memory_breakdown()` names the resident bytes of one rank's operator. `total_bytes()` sums
+the fields that are live at quiescence; the `d_` keys are counts, subsets of a field, or quantities
+no resting field can hold, so folding one into the total would double-count.
+
+The row store and the anticommutation index's dense columns are held as fixed-size chunks taken from
+a pool, not as vectors: growth appends a chunk, nothing is copied, and the only slack is the tail of
+the last chunk. Four keys describe that storage. `d_terms_slack_bytes` is that tail.
+`d_pool_mapped_bytes` is what the pools have *mapped* -- a pool maps whole arenas and keeps one as
+long as a single chunk in it is live, so it sits at or above what the chunk-counting fields price,
+and `d_pool_free_chunk_bytes` is the part of it not currently handed out. Those bytes are faulted
+only as they are written, but the mapping is what the kernel's high-water mark is charged for once
+they have been, which is why the ledger's total can sit below the resident set with nothing missing
+from any named field.
+
+`d_row_wide_rows`, `d_row_inline_width` and `d_row_restrides` describe the row layout. A row is a
+popcount slot followed by its set positions, at one width paid for by every row; rows wider than that
+but still within the cutoff's structural bound go to a second tier at a fixed wider stride, and rows
+over the bound to a lossless side-map. The width is predicted from the model, so a wrong guess costs
+one *restride* -- the store re-lays every row at the bound between gates, keeping every row index --
+and never a wrong answer. A nonzero `d_row_restrides` says the prediction was too narrow for this
+model; a wide-row count that is a large share of the term count says the same before it happens.
+
+`d_op_coeffs_slack_bytes` is the most capacity the coefficient array held beyond its live rows at any
+point in the last [propagate][monoprop.monomial_propagator.MonomialPropagator.propagate] or
+[build_graph][monoprop.monomial_propagator.MonomialPropagator.build_graph] call. The array grows at
+the row store's own 1.5x policy and is shrunk to fit when the call ends, which is the only moment a
+caller can read the ledger -- so it is reported as a high-water mark taken at the growth sites rather
+than as a measurement of the array as it stands, which would always be 0. Across partitions the marks
+are summed rather than maxed: the partitions grow together within a call, so the sum is the figure a
+per-process footprint wants, and it errs high.
+
+### Peak memory of large runs: pin glibc's `mmap` threshold
+
+Every gate allocates and frees a few large transient buffers: the records it stages, sends, receives
+and answers. glibc's allocator reacts to the first free of such a buffer by raising its dynamic `mmap`
+threshold (up to 32 MiB) and its trim threshold, so from then on the widest gate's transients are
+served from the heap and kept on free lists the allocator cannot return to the kernel. On a 250 M-term
+Hubbard run that retention is about a fifth of the resident set. Pinning the threshold disables the
+escalation, so every transient above it is a private mapping that is unmapped on free:
+
+```bash
+export GLIBC_TUNABLES=glibc.malloc.mmap_threshold=1048576   # 1 MiB
+mpirun -x GLIBC_TUNABLES ...                                # MPI ranks must inherit it
+```
+
+Measured on a 16-core workstation at 250 M terms (paired interleaved repetitions): peak resident
+high-water mark 0.95x in-process with 16 partitions and 0.91x (ranks summed) at 4 ranks x 4
+partitions, for about 1 % more wall time; a 128 KiB threshold takes a further 2 % of memory for 2-4 %
+more time. The cost is page faults on the re-mapped transients, so the setting pays only when a gate's
+compute amortises them: use it at or above ~10^8 terms with several partitions, and not on small
+single-core runs, where it costs ~20 % time. Results are bit-identical either way -- this changes
+where bytes live, not what is computed.
+
 ## Placement report
 
 Building a propagator writes one `COMMPLACE` line per rank to stderr, naming the

--- a/src/monoprop/bindings/binder.h
+++ b/src/monoprop/bindings/binder.h
@@ -271,7 +271,13 @@ auto bind_monomial_propagator(nb::module_ &mod) -> void {
                                              {"d_invidx_dense_columns", b.inverted_index_dense_columns},
                                              {"d_terms_slack_bytes", b.operator_terms_slack_bytes},
                                              {"d_state_coeffs_nonzero", b.state_coeffs_nonzero},
-                                             {"d_init_operator_entries", b.init_operator_entries}};
+                                             {"d_init_operator_entries", b.init_operator_entries},
+                                             {"d_op_coeffs_slack_bytes", b.op_coeffs_slack_bytes},
+                                             {"d_row_wide_rows", b.row_wide_rows},
+                                             {"d_row_inline_width", b.row_inline_width},
+                                             {"d_row_restrides", b.row_restrides},
+                                             {"d_pool_mapped_bytes", b.pool_mapped_bytes},
+                                             {"d_pool_free_chunk_bytes", b.pool_free_chunk_bytes}};
     });
 
     // The graph does not partition: its arrays are indexed by the flat world, so these grow with a P

--- a/tests/test_monoprop_smoke.py
+++ b/tests/test_monoprop_smoke.py
@@ -174,6 +174,30 @@ _GRAPH_DIAGNOSTIC_KEYS = (
     "d_occupied_slots",
     "d_cross_rank_endpoints",
 )
+_OPERATOR_LEDGER_KEYS = (
+    "operator_terms_bytes",
+    "op_coeffs_bytes",
+    "state_coeffs_bytes",
+    "indexing_bytes",
+    "init_operator_bytes",
+    "initial_state_bytes",
+    "inverted_index_bytes",
+    "matched_scratch_bytes",
+)
+_OPERATOR_DIAGNOSTIC_KEYS = (
+    "d_invidx_dense_bytes",
+    "d_invidx_sparse_bytes",
+    "d_invidx_dense_columns",
+    "d_terms_slack_bytes",
+    "d_state_coeffs_nonzero",
+    "d_init_operator_entries",
+    "d_op_coeffs_slack_bytes",
+    "d_row_wide_rows",
+    "d_row_inline_width",
+    "d_row_restrides",
+    "d_pool_mapped_bytes",
+    "d_pool_free_chunk_bytes",
+)
 
 
 @parametrize_with_cases(
@@ -214,3 +238,37 @@ def test_graph_memory_breakdown_keys_and_totals(problem, serial_comm):
     assert breakdown["d_occupied_slots"] <= breakdown["d_slot_records"]
     assert breakdown["d_occupied_slots"] <= breakdown["d_cross_rank_endpoints"]
     assert breakdown["d_slot_record_bytes"] <= breakdown["cross_rank_bytes"]
+
+
+@parametrize_with_cases(
+    "problem", cases=CasesFermionicProblem, has_tag="has_commutator_data"
+)
+def test_operator_memory_breakdown_keys_and_totals(problem, serial_comm):
+    """The operator ledger is the same measurement contract as the graph one."""
+    monomial_circuit = problem.monomial_circuit
+    core = _make_bound_core(problem, serial_comm, schrodinger=False)
+    _evolve_bound_core(core, monomial_circuit)
+
+    breakdown = core.operator_memory_breakdown()
+
+    assert set(breakdown) == {
+        *_OPERATOR_LEDGER_KEYS,
+        "total_bytes",
+        *_OPERATOR_DIAGNOSTIC_KEYS,
+    }
+
+    # total_bytes() is the live-at-quiescence figure: the d_ keys are subsets or counts.
+    assert breakdown["total_bytes"] == sum(breakdown[k] for k in _OPERATOR_LEDGER_KEYS)
+    assert breakdown["total_bytes"] == core.operator_memory_bytes()
+    assert breakdown["total_bytes"] > 0
+
+    # The pools map whole arenas, so the free part is a part of the mapping.
+    assert breakdown["d_pool_free_chunk_bytes"] <= breakdown["d_pool_mapped_bytes"]
+    # The chunked row store's slack is the tail of one chunk, so it cannot exceed the store.
+    assert breakdown["d_terms_slack_bytes"] <= breakdown["operator_terms_bytes"]
+    # A high-water mark over the call just made, and a subset of the array it breaks down. Growth is
+    # bounded by the 1.5x policy, so the peak stays under the array itself.
+    assert breakdown["d_op_coeffs_slack_bytes"] <= breakdown["op_coeffs_bytes"]
+    # The rows in the wide tier are rows of the store, and the inline width is a slot count.
+    assert breakdown["d_row_wide_rows"] <= core.size()
+    assert 1 <= breakdown["d_row_inline_width"] <= 32


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Main's term store is one contiguous, geometrically-grown array per operator: every restride copies
the whole store, and every row is sized for the worst case a fixed width has to cover. This PR
replaces that array with a pooled, chunked one (`ChunkedArray.h`) that rows and the inverted-index
columns both sit on, so growth allocates a new chunk instead of copying the store, and a two-tier
row layout (inline + wide) sizes each row from the model's own cutoff bound instead of one width
that fits every row.

The change is storage only. Main's ~290-line open-addressing hash index (`Slot`, `Table`, `find*`,
`bulk_insert*`, `emplace`, `for_each`, ...) is carried over unchanged behind the new storage; row
indices are preserved across every restride (asserted directly, not assumed); and the inverted-index
fold stays exact by associativity (it was already blocked on main). The memory ledger gains
diagnostic keys for the pool and the coefficient/row slack.

This is PR 1 of 7 in a stack on `origin/main`. It is the base of the stack (no predecessor). The
next PR (`perf/stack-2-router`) adds a single GF(2)-linear rank router and does not touch storage.

## Changes

**Engine**
- `cpp/monoprop/detail/operator/ChunkedArray.h` (new, 557 lines): a pooled chunked array with
  in-place restride, shared by term rows and inverted-index columns.
- `cpp/monoprop/detail/operator/OperatorIndex.h`: rows and the wide tier moved onto `ChunkedArray`;
  `rechunk_`/`restride_to_bound` re-lay rows in place and preserve every row index. Main's hash
  index is untouched apart from the mechanical `&rows_[i*stride_]` → `rows_.at(i)` swap.
- `cpp/monoprop/detail/operator/InvertedIndex.h`: dense columns moved onto pooled chunks; the
  blocked XOR fold (`combine_columns_block`) is kept exact; the density histogram is dropped.
- `cpp/monoprop/detail/operator/MPOperator.h`: `reserve_coeffs_geometric` grows coefficients at
  1.5×, at the row store's own policy; new ledger diagnostics for pool and slack bytes.
- `cpp/include/monoprop/MonomialPropagator.h` / `.inl`: `predicted_inline_width_` and
  `follow_cutoff_bound_` size each row's tier from the model (Majorana: bound rounded down to even
  for an even-parity initial operator; Pauli: 0.79× bound); the store restrides between gates.
- `cpp/monoprop/detail/evolution/CosineRecompute.h`, `.../layer_build/Scan.h`: the blocked fold's
  pivot pointer moves inside the block, which chunking a column requires; no other behavior change.
- `src/monoprop/bindings/binder.h`: expose the new ledger keys.

**Tests**
- `cpp/tests/chunked_array_tests.cpp` (new, 306 lines): chunk sizing, restride, pool accounting.
- `cpp/tests/operator_index_tests.cpp`, `inverted_index_tests.cpp`, `mp_operator_tests.cpp`:
  storage/restride/ledger cases, including `dense_columns_fold_identically_across_chunk_boundaries`
  and `make_fold_cache_is_blocked_and_bit_identical_across_chunk_sizes` (chunked vs single-piece,
  `BOOST_CHECK_EQUAL_COLLECTIONS`).
- `tests/test_monoprop_smoke.py`: `test_operator_memory_breakdown_keys_and_totals` pins the ledger
  key set and its invariants (e.g. `d_pool_free_chunk_bytes <= d_pool_mapped_bytes`).
- `cpp/tests/README.md`: "Operator store" section updated for the new files.

**Docs**
- `docs/content/docs/features/parallelism.mdx`: the new ledger key paragraphs and the
  `mmap_threshold` recipe.

## Measurements

Bit-identical to origin/main c5e88c8 (raw coefficient bits, positional mode, gate
record md5 `32fe8289bf0d2acacac51e54d3fb5d98`). A positional gate is the right one for this level:
row indices are unchanged by any restride, which the storage half of `operator_index_tests.cpp`
asserts directly (the value-keyed hash index answers exactly as it did before a restride).

Paired A/B, 3 interleaved reps against origin/main c5e88c8, ratios only:

| rung | time st1/mainB | peak RSS (kernel) st1/mainB |
| --- | ---: | ---: |
| L1-hubbard | 1.006 | 0.887 |
| L1-pauli | 1.021 | 0.860 |
| M2a-hubbard | 0.991 | 0.948 |

Time is within this box's noise floor (±1%) on every rung. The peak effect is size-dependent, and
this PR states it rather than quoting the best number: L1 ≈ 0.88–0.89, M2a ≈ 0.958 (measured
downstream in PR 2's and PR 3's ladders, unchanged there since neither touches storage), and at
250 M terms (L2b, 4 ranks × 4 partitions) the ranks-summed peak is 0.998 — the store's own
gain is real (`bytes/term` there is 0.906) but is mostly eaten by pool mapping and coefficient slack
at that size (`d_pool_mapped_bytes` 6488 MiB vs. terms+inverted-index 5019 MiB;
`d_op_coeffs_slack_bytes` 946 MiB). `bytes/term`, the size-independent figure, stays a clear win at
every size measured: 0.878 / 0.827 / 0.931 / 0.906.

## Notes for reviewers

- `indexing_bytes` keeps main's meaning here (the store object plus the hash table); it is not
  redefined to the term-table size until PR 4.
- No key array, `key_of_row`/`key_of_positions`, `join_tag` or `RowBlock` land in this PR — those
  are PR 4's, and `OperatorIndex.h` deliberately does not include `detail/mpi/Routing.h` yet.
- The optional `row_block` private helper (to hoist the shift/mask on `rows_.at(i)`) is not added:
  it was conditional on M2a costing more than 3% of time, which it did not (0.991 above), and adding
  it now would import PR 4's shape early.
- `TermLookup.h`, the `insert_absent_terms` `KeyFn` drop, `GateScratch.h`/`d_gate_*` counters, and
  `MemProf`/`TimeProf` are out of scope here — PR 4 and PR 5 respectively, or (diagnostics) not
  landing in the stack at all.
- One bug was found and fixed during implementation, in this PR's own test, not in the engine: an
  early version of the restride test asserted `find(want[i]) == i`, which is wrong once two rows
  hash to the same value (the synthetic generator repeats every 64 rows); it now compares what
  `find()` answered before and after the restride, which is the actual claim.
- Ledger: six new diagnostic keys land here — `d_op_coeffs_slack_bytes`, `d_pool_mapped_bytes`,
  `d_pool_free_chunk_bytes`, `d_row_wide_rows`, `d_row_inline_width`, `d_row_restrides`.
  `d_invidx_dense_columns` already existed on main and needed only the binder addition, not a new
  key.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable (n/a — the repository has no `CHANGELOG`)

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (claude-sonnet-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
