### PR TITLE
perf(mpi): ⚡ route every term through one GF(2)-linear router

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,4 +60,8 @@ just build-docs
   recipe in `docs/content/docs/building.mdx`.
 - Slow CTest startup in MPI builds is `MPI_Init` fabric probing; see
   `monoprop_TEST_EXCLUDE_MPI_FABRIC` in `cpp/tests/CMakeLists.txt`.
+- `monoprop_ROUTING=splitmix` (`detail/mpi/Routing.h`) is the live fallback for a rank count that is
+  not a power of two: the default GF(2)-linear routing has no XOR structure to use there and refuses
+  the geometry. It is bit-for-bit `monomial_hash % (R × S)`, and `routing_tests.cpp` pins both that
+  equivalence and the refusal.
 - Sanitizer rebuild and test:

--- a/cpp/include/monoprop/MonomialPropagator.h
+++ b/cpp/include/monoprop/MonomialPropagator.h
@@ -382,6 +382,8 @@ private:
     // Immutable after construction.
     Basis basis_{Basis::Majorana};
 
+    bool routing_coverage_reported_{false}; // report_routing_coverage_ speaks once per propagator
+
     // Intra-process partition runtime. Null ⇒ ordinary single-partition propagator; non-null ⇒ a partition facade
     // whose own mp_op_/graph_ are unused and every method fans out to the S partition propagators.
     std::unique_ptr<detail::partition::PartitionGroup<NumModes>> partition_group_;
@@ -462,6 +464,10 @@ private:
     auto run_gate_loop_(const std::vector<VecZ> &majoranas,
                         std::optional<size_t> only_rotate_len_k,
                         EvolutionFunc evolution_func) -> void;
+
+    // Do this call's generator shifts span log2(R)? If not, ranks receive nothing (routing::gf2_rank).
+    // Not beside check_routing_agreement: at construction the gate list does not exist yet.
+    auto report_routing_coverage_(const std::vector<VecZ> &majoranas) -> void;
 
     auto propagate_one_(const VecZ &gen_vec,
                         std::optional<size_t> only_rotate_len_k,

--- a/cpp/monoprop/detail/EnvConfig.h
+++ b/cpp/monoprop/detail/EnvConfig.h
@@ -14,17 +14,35 @@
 
 #pragma once
 
+#include <cerrno>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 
 // Single home for runtime environment configuration. Kept dependency-free by design, because it is
 // pulled into hot-path headers.
 //
 //   monoprop_NUM_THREADS        positive int (1..1e6), else ignored → num_threads
 //   monoprop_PARTITIONS         int N | "auto" | "off"; parsed where it is used (resolve_partition_count_)
+//   monoprop_ROUTING            "splitmix" | "linear" → routing_mode (see detail/mpi/Routing.h)
+//   monoprop_ROUTE_SEED         decimal uint64 basis seed → route_seed
+//   monoprop_COMMPROF           0|1 (off by default) → comm_profile
+//
+// The routing knobs and the report switch THROW on a malformed value instead of falling back: each
+// silently changes the transport or what is reported, so a typo that defaulted would stay invisible.
 
 namespace monoprop::config {
+
+class EnvConfigError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+enum class RoutingMode : std::uint8_t { Splitmix, Linear };
 
 namespace detail {
 
@@ -43,10 +61,67 @@ inline auto parse_positive_int(const char *text) -> std::optional<int> {
     return static_cast<int>(value);
 }
 
+[[noreturn]] inline auto reject_env(std::string_view name, const char *text, std::string_view expected) -> void {
+    throw EnvConfigError(std::string{name} + "=\"" + text + "\" is not " + std::string{expected}
+                         + "; correct it or leave the variable unset.");
+}
+
+// Unset and empty are both nullopt; a value that is present but unparseable throws.
+inline auto parse_uint64(std::string_view name, const char *text) -> std::optional<std::uint64_t> {
+    if (text == nullptr || *text == '\0') {
+        return std::nullopt;
+    }
+    // strtoull WRAPS a negative literal to a huge unsigned rather than failing, so '-' is rejected here.
+    if (std::string_view{text}.find('-') != std::string_view::npos) {
+        reject_env(name, text, "a decimal uint64");
+    }
+    errno = 0;
+    char *end = nullptr;
+    const unsigned long long value = std::strtoull(text, &end, 10);
+    if (end == text || *end != '\0' || errno == ERANGE) {
+        reject_env(name, text, "a decimal uint64");
+    }
+    return static_cast<std::uint64_t>(value);
+}
+
+// 0/1 only, so the variable reads the same way in a job script as in the docs.
+inline auto parse_bool(std::string_view name, const char *text) -> std::optional<bool> {
+    if (text == nullptr || *text == '\0') {
+        return std::nullopt;
+    }
+    const std::string_view value{text};
+    if (value == "0") {
+        return false;
+    }
+    if (value == "1") {
+        return true;
+    }
+    reject_env(name, text, "0 or 1");
+}
+
+inline auto parse_routing_mode(std::string_view name, const char *text) -> std::optional<RoutingMode> {
+    if (text == nullptr || *text == '\0') {
+        return std::nullopt;
+    }
+    const std::string_view value{text};
+    if (value == "splitmix") {
+        return RoutingMode::Splitmix;
+    }
+    if (value == "linear") {
+        return RoutingMode::Linear;
+    }
+    reject_env(name, text, "one of \"splitmix\" or \"linear\"");
+}
+
 } // namespace detail
 
 struct Settings {
     std::optional<int> num_threads;
+    std::optional<RoutingMode> routing_mode;
+    std::optional<std::uint64_t> route_seed;
+    // Report-only: one COMMPROF line per slot per propagate/build_graph call, naming the gate exchange's
+    // wire volume. Nothing reads it back.
+    bool comm_profile = false;
 };
 
 // Parse the environment once; the Settings are cached and shared across TUs.
@@ -54,6 +129,9 @@ inline auto get() -> const Settings & {
     static const Settings settings = [] {
         Settings s;
         s.num_threads = detail::parse_positive_int(std::getenv("monoprop_NUM_THREADS"));
+        s.routing_mode = detail::parse_routing_mode("monoprop_ROUTING", std::getenv("monoprop_ROUTING"));
+        s.route_seed = detail::parse_uint64("monoprop_ROUTE_SEED", std::getenv("monoprop_ROUTE_SEED"));
+        s.comm_profile = detail::parse_bool("monoprop_COMMPROF", std::getenv("monoprop_COMMPROF")).value_or(false);
         return s;
     }();
     return settings;

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -36,6 +36,7 @@
 #include "monoprop/detail/evolution/layer_build/Scan.h"
 #include "monoprop/detail/graph_encoding/MPGraphEncodingStorage.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
+#include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
 #include "monoprop/detail/operator/RowAccess.h"
 
@@ -580,6 +581,10 @@ auto build_layer(MPOperator<NumModes> &local_op,
     validate_only_rotate_len_k_(only_rotate_len_k, 2 * NumModes);
     const size_t my_rank = static_cast<size_t>(mpi::rank(comm));
     const size_t R = static_cast<size_t>(mpi::size(comm));
+    // R is the FLAT world (ranks x partitions); the router is what splits it back into the two levels.
+    // Hoisted here because mpi::geometry can reach the communicator, so it must never run per term.
+    const routing::Router router = router_for<NumModes>(comm);
+    assert(router.flat_world() == R);
     // Fused contraction runs at all rank counts (R>1 via the cross-rank half-rotation exchange).
     const bool use_fused = (fused_contract != nullptr);
     const auto cut_st = build_majorana_evolution_cutoff_state(atol, local_coeffs, upper_atol, param);
@@ -608,7 +613,7 @@ auto build_layer(MPOperator<NumModes> &local_op,
                                                        cut_st,
                                                        coeffs,
                                                        only_rotate_len_k,
-                                                       R,
+                                                       router,
                                                        my_rank,
                                                        /*capture_values=*/use_fused,
                                                        sweep_ptr,

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -604,9 +604,19 @@ auto build_layer(MPOperator<NumModes> &local_op,
     }
     assert(fused_scale_coeffs == nullptr || (local_coeffs && &local_coeffs->get() == fused_scale_coeffs));
 
-    FusedScanResult<NumModes> fused = [&] {
+    // An identity generator anticommutes with nothing: the scan returns on its empty fold-column set
+    // with no query, no cosine block and no coefficient swept, and run_exchange's three collectives per
+    // pass would carry no payload. The generator list is replicated, so skipping needs no agreement.
+    // (These are the identity monomials a gate whose every term fell below its atol expands to; a zero
+    // chemical potential alone contributes 60 of the 60-site Hubbard's 476 generators per Trotter
+    // layer.) No gate is merged: a no-op gate is simply not exchanged for, and the layer is still built.
+    const bool identity_gen = !gen.any();
+
+    FusedScanResult<NumModes> fused;
+    CosMask cos_all;
+    if (!identity_gen) {
         double *const sweep_ptr = fused_scale ? fused_scale_coeffs->data() : nullptr;
-        return with_algebra<NumModes>(basis, [&]<typename A>() {
+        fused = with_algebra<NumModes>(basis, [&]<typename A>() {
             return fused_find_and_collect<NumModes, A>(local_op,
                                                        gen,
                                                        cut_eval,
@@ -619,21 +629,19 @@ auto build_layer(MPOperator<NumModes> &local_op,
                                                        sweep_ptr,
                                                        cos_build);
         });
-    }();
-
-    CosMask cos_all;
-    if (fused.cos_blocks.size() == 1) {
-        // The serial scan produces a single cosine block set — take it wholesale.
-        cos_all = std::move(fused.cos_blocks[0]);
-    }
-    else {
-        // Cosine block sets are disjoint and ascending; concatenate in order.
-        for (const auto &block : fused.cos_blocks) {
-            cos_all.total_count += block.total_count;
-            cos_all.blocks.insert(cos_all.blocks.end(), block.blocks.begin(), block.blocks.end());
+        if (fused.cos_blocks.size() == 1) {
+            // The serial scan produces a single cosine block set — take it wholesale.
+            cos_all = std::move(fused.cos_blocks[0]);
         }
+        else {
+            // Cosine block sets are disjoint and ascending; concatenate in order.
+            for (const auto &block : fused.cos_blocks) {
+                cos_all.total_count += block.total_count;
+                cos_all.blocks.insert(cos_all.blocks.end(), block.blocks.begin(), block.blocks.end());
+            }
+        }
+        fused.cos_blocks = std::vector<CosMask>{};
     }
-    fused.cos_blocks = std::vector<CosMask>{};
 
     auto run = [&]<typename Sink>(Sink sink) -> std::shared_ptr<LayerCore> {
         LayerBuildEngine<NumModes, Sink> eng(local_op,
@@ -643,16 +651,21 @@ auto build_layer(MPOperator<NumModes> &local_op,
                                              matched_scratch,
                                              /*combined_size=*/local_op.store->size(),
                                              std::move(sink));
-        eng.run_exchange(/*is_leader_pass=*/true,
-                         std::move(fused.leader_queries),
-                         std::move(fused.leader_src),
-                         std::move(fused.leader_val),
-                         std::move(fused.leader_self));
-        eng.run_exchange(/*is_leader_pass=*/false,
-                         std::move(fused.follower_queries),
-                         std::move(fused.follower_src),
-                         std::move(fused.follower_val),
-                         std::move(fused.follower_self));
+        // LayerBuildEngine construction stays outside the test: its ctor sizes the caller-owned matched
+        // scratch, which is reported as matched_scratch_bytes, so skipping it would move that telemetry
+        // when a propagator's first gate is identity. The ctor is O(R).
+        if (!identity_gen) {
+            eng.run_exchange(/*is_leader_pass=*/true,
+                             std::move(fused.leader_queries),
+                             std::move(fused.leader_src),
+                             std::move(fused.leader_val),
+                             std::move(fused.leader_self));
+            eng.run_exchange(/*is_leader_pass=*/false,
+                             std::move(fused.follower_queries),
+                             std::move(fused.follower_src),
+                             std::move(fused.follower_val),
+                             std::move(fused.follower_self));
+        }
 
         return eng.finish(std::move(cos_all), out_cos);
     };

--- a/cpp/monoprop/detail/evolution/layer_build/Scan.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Scan.h
@@ -34,6 +34,7 @@
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
 #include "monoprop/detail/graph_encoding/MPGraphEncodingTypes.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
+#include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/InvertedIndex.h"
 #include "monoprop/detail/operator/MPOperator.h"
 
@@ -224,9 +225,9 @@ struct FusedScanResult {
 };
 
 // Classify, cut off and emit in one pass over the anticommuting terms. Queries go to the owner of
-// M'=M⊕G (hash%R; self at R==1) in ascending source-index order, so resolve and index assignment are
-// deterministic. `fused_scale_coeffs` (no length cap only; must alias coeffs.data()) scales every anticommuting
-// coeff in place by `fused_scale_cos`=cos(2·build_angle), so no cosine set is built and a hit's stored
+// M'=M⊕G (routing::Router; self at R==1) in ascending source-index order, so resolve and index
+// assignment are deterministic. `fused_scale_coeffs` (no length cap only; must alias coeffs.data()) scales every
+// anticommuting coeff in place by `fused_scale_cos`=cos(2·build_angle), so no cosine set is built and a hit's stored
 // value is post-cos (resolve recovers it via 1/cos).
 template <size_t NumModes, Algebra A>
 auto fused_find_and_collect(const MPOperator<NumModes> &op,
@@ -235,12 +236,14 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
                             const CutoffContext &cut_st,
                             const VecD &coeffs,
                             std::optional<size_t> only_rotate_len_k,
-                            size_t rank_count,
+                            const routing::Router &router,
                             size_t my_rank,
                             bool capture_values = false,
                             double *fused_scale_coeffs = nullptr,
                             double fused_scale_cos = 1.0) -> FusedScanResult<NumModes> {
     validate_only_rotate_len_k_(only_rotate_len_k, 2 * NumModes);
+    // The flat world the router indexes: R ranks x S partitions, which is what mpi::size reports.
+    const size_t rank_count = router.flat_world();
     const size_t gen_pop = gen.count();
     const auto ectx = A::make_gen_context(gen);
 
@@ -323,12 +326,13 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
                         size_t i,
                         double v_src,
                         bool is_follower) {
-            // Single rank: every partner is self-owned, skip the O(W) hash; multi-rank routes by owner.
-            // Must be the same function find_rank computes (MPIUtils.h) or a term is placed and queried
-            // on different ranks, which duplicates a row silently; mpi_utils_tests.cpp asserts it.
+            // Single rank: every partner is self-owned, skip the O(W) map; multi-rank routes by owner.
+            // The Router is the single authority and find_rank calls the same dest(), or a term is
+            // placed and queried on different ranks, which duplicates a row silently;
+            // mpi_utils_tests.cpp asserts the two agree.
             size_t r_prime = my_rank;
             if (rank_count != 1) {
-                r_prime = monomial_hash<NumModes>(dense) % rank_count;
+                r_prime = router.dest<NumModes>(dense);
             }
             if (r_prime == my_rank) {
                 (is_follower ? res.follower_self : res.leader_self).push(pos, phase);

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -144,6 +144,8 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
         return;
     }
 
+    check_routing_agreement(comm_); // a disagreement here would hang the first exchange, not corrupt it
+    const routing::Router router = router_for<NumModes>(comm_); // hoisted: geometry() reaches the comm
     const size_t num_ranks = static_cast<size_t>(mpi::size(comm_));
     const size_t my_rank = static_cast<size_t>(mpi::rank(comm_));
     MonomialList<NumModes> local_heisenberg_terms;
@@ -158,7 +160,7 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
             core_term = encoded_coeff;
             continue;
         }
-        if (my_rank == find_rank<NumModes>(majorana_bitset, num_ranks)) {
+        if (my_rank == find_rank<NumModes>(majorana_bitset, router)) {
             mp_op_.init_op_map[majorana_bitset] = encoded_coeff;
             local_heisenberg_terms.push_back(majorana_bitset);
         }
@@ -207,7 +209,7 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
     // The initial monomials are distinct, so emplace (insert-if-absent) is an assigning insert here. A row
     // index is a position in the kept subsequence, so the enumeration order below is load-bearing.
     const auto keep_if_owned = [&](const Monomial<NumModes> &mono) {
-        if (my_rank == find_rank<NumModes>(mono, num_ranks)) {
+        if (my_rank == find_rank<NumModes>(mono, router)) {
             mp_op_.append_term(mono);
             mp_op_.store->emplace(mono, i++);
         }
@@ -435,7 +437,7 @@ auto MonomialPropagator<NumModes>::apply_initial_operator_(const OperatorDict &o
         for_each_partition_([&](MonomialPropagator &s) { s.update_initial_operator(op_dict); });
         return {};
     }
-    const size_t num_ranks = static_cast<size_t>(mpi::size(comm_));
+    const routing::Router router = router_for<NumModes>(comm_); // hoisted: geometry() reaches the comm
     const size_t my_rank = static_cast<size_t>(mpi::rank(comm_));
 
     OperatorDict new_op;
@@ -445,7 +447,7 @@ auto MonomialPropagator<NumModes>::apply_initial_operator_(const OperatorDict &o
             core_term_ = algebra_encode_coeff<NumModes>(basis_, coeff, mono);
             continue;
         }
-        if (my_rank == find_rank<NumModes>(mono, num_ranks)) {
+        if (my_rank == find_rank<NumModes>(mono, router)) {
             const auto mono_indices = bitset_to_indices<NumModes>(mono);
             new_op[mono_indices] = coeff;
         }

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -144,7 +144,6 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
         return;
     }
 
-    check_routing_agreement(comm_); // a disagreement here would hang the first exchange, not corrupt it
     const routing::Router router = router_for<NumModes>(comm_); // hoisted: geometry() reaches the comm
     const size_t num_ranks = static_cast<size_t>(mpi::size(comm_));
     const size_t my_rank = static_cast<size_t>(mpi::rank(comm_));
@@ -229,6 +228,15 @@ MonomialPropagator<NumModes>::MonomialPropagator(const OperatorDict &initial_ope
     core_term_ = core_term;
 
     initialize_operator_caches_();
+
+    // LAST, after every validation this constructor can fail on: it is a collective, and a partition
+    // that throws while its peers are inside one poisons the in-process comm, so the caller is told the
+    // comm is poisoned instead of which setting was wrong. Deterministic errors (the schrodinger_cutoff
+    // ceiling above, the tolerance and mode-count checks) are raised by every partition, which is
+    // exactly the race -- tests/test_parameter_validation.py pins the message at S > 1. Placing it here
+    // still puts it before the first exchange, and seeding needs no agreement: it communicates nothing,
+    // so a rank that resolved a different router has merely claimed the wrong share when this throws.
+    check_routing_agreement(comm_); // a disagreement would hang the first exchange, not corrupt it
 }
 
 template <size_t NumModes>

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -251,6 +251,7 @@ MonomialPropagator<NumModes>::MonomialPropagator(const MonomialPropagator &other
       cutoff_type_(other.cutoff_type_),
       basis_change_(other.basis_change_),
       basis_(other.basis_),
+      routing_coverage_reported_(other.routing_coverage_reported_),
       partition_group_(other.partition_group_
                            ? std::make_unique<detail::partition::PartitionGroup<NumModes>>(*other.partition_group_)
                            : nullptr) {}
@@ -794,10 +795,49 @@ auto MonomialPropagator<NumModes>::propagate(const std::vector<VecZ> &majoranas,
 }
 
 template <size_t NumModes>
+auto MonomialPropagator<NumModes>::report_routing_coverage_(const std::vector<VecZ> &majoranas) -> void {
+    // One report per rank, so only its partition 0 speaks, and only once whatever the outcome.
+    if (routing_coverage_reported_ || comm_.shm_rank != 0) {
+        return;
+    }
+    routing_coverage_reported_ = true;
+    const routing::Router router = router_for<NumModes>(comm_);
+    if (!router.is_linear()) {
+        return; // splitmix: no subspace to fall short of
+    }
+    std::vector<uint64_t> shifts;
+    shifts.reserve(majoranas.size());
+    for (const auto &gate : majoranas) {
+        // An out-of-range index is build_evolve_result_'s to reject, gate by gate: converting the whole
+        // list up front would pre-empt that throw.
+        if (std::ranges::any_of(gate, [this](size_t i) { return i >= 2 * logical_num_modes_; })) {
+            return;
+        }
+        shifts.push_back(static_cast<uint64_t>(router.rank_shift<NumModes>(indices_to_bitset<NumModes>(gate))));
+    }
+    std::ranges::sort(shifts);
+    shifts.erase(std::ranges::unique(shifts).begin(), shifts.end());
+    const size_t span = routing::gf2_rank(shifts);
+    if (span >= router.linear_bits()) {
+        return;
+    }
+    // A warning, not a throw: every term still lands on one owner, they just do not cover the ranks.
+    const auto line = std::format("COMMROUTE rank={} linear_bits={} shift_rank={} shifts={} idle_ranks={}\n",
+                                  static_cast<size_t>(mpi::rank(comm_)) / router.partitions(),
+                                  router.linear_bits(),
+                                  span,
+                                  shifts.size(),
+                                  router.ranks() - (size_t{1} << span));
+    std::fputs(line.c_str(), stderr);
+    std::fflush(stderr);
+}
+
+template <size_t NumModes>
 template <typename EvolutionFunc>
 auto MonomialPropagator<NumModes>::run_gate_loop_(const std::vector<VecZ> &majoranas,
                                                   std::optional<size_t> only_rotate_len_k,
                                                   EvolutionFunc evolution_func) -> void {
+    report_routing_coverage_(majoranas);
     mp_op_.reset_op_coeffs_slack_hwm();
     // Serial per partition; parallelism comes from partitioning the operator across cores.
     for (size_t i = 0; i < majoranas.size(); ++i) {

--- a/cpp/monoprop/detail/mpi/CMakeLists.txt
+++ b/cpp/monoprop/detail/mpi/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
         "MPICompat.h"
         "MPIUtils.h"
         "PartitionBarrier.h"
+        "Routing.h"
         "ShmComm.h"
 )
 

--- a/cpp/monoprop/detail/mpi/HybridComm.h
+++ b/cpp/monoprop/detail/mpi/HybridComm.h
@@ -97,6 +97,8 @@ public:
     auto operator=(const HybridComm &) -> HybridComm & = delete;
 
     auto size() const -> int { return r_ * s_; }
+    auto ranks() const -> int { return r_; }
+    auto partitions() const -> int { return s_; }
     auto global_rank(int local_partition) const -> int { return mpi_rank_ * s_ + local_partition; }
 
     auto alltoall_counts(int local_partition, const int *send_counts /*[P]*/, int *recv_counts /*[P]*/) -> void {

--- a/cpp/monoprop/detail/mpi/MPICompat.cpp
+++ b/cpp/monoprop/detail/mpi/MPICompat.cpp
@@ -84,6 +84,20 @@ auto size(const Comm &comm) -> int {
 #endif
 }
 
+auto geometry(const Comm &comm) -> Geometry {
+    if (comm.kind == Comm::Kind::Shm) {
+        return {.ranks = 1, .partitions = comm.shm->size()};
+    }
+#ifdef monoprop_ENABLE_MPI
+    if (comm.kind == Comm::Kind::Hybrid) {
+        return {.ranks = comm.hyb->ranks(), .partitions = comm.hyb->partitions()};
+    }
+    return {.ranks = size(comm), .partitions = 1};
+#else
+    return {.ranks = 1, .partitions = 1};
+#endif
+}
+
 auto allreduce_sum_inplace(VecD &values, Comm comm) -> void {
     if (comm.kind == Comm::Kind::Shm) {
         comm.shm->allreduce_sum_inplace(comm.shm_rank, values.data(), values.size());

--- a/cpp/monoprop/detail/mpi/MPICompat.h
+++ b/cpp/monoprop/detail/mpi/MPICompat.h
@@ -91,6 +91,20 @@ inline auto finalize() -> void {}
 monoprop_EXPORT auto rank(const Comm &comm) -> int;
 monoprop_EXPORT auto size(const Comm &comm) -> int;
 
+/*!
+ * @brief How the flat world of size() is actually built: ranks * partitions.
+ *
+ * Routing needs the split, because an inter-rank message costs a network hop while an inter-partition
+ * one is a shared-memory copy -- size() alone cannot tell them apart. Exported because public template
+ * chains (routing::Router, find_rank) reach it from headers across the hidden-visibility boundary.
+ * Invariant: ranks * partitions == size() for every Kind.
+ */
+struct Geometry {
+    int ranks = 1;      //!< MPI ranks in the world.
+    int partitions = 1; //!< In-process partitions per rank.
+};
+monoprop_EXPORT auto geometry(const Comm &comm) -> Geometry;
+
 template <typename T>
 inline auto allreduce_sum(T local_val, Comm comm) -> T {
     if (comm.kind == Comm::Kind::Shm) {

--- a/cpp/monoprop/detail/mpi/MPIUtils.h
+++ b/cpp/monoprop/detail/mpi/MPIUtils.h
@@ -16,12 +16,15 @@
 
 #include <cstddef>
 #include <cstring>
+#include <format>
+#include <stdexcept>
 #include <vector>
 
 #include "monoprop/MPGraph.h"
 #include "monoprop/TypeAliases.h"
 #include "monoprop/core/Monomial.h"
 #include "monoprop/detail/mpi/MPICompat.h"
+#include "monoprop/detail/mpi/Routing.h"
 
 namespace monoprop::mpi_detail {
 
@@ -48,13 +51,75 @@ inline auto read_monomial_from_words(const VecZ &buffer, size_t start) -> Monomi
 
 namespace monoprop {
 
-// Stateless and identical on every rank, so all ranks agree on a term's owner without communication.
+/*!
+ * @brief The flat slot that owns `mono`: stateless and identical on every rank, so all ranks agree on
+ * a term's owner without communication.
+ *
+ * Goes through routing::Router::dest and nothing else -- this and Scan.h's query emission must return
+ * the same slot for the same monomial, and a divergence splits ownership silently. There is
+ * deliberately no rank-count overload: it would answer splitmix during a linear run, which is that
+ * split.
+ */
 template <size_t NumModes>
-auto find_rank(const Monomial<NumModes> &mono, const size_t n_ranks) -> size_t {
-    if (n_ranks == 0) {
-        return 0;
+auto find_rank(const Monomial<NumModes> &mono, const routing::Router &router) -> size_t {
+    return router.dest<NumModes>(mono);
+}
+
+//! @brief The router this communicator's geometry implies, honouring monoprop_ROUTING.
+template <size_t NumModes>
+inline auto router_for(const mpi::Comm &comm) -> routing::Router {
+    const auto geom = mpi::geometry(comm);
+    return routing::make_router<NumModes>(static_cast<size_t>(geom.ranks), static_cast<size_t>(geom.partitions));
+}
+
+//! @brief Participants resolved different routers; see check_routing_agreement.
+class RoutingDisagreement : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+/*!
+ * @brief Throw unless every participant resolves the SAME router.
+ *
+ * The failure mode if they do not is a hang, not a wrong answer: linear routing makes each rank post
+ * receives from the peers its own bits imply, so a rank whose monoprop_ROUTING or monoprop_ROUTE_SEED
+ * did not reach it waits forever on a peer that never sends. Turning that into an exception costs two
+ * allreduces, called once per propagator and never per gate.
+ *
+ * TWO independent digests, not one: allreduce_sum is the only collective in the tree, and a sum is not
+ * an equality test -- differing values can add up to mine*world. Both must agree, so a disagreement
+ * survives at ~2^-128 rather than ~2^-64. Partitions are in the digest because S enters Router::dest:
+ * two ranks differing only in S agree on the mode and the seed and still route apart.
+ */
+inline auto check_routing_agreement(const mpi::Comm &comm) -> void {
+    const auto world = static_cast<size_t>(mpi::size(comm));
+    if (world <= 1) {
+        return;
     }
-    return monomial_hash<NumModes>(mono) % n_ranks;
+    const auto geom = mpi::geometry(comm);
+    const auto parts = static_cast<uint64_t>(geom.partitions);
+    const auto linear = static_cast<uint64_t>(routing::linear_requested());
+    const uint64_t seed = routing::seed_from_env();
+    const auto digest = [&](uint64_t salt) {
+        return routing::mix64(routing::mix64(routing::mix64(salt ^ linear) ^ parts) ^ seed);
+    };
+    const auto agrees = [&](uint64_t mine) {
+        return mpi::allreduce_sum<uint64_t>(mine, comm) == mine * static_cast<uint64_t>(world);
+    };
+    // Both allreduces run on every participant: short-circuiting the second would itself deadlock.
+    const bool ok_first = agrees(digest(0x9E37'79B9'7F4A'7C15ULL));
+    const bool ok_second = agrees(digest(0xC2B2'AE3D'27D4'EB4FULL));
+    if (!ok_first || !ok_second) {
+        throw RoutingDisagreement(
+            std::format("routing configuration differs across the {} participants (this one: linear={}, "
+                        "partitions={}, seed={}). monoprop_ROUTING / monoprop_ROUTE_SEED must reach every rank "
+                        "identically -- under linear routing a disagreement deadlocks the exchange rather than "
+                        "corrupting it.",
+                        world,
+                        linear,
+                        parts,
+                        seed));
+    }
 }
 
 } // namespace monoprop

--- a/cpp/monoprop/detail/mpi/Routing.h
+++ b/cpp/monoprop/detail/mpi/Routing.h
@@ -1,0 +1,279 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "monoprop/core/Monomial.h"
+#include "monoprop/detail/EnvConfig.h"
+
+// The single home for "which flat slot owns this monomial". Two call sites must agree exactly -- Scan.h
+// emits queries by it, MonomialPropagator seeds the operator by it -- and a disagreement splits
+// ownership silently rather than crashing, so both go through Router and nothing else.
+//
+//     rank = fp & (R - 1)               fp = linear_hash(M); all log2(R) rank bits, so fanout is 1
+//     part = (fp >> log2 R) & (S - 1)   S a power of two: linear too, so a slot has ONE peer slot
+//          = mix64(fp) % S             otherwise: balance only
+//     flat = rank * S + part
+//
+// Linear or not is a switch and not a dial: the rank takes every bit of the linear hash or none of them.
+// None of them is the splitmix router, which is `monomial_hash % (R*S)` bit for bit, and R == 1 is that
+// case by construction. R > 1 must then be a power of two, or there is no XOR structure to route by and
+// the geometry is REJECTED (UnroutableGeometry) rather than silently falling back -- a fallback taken on
+// some ranks only is a deadlocked exchange.
+//
+// Knobs, parsed and validated in EnvConfig.h: monoprop_ROUTING (linear | splitmix), monoprop_ROUTE_SEED.
+// The derivation and what linear routing buys: docs/content/docs/features/parallelism.mdx, "Rank routing".
+
+namespace monoprop::routing {
+
+inline constexpr uint64_t kDefaultSeed = 0x5DEE'CE66'D0C6'2517ULL;
+
+/*!
+ * @brief A rank count linear routing cannot serve. Thrown at Router construction, not at the first
+ * term: the alternative is a silent fallback to splitmix on some ranks and a deadlocked exchange.
+ */
+class UnroutableGeometry : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+//! @brief splitmix64 finaliser: full avalanche, used for the seed and the non-power-of-two partition index.
+inline constexpr auto mix64(uint64_t x) noexcept -> uint64_t {
+    x += 0x9E37'79B9'7F4A'7C15ULL;
+    x = (x ^ (x >> 30)) * 0xBF58'476D'1CE4'E5B9ULL;
+    x = (x ^ (x >> 27)) * 0x94D0'49BB'1331'11EBULL;
+    return x ^ (x >> 31);
+}
+
+//! @brief The basis seed in force, from monoprop_ROUTE_SEED or kDefaultSeed.
+inline auto seed_from_env() -> uint64_t {
+    return config::get().route_seed.value_or(kDefaultSeed);
+}
+
+/*!
+ * @brief One 64-bit label per bit position (2 per mode). Deterministic from the seed alone, so every
+ * rank builds the same table with no communication -- the property find_rank's contract rests on.
+ */
+template <size_t NumBits>
+inline auto linear_basis() -> const std::array<uint64_t, NumBits> & {
+    static const auto table = [] {
+        std::array<uint64_t, NumBits> v{};
+        const uint64_t seed = seed_from_env();
+        for (size_t i = 0; i < NumBits; ++i) {
+            v[i] = mix64(mix64(seed) + (static_cast<uint64_t>(i) * 0x9E37'79B9'7F4A'7C15ULL));
+        }
+        return v;
+    }();
+    return table;
+}
+
+//! @brief The 64-bit image of a dense monomial: one label XOR per set bit.
+template <size_t NumBits>
+[[nodiscard]] inline auto linear_hash(const monoprop::Bitset<NumBits> &bits) noexcept -> uint64_t {
+    const auto &v = linear_basis<NumBits>();
+    uint64_t h = 0;
+    for (size_t i = bits.find_first(); i < NumBits; i = bits.find_next(i)) {
+        h ^= v[i];
+    }
+    return h;
+}
+
+/*!
+ * @brief The fingerprint of a term given as ascending positions -- the same map as linear_hash, so a
+ * packed row is never expanded into a bitset to be routed.
+ *
+ * `labels` is linear_basis<NumBits>().data(), bound once per gate by the caller so the per-term path
+ * never reaches the static-init guard. The map is GF(2)-linear: fp(M ^ G) == fp(M) ^ fp(G). It is NOT
+ * injective (2*NumModes bits into 64), so equal fingerprints are a prefilter and every match must be
+ * confirmed against the positions themselves.
+ */
+template <typename PosT>
+[[nodiscard]] [[gnu::always_inline]] inline auto fingerprint_positions(const uint64_t *labels,
+                                                                       const PosT *pos,
+                                                                       size_t k) noexcept -> uint64_t {
+    uint64_t h = 0;
+    for (size_t j = 0; j < k; ++j) {
+        h ^= labels[static_cast<size_t>(pos[j])];
+    }
+    return h;
+}
+
+/*!
+ * @brief GF(2) rank of a set of 64-bit vectors, by Gaussian elimination over the bit columns.
+ *
+ * The per-generator shifts must span at least linear_bits() dimensions or the reachable destinations
+ * form a strict subspace and 2^bits - 2^rank slots stay empty -- a balance failure, not a correctness
+ * one, so its caller (MonomialPropagator::report_routing_coverage_) warns rather than throws.
+ */
+[[nodiscard]] inline auto gf2_rank(std::vector<uint64_t> vectors) noexcept -> size_t {
+    size_t rank = 0;
+    for (size_t bit = 0; bit < 64 && rank < vectors.size(); ++bit) {
+        const uint64_t probe = uint64_t{1} << bit;
+        size_t pivot = vectors.size();
+        for (size_t i = rank; i < vectors.size(); ++i) {
+            if ((vectors[i] & probe) != 0) {
+                pivot = i;
+                break;
+            }
+        }
+        if (pivot == vectors.size()) {
+            continue;
+        }
+        std::swap(vectors[rank], vectors[pivot]);
+        for (size_t i = 0; i < vectors.size(); ++i) {
+            if (i != rank && (vectors[i] & probe) != 0) {
+                vectors[i] ^= vectors[rank];
+            }
+        }
+        ++rank;
+    }
+    return rank;
+}
+
+/*!
+ * @brief The term -> flat-slot map, in one of two states (the file header carries the formula).
+ * Trivially copyable and cheap to build; hold one per build_layer call rather than per term.
+ */
+class Router final {
+public:
+    //! @brief The only way to a linear router; throws UnroutableGeometry if `linear` and R is not 2^k.
+    template <size_t NumModes>
+    [[nodiscard]] static auto for_modes(size_t ranks, size_t partitions, bool linear) -> Router {
+        return Router{ranks, partitions, linear};
+    }
+
+    //! @brief The dense router: one flat world, full avalanche, no linear bits.
+    static constexpr auto splitmix(size_t flat_world) noexcept -> Router { return Router{flat_world, 1, false}; }
+
+    [[nodiscard]] constexpr auto ranks() const noexcept -> size_t { return ranks_; }
+    [[nodiscard]] constexpr auto partitions() const noexcept -> size_t { return parts_; }
+    [[nodiscard]] constexpr auto flat_world() const noexcept -> size_t { return flat_; }
+    //! @brief False for a splitmix router AND for R == 1, which has no rank bit to take: both route densely.
+    [[nodiscard]] constexpr auto is_linear() const noexcept -> bool { return linear_; }
+    /*!
+     * @brief Is the whole flat slot a GF(2)-linear function of the term -- linear routing with S a
+     * power of two? Then flat_shift(G) is defined and every slot has one peer slot per generator.
+     */
+    [[nodiscard]] constexpr auto is_flat_linear() const noexcept -> bool { return linear_ && parts_pow2_; }
+    //! @brief Rank bits read off the fingerprint: log2(R), or 0 when not linear. The span a generator
+    //! set must cover for every rank to be reachable.
+    [[nodiscard]] constexpr auto linear_bits() const noexcept -> size_t {
+        return linear_ ? static_cast<size_t>(std::countr_zero(ranks_)) : 0;
+    }
+    //! @brief Every bit the slot is linear in: log2(R) + log2(S) when flat-linear, else linear_bits().
+    [[nodiscard]] constexpr auto flat_linear_bits() const noexcept -> size_t {
+        return is_flat_linear() ? linear_bits() + parts_log2_ : linear_bits();
+    }
+
+    /*!
+     * @brief Flat destination slot in [0, flat_world) for a dense monomial. The branch is on a member,
+     * so it is perfectly predicted; the splitmix arm is bit-for-bit `monomial_hash % P`.
+     */
+    template <size_t NumModes>
+    [[nodiscard]] [[gnu::always_inline]] inline auto dest(const Monomial<NumModes> &mono) const noexcept -> size_t {
+        if (!linear_) {
+            return static_cast<size_t>(monomial_hash<NumModes>(mono) % flat_);
+        }
+        return dest_from_fingerprint(linear_hash<2 * NumModes>(mono));
+    }
+
+    /*!
+     * @brief The same slot from the term's fingerprint (linear routing only; asserted). This is the
+     * emit path: the partner's fingerprint is fp(M) ^ fp(G), so no dense form and no hash exist there.
+     */
+    [[nodiscard]] [[gnu::always_inline]] inline auto dest_from_fingerprint(uint64_t fp) const noexcept -> size_t {
+        assert(linear_ && "dest_from_fingerprint on a splitmix router: the fingerprint is not its map");
+        const size_t rank = static_cast<size_t>(fp & static_cast<uint64_t>(ranks_ - 1));
+        if (parts_ == 1) {
+            return rank;
+        }
+        if (parts_pow2_) {
+            return (rank << parts_log2_) | static_cast<size_t>((fp >> linear_bits()) & parts_mask_);
+        }
+        return (rank * parts_) + static_cast<size_t>(mix64(fp) % parts_);
+    }
+
+    //! @brief The rank-level shift a generator induces: rank(M^G) == rank(M) ^ rank_shift(G). Zero for
+    //! every G when the router is not linear.
+    template <size_t NumModes>
+    [[nodiscard]] auto rank_shift(const Monomial<NumModes> &gen) const noexcept -> size_t {
+        if (!linear_) {
+            return 0;
+        }
+        return static_cast<size_t>(linear_hash<2 * NumModes>(gen) & static_cast<uint64_t>(ranks_ - 1));
+    }
+
+    /*!
+     * @brief The flat-slot shift a generator induces: flat(M^G) == flat(M) ^ flat_shift(G). nullopt
+     * when the slot is not linear (splitmix, R == 1, S not 2^k), so a caller cannot XOR a shift that
+     * does not exist.
+     */
+    template <size_t NumModes>
+    [[nodiscard]] auto flat_shift(const Monomial<NumModes> &gen) const noexcept -> std::optional<size_t> {
+        if (!is_flat_linear()) {
+            return std::nullopt;
+        }
+        return dest_from_fingerprint(linear_hash<2 * NumModes>(gen));
+    }
+
+private:
+    // ranks x partitions == the flat world the destinations index.
+    constexpr Router(size_t ranks, size_t partitions, bool linear)
+        : ranks_(ranks == 0 ? 1 : ranks),
+          parts_(partitions == 0 ? 1 : partitions),
+          flat_(ranks_ * parts_),
+          linear_(linear && ranks_ > 1), // R == 1 takes no rank bit, so it IS the dense case
+          parts_pow2_(std::has_single_bit(parts_)),
+          parts_mask_(parts_ - 1),
+          parts_log2_(static_cast<size_t>(std::countr_zero(parts_))) {
+        if (linear && !std::has_single_bit(ranks_)) {
+            throw UnroutableGeometry(
+                std::format("linear routing needs a power-of-two rank count, got {}. Launch 2^k ranks, or set "
+                            "monoprop_ROUTING=splitmix to keep the dense all-to-all.",
+                            ranks_));
+        }
+    }
+
+    size_t ranks_;
+    size_t parts_;
+    size_t flat_;
+    bool linear_;
+    bool parts_pow2_;   // S is 2^k, so `% S` is a mask and `/ S` a shift
+    size_t parts_mask_; // S - 1, and parts_log2_ == log2(S); both meaningless unless parts_pow2_
+    size_t parts_log2_;
+};
+
+//! @brief The mode, before any geometry: linear unless monoprop_ROUTING asks for splitmix.
+inline auto linear_requested() -> bool {
+    return config::get().routing_mode.value_or(config::RoutingMode::Linear) == config::RoutingMode::Linear;
+}
+
+//! @brief The router a geometry resolves to under the environment's mode.
+template <size_t NumModes>
+inline auto make_router(size_t ranks, size_t partitions) -> Router {
+    return Router::for_modes<NumModes>(ranks, partitions, linear_requested());
+}
+
+} // namespace monoprop::routing

--- a/cpp/tests/README.md
+++ b/cpp/tests/README.md
@@ -88,8 +88,13 @@ name and cannot address suite-nested cases, tests use flat
   CutoffEvaluator, interleave phase, coeff encode/decode, cutoff_sums vs a
   bitwise reference), `validation_tests.cpp`
   (parameter validators), `mpi_utils_tests.cpp` (find_rank, word serialization,
-  scan routing agreement), `evolution_detail_tests.cpp` (MatchedEpochSet +
-  CutoffContext),
+  scan routing agreement under both routers, the routing-agreement check),
+  `routing_tests.cpp` (Router term -> flat-slot map: the splitmix equivalence
+  with `hash % P`, the linear shift identity, the gf2_rank coverage
+  diagnostic, the non-power-of-two throw and the shipped default),
+  `env_config_tests.cpp` (the environment parsers, which throw rather than
+  default on a malformed routing knob),
+  `evolution_detail_tests.cpp` (MatchedEpochSet + CutoffContext),
   `row_accessor_tests.cpp` (dense vs OperatorIndex row accessors).
 - **Operator store**: `chunked_array_tests.cpp` (the pooled chunk allocator and
   the chunked arrays on it: arena reuse, unmapping read from

--- a/cpp/tests/env_config_tests.cpp
+++ b/cpp/tests/env_config_tests.cpp
@@ -14,11 +14,17 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <cstdint>
 #include <optional>
 
 #include "monoprop/detail/EnvConfig.h"
 
+using monoprop::config::EnvConfigError;
+using monoprop::config::RoutingMode;
+using monoprop::config::detail::parse_bool;
 using monoprop::config::detail::parse_positive_int;
+using monoprop::config::detail::parse_routing_mode;
+using monoprop::config::detail::parse_uint64;
 
 BOOST_AUTO_TEST_CASE(env_config_parse_positive_int_null_and_malformed) {
     BOOST_CHECK(parse_positive_int(nullptr) == std::nullopt);
@@ -43,4 +49,40 @@ BOOST_AUTO_TEST_CASE(env_config_settings_cached_singleton) {
     BOOST_CHECK_EQUAL(&a, &b);
     // Touch a field so the Settings aggregate is actually read.
     BOOST_CHECK(a.num_threads == std::nullopt || *a.num_threads >= 1);
+}
+
+// Both routing parsers throw where parse_positive_int returns nullopt: a routing knob that
+// defaulted silently would change the transport with no diagnostic.
+BOOST_AUTO_TEST_CASE(env_config_parse_uint64_unset_valid_and_rejected) {
+    BOOST_CHECK(parse_uint64("k", nullptr) == std::nullopt);
+    BOOST_CHECK(parse_uint64("k", "") == std::nullopt);
+    BOOST_CHECK(parse_uint64("k", "0") == std::optional<std::uint64_t>(0));
+    BOOST_CHECK(parse_uint64("k", "18446744073709551615") == std::optional<std::uint64_t>(~std::uint64_t{0}));
+    BOOST_CHECK_THROW(parse_uint64("k", "abc"), EnvConfigError);
+    BOOST_CHECK_THROW(parse_uint64("k", "12x"), EnvConfigError);
+    BOOST_CHECK_THROW(parse_uint64("k", "-1"), EnvConfigError);                   // strtoull would WRAP it
+    BOOST_CHECK_THROW(parse_uint64("k", "18446744073709551616"), EnvConfigError); // ERANGE
+}
+
+// The report knob is 0/1 and nothing else: "true" or "yes" defaulting to off would leave a
+// diagnostic switched off with no diagnostic of its own.
+BOOST_AUTO_TEST_CASE(env_config_parse_bool_rejects_anything_but_zero_or_one) {
+    BOOST_CHECK(parse_bool("k", nullptr) == std::nullopt);
+    BOOST_CHECK(parse_bool("k", "") == std::nullopt);
+    BOOST_CHECK(parse_bool("k", "0") == std::optional<bool>(false));
+    BOOST_CHECK(parse_bool("k", "1") == std::optional<bool>(true));
+    BOOST_CHECK_THROW(parse_bool("k", "true"), EnvConfigError);
+    BOOST_CHECK_THROW(parse_bool("k", "yes"), EnvConfigError);
+    BOOST_CHECK_THROW(parse_bool("k", "2"), EnvConfigError);
+    BOOST_CHECK_THROW(parse_bool("k", "01"), EnvConfigError);
+}
+
+BOOST_AUTO_TEST_CASE(env_config_parse_routing_mode_rejects_a_typo) {
+    BOOST_CHECK(parse_routing_mode("k", nullptr) == std::nullopt);
+    BOOST_CHECK(parse_routing_mode("k", "") == std::nullopt);
+    BOOST_CHECK(parse_routing_mode("k", "splitmix") == std::optional<RoutingMode>(RoutingMode::Splitmix));
+    BOOST_CHECK(parse_routing_mode("k", "linear") == std::optional<RoutingMode>(RoutingMode::Linear));
+    BOOST_CHECK_THROW(parse_routing_mode("k", "dense"), EnvConfigError);
+    BOOST_CHECK_THROW(parse_routing_mode("k", "off"), EnvConfigError);
+    BOOST_CHECK_THROW(parse_routing_mode("k", "Linear"), EnvConfigError);
 }

--- a/cpp/tests/mpi_utils_tests.cpp
+++ b/cpp/tests/mpi_utils_tests.cpp
@@ -18,6 +18,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <bit>
 #include <cstddef>
 #include <functional>
 #include <optional>
@@ -28,13 +29,15 @@
 #include "monoprop/detail/evolution/CutoffContext.h"
 #include "monoprop/detail/evolution/layer_build/Scan.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
+#include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
 #include "monoprop/detail/operator/OperatorIndex.h"
 
 using namespace monoprop;
 
-// find_rank is splitmix over the dense words modulo the rank count, and nothing else, so the oracle
-// is asserted unconditionally rather than as one of several permitted hashes.
+// Under the splitmix router find_rank is the dense words modulo the rank count and nothing else, so the
+// oracle is asserted unconditionally rather than as one of several permitted hashes. The router is
+// constructed explicitly: there is no rank-count overload to reach it by accident.
 BOOST_AUTO_TEST_CASE(mpi_utils_find_rank_range_and_hash_mod) {
     constexpr size_t N = 32;
     std::mt19937_64 rng(0x9E3779B9ULL);
@@ -46,19 +49,21 @@ BOOST_AUTO_TEST_CASE(mpi_utils_find_rank_range_and_hash_mod) {
         }
         const auto mono = indices_to_bitset<N>(inds);
         for (size_t n_ranks : {size_t{1}, size_t{2}, size_t{3}, size_t{7}}) {
-            const size_t r = find_rank<N>(mono, n_ranks);
+            const auto router = routing::Router::splitmix(n_ranks);
+            const size_t r = find_rank<N>(mono, router);
             BOOST_TEST(r == monomial_hash<N>(mono) % n_ranks);
             BOOST_TEST(r < n_ranks);
-            BOOST_TEST(r == find_rank<N>(mono, n_ranks)); // deterministic
+            BOOST_TEST(r == find_rank<N>(mono, router)); // deterministic
         }
     }
 }
 
-// n_ranks == 0 is degenerate: owner is rank 0, not a modulo by zero.
+// A zero-slot world is degenerate: Router clamps it to one slot, so the owner is rank 0 rather than a
+// modulo by zero.
 BOOST_AUTO_TEST_CASE(mpi_utils_find_rank_zero_ranks) {
     constexpr size_t N = 32;
     const auto mono = indices_to_bitset<N>(VecZ{0, 3, 5});
-    BOOST_TEST(find_rank<N>(mono, 0) == 0U);
+    BOOST_TEST(find_rank<N>(mono, routing::Router::splitmix(0)) == 0U);
 }
 
 BOOST_AUTO_TEST_CASE(mpi_utils_monomial_words_roundtrip) {
@@ -111,7 +116,7 @@ auto build_op(const std::vector<Monomial<32>> &terms) -> detail::MPOperator<32> 
     return op;
 }
 
-auto check_bucket_ownership(const std::vector<VecZ> &buckets, size_t ranks, size_t &checked) -> void {
+auto check_bucket_ownership(const std::vector<VecZ> &buckets, const routing::Router &router, size_t &checked) -> void {
     // Every offset comes from the record walk: widths vary, so a hardcoded stride would compare a
     // monomial decoded at the wrong offset against the wrong rank.
     using QW = detail::QueryWire<32>;
@@ -126,7 +131,7 @@ auto check_bucket_ownership(const std::vector<VecZ> &buckets, size_t ranks, size
             for (size_t j = 0; j < k; ++j) {
                 mono.set(static_cast<size_t>(pos[j]));
             }
-            BOOST_REQUIRE_EQUAL(find_rank<32>(mono, ranks), r);
+            BOOST_REQUIRE_EQUAL(find_rank<32>(mono, router), r);
             off = QW::next_off(buckets[r], form, off);
             ++checked;
         }
@@ -136,14 +141,16 @@ auto check_bucket_ownership(const std::vector<VecZ> &buckets, size_t ranks, size
 
 // The self-owned bucket is staged as positions, not encoded, so it is invisible to the walk above --
 // without this the r == my_rank arm of the routing decision goes unchecked.
-auto check_self_ownership(const detail::SelfQueryStage<32> &stage, size_t ranks, size_t my_rank, size_t &checked)
-    -> void {
+auto check_self_ownership(const detail::SelfQueryStage<32> &stage,
+                          const routing::Router &router,
+                          size_t my_rank,
+                          size_t &checked) -> void {
     for (size_t q = 0; q < stage.size(); ++q) {
         Monomial<32> mono;
         for (size_t j = 0; j < stage.k_of[q]; ++j) {
             mono.set(static_cast<size_t>(stage.pos_flat[stage.pos_off[q] + j]));
         }
-        BOOST_REQUIRE_EQUAL(find_rank<32>(mono, ranks), my_rank);
+        BOOST_REQUIRE_EQUAL(find_rank<32>(mono, router), my_rank);
         ++checked;
     }
 }
@@ -172,36 +179,43 @@ BOOST_AUTO_TEST_CASE(mpi_utils_scan_routing_agrees_with_find_rank) {
                                                                    std::nullopt,
                                                                    std::optional<double>{0.3});
 
-    size_t checked = 0;
-    size_t self_checked = 0;
-    for (const size_t ranks : {2U, 4U, 8U}) {
-        const auto res = detail::fused_find_and_collect<kN, MajoranaAlgebra<kN>>(op,
-                                                                                 gen,
-                                                                                 eval,
-                                                                                 cut,
-                                                                                 coeffs,
-                                                                                 std::nullopt,
-                                                                                 ranks,
-                                                                                 0,
-                                                                                 false,
-                                                                                 nullptr,
-                                                                                 1.0);
-        BOOST_REQUIRE_EQUAL(res.leader_queries.size(), ranks);
-        // The scan routes a self-owned partner to the stage, so bucket 0 must be empty here.
-        BOOST_REQUIRE(res.leader_queries[0].empty());
-        BOOST_REQUIRE(res.follower_queries[0].empty());
-        check_bucket_ownership(res.leader_queries, ranks, checked);
-        check_bucket_ownership(res.follower_queries, ranks, checked);
-        check_self_ownership(res.leader_self, ranks, /*my_rank=*/0, self_checked);
-        check_self_ownership(res.follower_self, ranks, /*my_rank=*/0, self_checked);
+    // BOTH routers, because the agreement is a property of the pair and not of either map: the scan
+    // routes the partner it just built and find_rank routes what the resolve side decoded, so a
+    // divergence introduced by either shows up here whichever routing the geometry resolves to.
+    for (const bool linear : {false, true}) {
+        size_t checked = 0;
+        size_t self_checked = 0;
+        for (const size_t ranks : {2U, 4U, 8U}) {
+            const auto router = routing::Router::for_modes<kN>(ranks, /*partitions=*/1, linear);
+            BOOST_REQUIRE_EQUAL(router.is_linear(), linear);
+            const auto res = detail::fused_find_and_collect<kN, MajoranaAlgebra<kN>>(op,
+                                                                                     gen,
+                                                                                     eval,
+                                                                                     cut,
+                                                                                     coeffs,
+                                                                                     std::nullopt,
+                                                                                     router,
+                                                                                     0,
+                                                                                     false,
+                                                                                     nullptr,
+                                                                                     1.0);
+            BOOST_REQUIRE_EQUAL(res.leader_queries.size(), ranks);
+            // The scan routes a self-owned partner to the stage, so bucket 0 must be empty here.
+            BOOST_REQUIRE(res.leader_queries[0].empty());
+            BOOST_REQUIRE(res.follower_queries[0].empty());
+            check_bucket_ownership(res.leader_queries, router, checked);
+            check_bucket_ownership(res.follower_queries, router, checked);
+            check_self_ownership(res.leader_self, router, /*my_rank=*/0, self_checked);
+            check_self_ownership(res.follower_self, router, /*my_rank=*/0, self_checked);
+        }
+        // Without this the loop above passes trivially if the scan emitted nothing. The floors are per
+        // router, not summed over them: a sum lets one router carry the other. The total floor is what is
+        // invariant across the split; each arm keeps its own so a bug that sends everything one way fails.
+        BOOST_TEST_MESSAGE("linear=" << linear << " encoded=" << checked << " staged=" << self_checked);
+        BOOST_TEST(checked + self_checked > 1000U);
+        BOOST_TEST(checked > 500U);
+        BOOST_TEST(self_checked > 200U);
     }
-    // Without this the loop above passes trivially if the scan emitted nothing. The floor is on the total
-    // because that is what is invariant across the split; each arm also keeps its own floor so a routing
-    // bug that sends everything one way still fails.
-    BOOST_TEST_MESSAGE("encoded=" << checked << " staged=" << self_checked);
-    BOOST_TEST(checked + self_checked > 1000U);
-    BOOST_TEST(checked > 500U);
-    BOOST_TEST(self_checked > 200U);
 }
 
 // A Schrodinger propagator seeds a slot by walking the whole paired basis and keeping find_rank ==
@@ -218,30 +232,50 @@ BOOST_AUTO_TEST_CASE(mpi_utils_paired_enumeration_partitions_by_find_rank) {
     BOOST_REQUIRE_EQUAL(full.size(), paired_op_size(kMaxPairs, kLogical));
 
     for (const size_t slots : {size_t{1}, size_t{2}, size_t{3}, size_t{8}, size_t{128}}) {
-        size_t total = 0;
-        for (size_t slot = 0; slot < slots; ++slot) {
-            MonomialList<kN> kept;
-            for_each_paired_monomial<kN>(kMaxPairs, kLogical, [&](const Monomial<kN> &mono) {
-                if (find_rank<kN>(mono, slots) == slot) {
-                    kept.push_back(mono);
-                }
-            });
-            total += kept.size();
+        // Both routers where the geometry admits both: the partition property is a property of the walk
+        // and the owner function, so it must not depend on which owner function is in force.
+        for (const bool linear : {false, true}) {
+            if (linear && !std::has_single_bit(slots)) {
+                continue; // linear routing refuses a non-power-of-two world (routing_tests pins the throw)
+            }
+            const auto router = routing::Router::for_modes<kN>(slots, /*partitions=*/1, linear);
+            size_t total = 0;
+            for (size_t slot = 0; slot < slots; ++slot) {
+                MonomialList<kN> kept;
+                for_each_paired_monomial<kN>(kMaxPairs, kLogical, [&](const Monomial<kN> &mono) {
+                    if (find_rank<kN>(mono, router) == slot) {
+                        kept.push_back(mono);
+                    }
+                });
+                total += kept.size();
 
-            // kept[r] == full[j_r] with j_0 < j_1 < ... : row r's monomial follows from the global order.
-            size_t cursor = 0;
-            for (const auto &mono : kept) {
-                while (cursor < full.size() && !(full[cursor] == mono)) {
+                // kept[r] == full[j_r] with j_0 < j_1 < ... : row r's monomial follows from the global order.
+                size_t cursor = 0;
+                for (const auto &mono : kept) {
+                    while (cursor < full.size() && !(full[cursor] == mono)) {
+                        ++cursor;
+                    }
+                    BOOST_REQUIRE_LT(cursor, full.size());
                     ++cursor;
                 }
-                BOOST_REQUIRE_LT(cursor, full.size());
-                ++cursor;
+            }
+            // The walk is duplicate-free (pinned in majorana_cutoff_tests), so equal counts mean the slots'
+            // kept sets are disjoint AND cover every term exactly once.
+            BOOST_TEST_CONTEXT("slots=" << slots << " linear=" << linear) {
+                BOOST_CHECK_EQUAL(total, full.size());
             }
         }
-        // The walk is duplicate-free (pinned in majorana_cutoff_tests), so equal counts mean the slots'
-        // kept sets are disjoint AND cover every term exactly once.
-        BOOST_TEST_CONTEXT("slots=" << slots) {
-            BOOST_CHECK_EQUAL(total, full.size());
-        }
     }
+}
+
+// One environment across the world resolves one router, so the agreement check must pass. The value of
+// the case is under the MPI variants (2 ranks): the digests are built from the mode, the seed and the
+// partition count and reduced with two allreduces, so a rank that never entered them would hang here
+// rather than return -- which is the failure this check exists to convert into an exception.
+BOOST_AUTO_TEST_CASE(mpi_utils_routing_agreement_holds_across_the_world) {
+    const monoprop::mpi::Comm comm{MPI_COMM_WORLD};
+    BOOST_CHECK_NO_THROW(check_routing_agreement(comm));
+    // MPI_COMM_SELF is a world of one: the check returns before any collective, so it is safe to call
+    // on a communicator the other ranks are not in.
+    BOOST_CHECK_NO_THROW(check_routing_agreement(monoprop::mpi::Comm{MPI_COMM_SELF}));
 }

--- a/cpp/tests/routing_tests.cpp
+++ b/cpp/tests/routing_tests.cpp
@@ -1,0 +1,429 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// routing::Router -- the term -> flat-slot map. Two states, two properties that carry the whole design:
+//   * splitmix is bit-for-bit main's `monomial_hash % P`, so the refactor cannot move a single term;
+//   * under linear routing the destination of M^G is read off fp(M) ^ fp(G), and with a power-of-two
+//     partition count the whole slot obeys flat(M^G) == flat(M) ^ flat_shift(G), which is what turns
+//     the dense all-to-all into a pairwise exchange. A break here is silent -- wrong owner, not a
+//     crash -- so the shift identity and the map's bit identity are both asserted explicitly.
+//
+// Flat cases with a shared prefix, no suite nesting (suites break Boost's ctest discovery here).
+
+#include <boost/test/unit_test.hpp>
+
+#include <bit>
+#include <cstdint>
+#include <cstdlib>
+#include <random>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "monoprop/algebra/AlgebraCommon.h"
+#include "monoprop/detail/mpi/MPIUtils.h"
+#include "monoprop/detail/mpi/Routing.h"
+
+using namespace monoprop;
+using monoprop::routing::Router;
+
+namespace {
+
+constexpr size_t kN = 64; // 2N = 128 bits -> 2 words, so the multi-word hash path is exercised
+
+// Exactly `weight` distinct bits, so a case can pin the popcount the bit walk pays for.
+auto monomials_of_weight(size_t count, size_t weight, uint64_t seed) -> std::vector<Monomial<kN>> {
+    std::mt19937_64 rng(seed);
+    std::uniform_int_distribution<size_t> slot(0, 2 * kN - 1);
+    std::vector<Monomial<kN>> out;
+    out.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        Monomial<kN> m;
+        while (m.count() < weight) {
+            m.set(slot(rng));
+        }
+        out.push_back(m);
+    }
+    return out;
+}
+
+// The specified map: load one 64-bit label per SET bit and XOR. Rebuilt from mix64 and the seed rather
+// than read from linear_basis(), so the router and this share nothing but the specification.
+template <size_t NumBits>
+auto linear_hash_reference(const monoprop::Bitset<NumBits> &bits) -> uint64_t {
+    const uint64_t seed = routing::seed_from_env();
+    uint64_t h = 0;
+    for (size_t i = bits.find_first(); i < NumBits; i = bits.find_next(i)) {
+        h ^= routing::mix64(routing::mix64(seed) + (static_cast<uint64_t>(i) * 0x9E37'79B9'7F4A'7C15ULL));
+    }
+    return h;
+}
+
+auto random_monomials(size_t count, size_t weight, uint64_t seed) -> std::vector<Monomial<kN>> {
+    std::mt19937_64 rng(seed);
+    std::uniform_int_distribution<size_t> slot(0, 2 * kN - 1);
+    std::vector<Monomial<kN>> out;
+    out.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        VecZ inds;
+        for (size_t k = 0; k < weight; ++k) {
+            inds.push_back(slot(rng));
+        }
+        out.push_back(indices_to_bitset<kN>(inds));
+    }
+    return out;
+}
+
+} // namespace
+
+// The splitmix router must not move a single term relative to `monomial_hash % P`: this is the
+// regression gate that licenses everything else.
+BOOST_AUTO_TEST_CASE(routing_splitmix_is_bit_identical_to_hash_mod_p) {
+    const auto monos = random_monomials(500, 5, 0xC0FFEEULL);
+    for (const size_t flat : {size_t{1}, size_t{2}, size_t{7}, size_t{112}, size_t{1792}}) {
+        const auto router = Router::splitmix(flat);
+        BOOST_TEST(!router.is_linear());
+        for (const auto &m : monos) {
+            const size_t expected = monomial_hash<kN>(m) % flat;
+            BOOST_TEST(router.dest<kN>(m) == expected);
+            BOOST_TEST(find_rank<kN>(m, router) == expected);
+        }
+    }
+}
+
+// A two-level splitmix router is still main's routing, even though it knows about partitions:
+// ((q/S) % R)*S + q%S == q % (R*S). 12 ranks is here too: splitmix carries no power-of-two condition.
+BOOST_AUTO_TEST_CASE(routing_splitmix_two_level_collapses_to_flat_modulo) {
+    const auto monos = random_monomials(300, 6, 0xBEEF01ULL);
+    for (const auto [r, s] : {std::pair<size_t, size_t>{8, 14}, {4, 28}, {128, 14}, {64, 28}, {12, 5}}) {
+        const auto router = Router::for_modes<kN>(r, s, false);
+        for (const auto &m : monos) {
+            BOOST_TEST(router.dest<kN>(m) == monomial_hash<kN>(m) % (r * s));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(routing_linear_hash_is_gf2_linear) {
+    const auto a = random_monomials(200, 5, 0x1234ULL);
+    const auto b = random_monomials(200, 3, 0x5678ULL);
+    for (size_t i = 0; i < a.size(); ++i) {
+        const uint64_t ha = routing::linear_hash<2 * kN>(a[i]);
+        const uint64_t hb = routing::linear_hash<2 * kN>(b[i]);
+        BOOST_TEST(routing::linear_hash<2 * kN>(a[i] ^ b[i]) == (ha ^ hb));
+    }
+    // The empty monomial is the identity of the group, so its hash must be the identity of the codomain.
+    BOOST_TEST(routing::linear_hash<2 * kN>(Monomial<kN>{}) == 0ULL);
+}
+
+// The load-bearing identity: under linear routing the destination RANK of M^G is rank(M) ^ shift(G),
+// so one rank's queries for one generator all land on one peer.
+BOOST_AUTO_TEST_CASE(routing_shift_identity_holds_under_linear_routing) {
+    constexpr size_t kRanks = 16;
+    constexpr size_t kParts = 14;
+    const auto router = Router::for_modes<kN>(kRanks, kParts, true);
+    BOOST_REQUIRE(router.is_linear());
+    BOOST_REQUIRE(router.linear_bits() == 4U); // every rank bit, log2(16)
+
+    const auto terms = random_monomials(400, 6, 0xAAAA01ULL);
+    const auto gens = random_monomials(40, 4, 0xBBBB02ULL);
+    for (const auto &g : gens) {
+        const size_t shift = router.rank_shift<kN>(g);
+        for (const auto &m : terms) {
+            const size_t rank_m = router.dest<kN>(m) / kParts;
+            const size_t rank_mg = router.dest<kN>(m ^ g) / kParts;
+            BOOST_TEST(rank_mg == (rank_m ^ shift));
+        }
+    }
+}
+
+// What the emit path will call: the partner's slot off its fingerprint fp(M) ^ fp(G). The check is
+// exact equality against dest() over every linear geometry -- S == 1 (no partition index at all), S a
+// power of two (the linear partition bits) and S = 3, 14 (the mixed modulo) are all here -- and, where
+// the whole slot is linear, the shift identity flat(M^G) == flat(M) ^ flat_shift(G).
+BOOST_AUTO_TEST_CASE(routing_dest_from_fingerprint_agrees_with_dest) {
+    const auto terms = random_monomials(400, 6, 0x5E1F7A11ULL);
+    const auto gens = random_monomials(25, 4, 0x9110F7E5ULL);
+    const std::vector<std::pair<size_t, size_t>>
+        geometries{{8, 1}, {16, 1}, {2, 2}, {32, 16}, {64, 8}, {4, 3}, {8, 14}};
+    size_t checked = 0;
+    size_t shifted = 0;
+    for (const auto &[r, s] : geometries) {
+        const auto router = Router::for_modes<kN>(r, s, true);
+        BOOST_REQUIRE(router.is_linear());
+        BOOST_REQUIRE_EQUAL(router.is_flat_linear(), std::has_single_bit(s));
+        for (const auto &g : gens) {
+            const uint64_t fp_g = routing::linear_hash<2 * kN>(g);
+            const auto flat_shift = router.flat_shift<kN>(g);
+            BOOST_REQUIRE_EQUAL(flat_shift.has_value(), router.is_flat_linear());
+            for (const auto &m : terms) {
+                const auto partner = m ^ g;
+                const uint64_t fp_m = routing::linear_hash<2 * kN>(m);
+                BOOST_REQUIRE_EQUAL(router.dest_from_fingerprint(fp_m ^ fp_g), router.dest<kN>(partner));
+                BOOST_REQUIRE_EQUAL(router.dest_from_fingerprint(fp_m), router.dest<kN>(m));
+                if (flat_shift) {
+                    BOOST_REQUIRE_EQUAL(router.dest<kN>(partner), router.dest<kN>(m) ^ *flat_shift);
+                    ++shifted;
+                }
+                ++checked;
+            }
+        }
+    }
+    BOOST_TEST_MESSAGE("dest_from_fingerprint checks: " << checked << " flat-shift checks: " << shifted);
+    BOOST_TEST(checked >= 50000U);
+    BOOST_TEST(shifted >= 20000U);
+}
+
+// The rank shift is the low log2(R) bits of the generator's image, zero under splitmix.
+BOOST_AUTO_TEST_CASE(routing_rank_shift_is_the_low_rank_bits) {
+    const auto gens = random_monomials(50, 4, 0x1234ULL);
+    for (const auto &g : gens) {
+        BOOST_TEST(Router::for_modes<kN>(16, 3, true).rank_shift<kN>(g) == (routing::linear_hash<2 * kN>(g) & 15U));
+        BOOST_TEST(Router::for_modes<kN>(16, 3, false).rank_shift<kN>(g) == 0U);
+        BOOST_TEST(!Router::for_modes<kN>(16, 3, false).flat_shift<kN>(g).has_value());
+        BOOST_TEST(!Router::for_modes<kN>(1, 8, true).flat_shift<kN>(g).has_value()); // R == 1 is dense
+    }
+}
+
+// The S == 1 skip: the partition index is 0 for every term, so under linear routing the destination is
+// the rank index alone and monomial_hash is not on the path at all.
+BOOST_AUTO_TEST_CASE(routing_single_partition_destination_is_the_rank_index) {
+    constexpr size_t kRanks = 64;
+    const auto router = Router::for_modes<kN>(kRanks, 1, true);
+    for (const auto &m : random_monomials(500, 5, 0x0FAE7101ULL)) {
+        BOOST_REQUIRE_EQUAL(router.dest<kN>(m), routing::linear_hash<2 * kN>(m) & (kRanks - 1));
+    }
+}
+
+// With S a power of two the whole slot is linear: every term a SLOT owns sends its query for one
+// generator to exactly one peer slot, inside the rank as well as across ranks.
+BOOST_AUTO_TEST_CASE(routing_fanout_is_one_slot_when_partitions_are_a_power_of_two) {
+    constexpr size_t kRanks = 8;
+    constexpr size_t kParts = 16;
+    const auto router = Router::for_modes<kN>(kRanks, kParts, true);
+    BOOST_REQUIRE(router.is_flat_linear());
+    BOOST_REQUIRE_EQUAL(router.flat_linear_bits(), 7U);
+    const auto terms = random_monomials(6000, 6, 0xCCCC03ULL);
+    const auto gens = random_monomials(12, 4, 0xDDDD04ULL);
+    std::vector<std::vector<Monomial<kN>>> owned(kRanks * kParts);
+    for (const auto &m : terms) {
+        owned[router.dest<kN>(m)].push_back(m);
+    }
+    size_t populated = 0;
+    for (size_t slot = 0; slot < owned.size(); ++slot) {
+        if (owned[slot].empty()) {
+            continue;
+        }
+        ++populated;
+        for (const auto &g : gens) {
+            std::set<size_t> dests;
+            for (const auto &m : owned[slot]) {
+                dests.insert(router.dest<kN>(m ^ g));
+            }
+            BOOST_REQUIRE_EQUAL(dests.size(), 1U);
+            BOOST_REQUIRE_EQUAL(*dests.begin(), slot ^ *router.flat_shift<kN>(g));
+        }
+    }
+    BOOST_TEST(populated == kRanks * kParts); // 6000 terms over 128 cosets: every slot populated
+}
+
+// With S not a power of two only the rank level is linear: one peer rank, and the partition index
+// within that peer still spreads.
+BOOST_AUTO_TEST_CASE(routing_fanout_is_one_rank_when_partitions_are_not_a_power_of_two) {
+    constexpr size_t kRanks = 8;
+    constexpr size_t kParts = 14;
+    const auto router = Router::for_modes<kN>(kRanks, kParts, true);
+    const auto terms = random_monomials(4000, 6, 0xCCCC03ULL);
+    const auto gens = random_monomials(12, 4, 0xDDDD04ULL);
+
+    std::vector<std::vector<Monomial<kN>>> owned(kRanks);
+    for (const auto &m : terms) {
+        owned[router.dest<kN>(m) / kParts].push_back(m);
+    }
+    for (size_t src = 0; src < kRanks; ++src) {
+        BOOST_REQUIRE(!owned[src].empty());
+        for (const auto &g : gens) {
+            std::set<size_t> dest_ranks;
+            std::set<size_t> dest_parts;
+            for (const auto &m : owned[src]) {
+                const size_t flat = router.dest<kN>(m ^ g);
+                dest_ranks.insert(flat / kParts);
+                dest_parts.insert(flat % kParts);
+            }
+            BOOST_TEST(dest_ranks.size() == 1U);
+            BOOST_TEST(dest_parts.size() > 1U); // partitions keep full avalanche
+        }
+    }
+}
+
+// Without a power-of-two rank count there is no XOR structure to exploit, and there is no partial dial
+// to fall back to, so the geometry is rejected at construction rather than routed on a subspace.
+BOOST_AUTO_TEST_CASE(routing_non_power_of_two_ranks_throw_under_linear_routing) {
+    for (const size_t r : {size_t{3}, size_t{7}, size_t{12}, size_t{112}}) {
+        BOOST_CHECK_THROW(static_cast<void>(Router::for_modes<kN>(r, 14, true)), routing::UnroutableGeometry);
+        BOOST_CHECK_NO_THROW(static_cast<void>(Router::for_modes<kN>(r, 14, false))); // splitmix has no condition
+    }
+    BOOST_CHECK_NO_THROW(static_cast<void>(Router::for_modes<kN>(64, 14, true)));
+}
+
+// R = 1 is a power of two, so it must NOT throw: it has no rank bit to take, which makes it the dense
+// router and keeps the collective transport that serves every single-rank run.
+BOOST_AUTO_TEST_CASE(routing_single_rank_is_dense_and_not_an_error) {
+    const auto monos = random_monomials(200, 5, 0x51A61EULL);
+    for (const size_t s : {size_t{1}, size_t{14}, size_t{112}}) {
+        const auto router = Router::for_modes<kN>(1, s, true);
+        BOOST_TEST(!router.is_linear());
+        BOOST_TEST(router.linear_bits() == 0U);
+        for (const auto &m : monos) {
+            BOOST_TEST(router.dest<kN>(m) == monomial_hash<kN>(m) % s);
+            BOOST_TEST(router.rank_shift<kN>(m) == 0U); // no bit to shift, so every generator is on-rank
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(routing_dest_is_in_range_and_deterministic) {
+    const auto monos = random_monomials(1000, 7, 0x9999ULL);
+    for (const auto [r, s] : {std::pair<size_t, size_t>{1, 1}, {1, 112}, {8, 14}, {128, 14}, {64, 28}}) {
+        for (const bool linear : {false, true}) {
+            const auto router = Router::for_modes<kN>(r, s, linear);
+            for (const auto &m : monos) {
+                const size_t slot = router.dest<kN>(m);
+                BOOST_TEST(slot < r * s);
+                BOOST_TEST(slot == router.dest<kN>(m)); // stateless
+            }
+        }
+    }
+}
+
+// dest() must be the specified map, bit for bit, on both routers and every geometry: a divergence is a
+// silently wrong owner. The reference rebuilds the label table from mix64 and the seed, so it shares
+// nothing with linear_basis() but the specification; fingerprint_positions is pinned to it as well.
+BOOST_AUTO_TEST_CASE(routing_dest_is_bit_identical_to_the_specified_map) {
+    std::vector<Monomial<kN>> monos;
+    for (const size_t w : {size_t{0},
+                           size_t{1},
+                           size_t{2},
+                           size_t{3},
+                           size_t{5},
+                           size_t{8},
+                           size_t{13},
+                           size_t{21},
+                           size_t{34},
+                           size_t{2 * kN}}) {
+        const auto batch = monomials_of_weight(500, w, 0xD15EA5E0ULL + w);
+        monos.insert(monos.end(), batch.begin(), batch.end());
+    }
+    BOOST_REQUIRE_EQUAL(monos.size(), 5000U);
+
+    const uint64_t *labels = routing::linear_basis<2 * kN>().data();
+    const std::vector<std::pair<size_t, size_t>> geometries{{128, 14},
+                                                            {16, 1},
+                                                            {64, 28},
+                                                            {8, 14},
+                                                            {1024, 1},
+                                                            {2, 112},
+                                                            {4096, 16},
+                                                            {32, 3},
+                                                            {1, 112},
+                                                            {256, 2},
+                                                            {2048, 1}};
+
+    size_t checked = 0;
+    for (const auto &[r, s] : geometries) {
+        for (const bool linear : {false, true}) {
+            const auto router = Router::for_modes<kN>(r, s, linear);
+            const size_t d = router.linear_bits();
+            BOOST_REQUIRE_EQUAL(d, linear ? static_cast<size_t>(std::countr_zero(r)) : 0U);
+            const uint64_t lin_mask = d == 0 ? 0ULL : (uint64_t{1} << d) - 1;
+            for (const auto &m : monos) {
+                const uint64_t q = monomial_hash<kN>(m);
+                const uint64_t fp = linear_hash_reference<2 * kN>(m);
+                std::vector<uint16_t> pos;
+                for (size_t b = m.find_first(); b < m.size(); b = m.find_next(b)) {
+                    pos.push_back(static_cast<uint16_t>(b));
+                }
+                BOOST_REQUIRE_EQUAL(routing::fingerprint_positions(labels, pos.data(), pos.size()), fp);
+                BOOST_REQUIRE_EQUAL(routing::linear_hash<2 * kN>(m), fp);
+                size_t expected = 0;
+                if (d == 0) {
+                    expected = static_cast<size_t>(q % (r * s)); // splitmix, and R = 1 under linear routing
+                }
+                else {
+                    const size_t rank = static_cast<size_t>(fp & lin_mask);
+                    const size_t part = std::has_single_bit(s) ? static_cast<size_t>((fp >> d) & (s - 1))
+                                                               : static_cast<size_t>(routing::mix64(fp) % s);
+                    expected = (rank * s) + part;
+                }
+                BOOST_REQUIRE_EQUAL(router.dest<kN>(m), expected);
+                BOOST_REQUIRE_EQUAL(router.rank_shift<kN>(m), static_cast<size_t>(fp & lin_mask));
+                ++checked;
+            }
+        }
+    }
+    BOOST_TEST_MESSAGE("bit-identity checks: " << checked);
+    BOOST_TEST(checked >= 100000U);
+}
+
+// gf2_rank is the coverage diagnostic: shifts that span fewer than log2(R) dimensions leave ranks empty.
+BOOST_AUTO_TEST_CASE(routing_gf2_rank_detects_a_degenerate_shift_set) {
+    BOOST_TEST(routing::gf2_rank({}) == 0U);
+    BOOST_TEST(routing::gf2_rank({0ULL, 0ULL}) == 0U);
+    BOOST_TEST(routing::gf2_rank({0b001ULL, 0b010ULL, 0b011ULL}) == 2U); // third is the XOR of the first two
+    BOOST_TEST(routing::gf2_rank({0b001ULL, 0b010ULL, 0b100ULL}) == 3U);
+
+    // The real generator shifts must span at least log2(R) dimensions or the reachable ranks are a
+    // strict subspace of the rank space.
+    constexpr size_t kRanks = 128;
+    const auto router = Router::for_modes<kN>(kRanks, 14, true);
+    std::vector<uint64_t> shifts;
+    for (const auto &g : random_monomials(200, 4, 0x7777ULL)) {
+        shifts.push_back(static_cast<uint64_t>(router.rank_shift<kN>(g)));
+    }
+    // Seed-independent, so this is NOT skipped when monoprop_ROUTE_SEED is overridden: 200 vectors fail
+    // to span F_2^7 with probability ~2^-194, whatever basis the seed picks.
+    BOOST_TEST(routing::gf2_rank(shifts) == 7U); // == log2(128): every rank is reachable
+}
+
+// The SHIPPED default, pinned by a test rather than left to a comment: with no environment override a
+// power-of-two rank count routes linearly at fanout 1, a single rank routes densely, and a geometry
+// with no XOR structure is refused. Skipped when the environment does override it, because then the
+// default is not what is under test.
+BOOST_AUTO_TEST_CASE(routing_default_is_linear_where_the_geometry_allows_it) {
+    const char *mode = std::getenv("monoprop_ROUTING");
+    if (mode != nullptr && *mode != '\0') {
+        BOOST_TEST_MESSAGE("routing overridden in the environment; default not under test");
+        return;
+    }
+    BOOST_TEST(routing::make_router<kN>(8, 14).is_linear());
+    BOOST_TEST(routing::make_router<kN>(128, 14).linear_bits() == 7U);
+    BOOST_TEST(!routing::make_router<kN>(1, 112).is_linear()); // single rank: nothing to route between
+
+    // 6 and 12 are not powers of two: no XOR structure and no partial dial to retreat to, so the
+    // geometry is rejected instead of silently routing onto a subspace of the ranks.
+    BOOST_CHECK_THROW(routing::make_router<kN>(6, 14), routing::UnroutableGeometry);
+    BOOST_CHECK_THROW(routing::make_router<kN>(12, 28), routing::UnroutableGeometry);
+}
+
+// monoprop_ROUTING=splitmix is a live escape and not a historical arm: it is the only routing a
+// non-power-of-two rank count can use, and it must still be main's map bit for bit under it.
+BOOST_AUTO_TEST_CASE(routing_splitmix_escape_serves_a_non_power_of_two_world) {
+    const auto monos = random_monomials(300, 5, 0xE5CA9EULL);
+    for (const auto [r, s] : {std::pair<size_t, size_t>{6, 1}, {12, 5}, {3, 14}}) {
+        const auto router = Router::for_modes<kN>(r, s, /*linear=*/false);
+        BOOST_REQUIRE(!router.is_linear());
+        BOOST_REQUIRE_EQUAL(router.flat_world(), r * s);
+        for (const auto &m : monos) {
+            BOOST_REQUIRE_EQUAL(router.dest<kN>(m), monomial_hash<kN>(m) % (r * s));
+        }
+    }
+}

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -89,3 +89,16 @@
       primaryClass={quant-ph},
       url={https://arxiv.org/abs/2603.23444},
 }
+
+@ARTICLE{Broers2025-or,
+  title         = "{Scalable Simulation of Quantum Many-Body Dynamics with Or-Represented Quantum Algebra}",
+  author        = "Broers, Lukas and Sun, Rong-Yang and Yunoki, Seiji",
+  journal       = "Phys. Rev. Applied",
+  volume        =  26,
+  pages         = "024046",
+  year          =  2026,
+  url           = "https://arxiv.org/abs/2506.13241",
+  archivePrefix = "arXiv",
+  primaryClass  = "quant-ph",
+  eprint        = "2506.13241"
+}

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -39,6 +39,9 @@ larger `lower_atol` (see [Truncation and cutoffs](/features/cutoff)).
 | `monoprop_NUM_THREADS` | one partition per physical core | Caps the number of partitions. Set it to run fewer partitions than cores. |
 | `monoprop_PARTITIONS` | `auto` | `auto` = one partition per core (capped by `monoprop_NUM_THREADS`); an integer `N` = exactly `N` partitions; `off` = one partition holding the whole operator. |
 
+Two further variables control which MPI rank owns a term; they belong with the
+distribution axis and are documented under [Rank routing](#rank-routing) below.
+
 ```bash
 # Run 8 partitions instead of one-per-core:
 export monoprop_NUM_THREADS=8
@@ -124,6 +127,68 @@ MPI partitions the operator and graph across ranks, composing with per-rank
 partitioning into one flat world of `R × S` partitions (`R` ranks, `S` partitions each).
 MPI communication is serialised through each rank's first partition, bracketed by
 the intra-rank barriers.
+
+### Rank routing
+
+For $N$ modes, monomials under a gate form the group $(\mathbb{F}_2^{2N}, \oplus)$: a generator $G$ sends
+$M \mapsto M \oplus G$. The rank index is chosen to be a homomorphism of that group —
+$h(M) = \bigoplus_{i \in \mathrm{supp}(M)} v_i$, over one fixed vector $v_i$ per Majorana
+slot, with $h_d$ its low $d = \log_2 R$ bits — so that
+
+$$
+h(M \oplus G) = h(M) \oplus h(G).
+$$
+
+Three consequences. A rank owning the fibre $h_d^{-1}(r)$ sends every query for $G$ to
+$r \oplus h_d(G)$: one peer, independent of $R$ and of $|\mathrm{supp}\,G|$, where a
+full-avalanche hash sprays the same queries across all $R$ ranks. XOR is an involution, so
+the peer relation is symmetric and both sides derive the pairing without communicating.
+And the fibres are cosets of $\ker h_d$, all of size $2^{2N-d}$, so a uniformly drawn
+monomial is balanced by construction; imbalance can only come from the operator's support
+being non-uniform, which is why balance is measured rather than proved — rank occupancy
+max/mean 1.001 at $R = 128$, with every rank used.
+
+The one condition is that the per-generator shifts $\{h_d(G)\}$ span $\mathbb{F}_2^{d}$.
+If they span only $\rho < d$ dimensions, the ranks a query can reach form a coset of a
+$\rho$-dimensional subspace: only $2^{\rho}$ of the $2^{d}$ are ever used and the rest stay
+empty. That is a load-balance failure and not a wrong answer, so it is reported as one
+`COMMROUTE` line per rank rather than enforced at runtime — measured $\rho = 32$ over the
+60-site Hubbard's 416 distinct shifts, against the $d = 7$ that $R = 128$ needs.
+
+The same image $h(M)$ — the term's *fingerprint*, computed by XOR-ing one label per set
+position, so a packed row need never be expanded into a bitset to be routed — also places
+the term within a rank. With $S$ a power of two the partition takes the next $\log_2 S$ bits
+of $h$, so the whole flat slot is linear in $M$ and every partition has exactly one peer
+partition per generator, inside the rank as well as across ranks:
+
+$$
+\mathrm{flat}(M) = h_d(M)\,S + \bigl(h(M) \gg d\bigr) \bmod S,
+\qquad
+\mathrm{flat}(M \oplus G) = \mathrm{flat}(M) \oplus \mathrm{flat}(G).
+$$
+
+With $S$ not a power of two only the rank level has that structure: the partition is the
+mixed fingerprint modulo $S$, balance only, and a generator's queries from one partition
+land on the $S$ partitions of one peer rank.
+
+Linear routing is a switch and not a dial: the rank index takes every bit of $h$ or none of
+them, and none of them is `splitmix`, which reproduces the dense `hash % (R × S)` bit for
+bit. It therefore requires $R$ to be a power of two; any other rank count has no XOR
+structure to route by and is raised at propagator construction rather than silently routed
+onto a subspace of the ranks. $R = 1$ is a power of two, takes no rank bit, and so is the
+dense case already.
+
+A related distributed scheme maps an index by summing its $k$-bit blocks modulo the rank
+count [@Broers2025-or]. That sum is additive modulo that count while the gate acts by XOR,
+so the carries make $f(I \oplus J)$ differ from $f(I)$ by $\pm 2^{J_j \bmod k}$ terms whose
+signs depend on the bits of $I$, bounding the destinations at $2^{2|J|+1}$ rather than
+collapsing them to one. Being linear over the same group the gate acts by is what turns
+that bound into an identity.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `monoprop_ROUTING` | `linear` | `splitmix` selects the dense all-to-all; `linear`, or unset, takes every rank bit from $h$ and requires a power-of-two $R$. Any other value is rejected at startup rather than silently defaulting. |
+| `monoprop_ROUTE_SEED` | `6768574230969066775` | Decimal `uint64` from which every rank derives the same basis $\{v_i\}$ with no communication. The same value must reach every rank: a mismatch in either of these variables, or in the partition count, is caught by two allreduces at propagator construction and raised, because under linear routing it deadlocks the exchange instead of corrupting it. |
 
 ### Single-node (`MPI.COMM_SELF`)
 

--- a/docs/content/docs/references.mdx
+++ b/docs/content/docs/references.mdx
@@ -50,4 +50,11 @@ described in [@Miller2023-bonsai]. Other representative large-scale applications
     <em>arXiv [quant-ph]</em>, 2026.
     <a href="http://arxiv.org/abs/2605.04025">arXiv:2605.04025</a>
   </li>
+  <li id="bib-broers2025-or">
+    L. Broers, R.-Y. Sun, and S. Yunoki,
+    "Scalable simulation of quantum many-body dynamics with or-represented
+    quantum algebra,"
+    <em>Phys. Rev. Applied</em>, vol. 26, p. 024046, 2026.
+    <a href="https://arxiv.org/abs/2506.13241">arXiv:2506.13241</a>
+  </li>
 </ol>

--- a/tests/test_parameter_validation.py
+++ b/tests/test_parameter_validation.py
@@ -75,6 +75,29 @@ class TestConstructorValidation:
                 comm=serial_comm,
             )
 
+    def test_schrodinger_cutoff_error_survives_several_partitions(
+        self, serial_comm, monkeypatch
+    ):
+        """The setting must be named even when the partitions raise it concurrently.
+
+        Every partition rejects the same setting, so one of them can be unwinding while its
+        peers are still inside a construction-time collective -- which poisons the in-process
+        comm and replaces the message with the poison. Constructing repeatedly is deliberate:
+        the ordering is a race, so one attempt is not evidence.
+        """
+        monkeypatch.setenv("monoprop_PARTITIONS", "4")
+        num_modes = 64
+        operator = MajoranaOperator({(0, 1): 1.0j}, num_modes=num_modes)
+        for _ in range(8):
+            with pytest.raises(RuntimeError, match="schrodinger_cutoff"):
+                MajoranaPropagator(
+                    operator,
+                    [],
+                    cutoff=4,
+                    schrodinger_cutoff=2 * num_modes,
+                    comm=serial_comm,
+                )
+
 
 class TestGraphAndParameterValidation:
     def test_build_graph_accumulates_layers(self, serial_comm):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Rank routing was duplicated inline at more than one call site. This PR consolidates it into a
single `routing::Router` (`detail/mpi/Routing.h`) with one default scheme: a GF(2)-linear
term→slot map, resolved per call from a `fingerprint_positions` fold of the monomial's positions.
`monoprop_ROUTING=splitmix` stays a live fallback (`monomial_hash % (R × S)`) for a rank count that
is not a power of two, where the linear scheme has no XOR structure to use; under the new default,
such a rank count now throws instead of silently routing.

`EnvConfig.h` centralizes the knobs the engine reads at runtime (`ROUTING`, `ROUTE_SEED`,
`COMMPROF`, `NUM_THREADS`, `PARTITIONS` — deliberately not `MEMPROF`/`TIMEPROF`, which stay local
diagnostics per the owner's decision and do not land in this stack). The router is resolved per
call (`build_layer`, propagator construction, `update_initial_operator`, the coverage report)
rather than held as a `MonomialPropagator` member, so downstream signatures are unchanged and PR 3
and PR 4's diffs against this PR stay small.

This is PR 2 of 7, based on `perf/stack-1-chunked-store`. The router is neutral at `R=1` and the
tip of every A/B row below confirms it. The next PR (`perf/stack-3-sparse-exchange`) uses the
router's peer geometry to narrow the exchange to reachable peers.

## Changes

**Engine**
- `cpp/monoprop/detail/EnvConfig.h` (new, 140 lines): parses the routing/thread/partition knobs
  in one place.
- `cpp/monoprop/detail/mpi/Routing.h` (new, 279 lines): `Router`, `linear_hash`,
  `fingerprint_positions`, `gf2_rank`, `UnroutableGeometry`.
- `cpp/monoprop/detail/mpi/MPIUtils.h`: `find_rank(mono, Router)`, `router_for`,
  `check_routing_agreement` (a collective that confirms every rank resolved the same geometry).
- `cpp/monoprop/detail/mpi/MPICompat.h`/`.cpp`: geometry export used by the agreement check.
- `cpp/monoprop/detail/evolution/layer_build/Engine.h`, `Scan.h`: destination calls take the
  `Router`; `Scan.h` takes it in place of a bare rank count (`rank_count = router.flat_world()`).
- `cpp/include/monoprop/MonomialPropagator.h`/`.inl`: seeds and resolves the router, reports
  routing coverage; `c310423` skips the scan and exchange outright for an identity generator.

**Tests**
- `cpp/tests/env_config_tests.cpp` (new), `routing_tests.cpp` (new, 429 lines: the linear/splitmix
  equivalence and the non-power-of-two refusal).
- `cpp/tests/mpi_utils_tests.cpp`: extended to both routers, plus a `check_routing_agreement` case
  exercised by the `mpiexec -n 2` ctest variant.
- `tests/test_parameter_validation.py`: `test_schrodinger_cutoff_error_survives_several_partitions`
  (the flake-fix regression test, see Notes below).

**Docs**
- `docs/content/docs/features/parallelism.mdx`: "### Rank routing" section and env table rows.
- `docs/bibliography.bib`, `docs/content/docs/references.mdx`: the routing citations.
- `AGENTS.md`: one Notes bullet documenting the `splitmix` fallback and its refusal behavior.

## Measurements

Gated multiset (not positional) vs origin/main c5e88c8's raw coefficient bits, because routing
moves the row → rank assignment at `R > 1`, which moves the raw dump's positional layout even
though it changes no value and no term set. gate record md5
`33275f8b1563c2b646c6d11f5aba7779` (rebased onto PR 1 at `19bd012`).

3 interleaved reps, ratios only:

| rung | time st2/mainB | time st1/mainB (predecessor) | peak st2/mainB | peak st1/mainB (predecessor) |
| --- | ---: | ---: | ---: | ---: |
| L1-hubbard | 1.003 | 1.001 | 0.885 | 0.886 |
| L1-pauli | 0.999 | 0.994 | 0.870 | 0.885 |
| M2a-hubbard | 0.988 | 0.988 | 0.959 | 0.960 |

All three rungs run at `R=1`, where the router is a no-op by design; st2 is within noise of st1 on
every row (time and peak both), which is the expected result for this PR — it is neutral until a
later level exercises `R>1`.

## Notes for reviewers

- Non-power-of-two rank counts now throw under the default (linear) routing —
  `"linear routing needs a power-of-two rank count, got 3 ..."` — where main previously routed
  silently under its inline scheme. This is deliberate and documented (`parallelism.mdx`,
  `AGENTS.md`); `monoprop_ROUTING=splitmix` is the escape and is exercised at `n=3` in
  `--with-mpi` pytest.
- `EnvConfig` parses `comm_profile`/`parse_bool`, but nothing reads it yet — its consumer,
  `report_comm_profile_`, is PR 5's — so `monoprop_COMMPROF` is deliberately not documented in
  `parallelism.mdx` until then.
- `routing_tests.cpp` does not carry `SlotWindow`/`PeerPlan`/`WindowVec` cases; those types land
  with PR 3's `Comm.h`.
- **CI, disclosed flake:** the first post-rebase `n=4` `--with-mpi` pytest run failed with one rank
  exit 1. Root cause: `check_routing_agreement` sat near the top of the constructor, before the
  `schrodinger_cutoff` ceiling check, so one partition could unwind its throw while peers were still
  inside the agreement allreduce, poisoning `ShmComm` and reporting "ShmComm poisoned" instead of
  the real validation error. Fixed in `19bd012` by moving the agreement collective to the
  constructor's last act, after every deterministic validation; the contract is unchanged (it still
  fires before the first exchange, and seeding communicates nothing, so a rank with a divergent
  router has only claimed the wrong share by the time it throws). Verified with 10/10 clean
  `mpiexec -n 4` `--with-mpi` pytest runs after the fix, against 1 failure in 9 before it.
- No new ledger keys in this PR.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable (n/a — the repository has no `CHANGELOG`)

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (claude-sonnet-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
