### PR TITLE
perf(mpi): ⚡ exchange gate payloads point-to-point over reachable peers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,4 +64,8 @@ just build-docs
   not a power of two: the default GF(2)-linear routing has no XOR structure to use there and refuses
   the geometry. It is bit-for-bit `monomial_hash % (R × S)`, and `routing_tests.cpp` pins both that
   equivalence and the refusal.
+- MPI CTest variants run at 2 **and** 4 ranks (`monoprop_MPI_TEST_PROCS` in
+  `cpp/tests/boost-test.cmake`): at 2 ranks a peer plan resolves one peer, so the sparse transport's
+  multi-peer paths are unreachable. Cross-rank cases self-skip below two ranks, so the same file runs
+  in the serial variant too.
 - Sanitizer rebuild and test:

--- a/cpp/include/monoprop/MonomialPropagator.h
+++ b/cpp/include/monoprop/MonomialPropagator.h
@@ -141,6 +141,9 @@ public:
         // leaves matched_scratch_bytes at 0 and only this level can fill it in.
         auto breakdown = detail::estimate_memory_usage(mp_op_);
         breakdown.matched_scratch_bytes = matched_scratch_.memory_bytes();
+        // The transport is shared by all S partitions of this rank, so only partition 0 reports it and
+        // the facade's sum over partitions counts the rank's staging exactly once.
+        breakdown.wire_staging_bytes = comm_.shm_rank == 0 ? mpi::staging_bytes(comm_) : 0uz;
         return breakdown;
     }
 

--- a/cpp/monoprop/Evolution.cpp
+++ b/cpp/monoprop/Evolution.cpp
@@ -26,6 +26,7 @@
 #include "monoprop/detail/evolution/CosineRecomputeCallbacks.h"
 #include "monoprop/detail/mpi/Exchange.h"
 #include "monoprop/detail/mpi/MPICompat.h"
+#include "monoprop/detail/mpi/Routing.h"
 
 namespace monoprop {
 namespace {
@@ -70,8 +71,22 @@ auto &acquire_flat_exchange_buffers() {
 }
 
 // A property of the communicator, not the layer: all ranks participate even at local total_count 0.
+// Still true with the pairwise arm: `wire_bits` decides the transport for the whole communicator, so a
+// rank that skipped the round strands the others whichever transport they are on.
 auto layer_exchange_participates(const mpi::Comm &comm) -> bool {
     return mpi::size(comm) != 1;
+}
+
+// The transport gate for post_flat_alltoallv, and the ONLY thing allowed to choose it: rank-uniform by
+// construction, because linear_bits_for reads the environment alone and check_routing_agreement
+// allreduces exactly that configuration at propagator construction and throws rather than proceed on a
+// mismatch. Fanout 1 -- every generator's queries land on one destination rank -- is both why a layer's
+// other legs are empty and why no rank can be on the other side of the branch. Any other geometry keeps
+// the collective.
+auto layer_exchange_wire_bits(const mpi::Comm &comm) -> int {
+    const auto ranks = static_cast<size_t>(mpi::geometry(comm).ranks);
+    const size_t bits = routing::linear_bits_for(ranks);
+    return (ranks >> bits) == 1 ? static_cast<int>(bits) : 0;
 }
 
 // Derives both sides at once: the count matrix is symmetric, so the recv layout is the send layout.
@@ -112,7 +127,8 @@ inline auto begin_flat_exchange(FlatExchangeBuffers &buffers, const mpi::Comm &c
                                                       .recv_counts = layout.counts.data(),
                                                       .recv_displs = layout.displs.data()},
                                                      mpi::size(comm),
-                                                     comm);
+                                                     comm,
+                                                     layer_exchange_wire_bits(comm));
     return handle;
 }
 

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -340,6 +340,9 @@ struct LayerBuildEngine {
     std::vector<std::vector<double>> src_val_r;
     // Fused query+value send scratch (ContractSink, R>1): shared by a gate's two exchange passes.
     std::vector<VecZ> combined_qv_;
+    // Which destination ranks this gate's queries can reach. Dense unless the router is GF(2)-linear;
+    // see mpi::PeerPlan. Derived once per layer in build_layer, never per query.
+    mpi::PeerPlan plan;
     Sink sink;
 
     LayerBuildEngine(MPOperator<NumModes> &local_op_,
@@ -348,7 +351,8 @@ struct LayerBuildEngine {
                      size_t my_rank_,
                      MatchedEpochSet &matched_scratch,
                      size_t combined_size_,
-                     Sink &&sink_)
+                     Sink &&sink_,
+                     mpi::PeerPlan plan_ = {}) // dense by default: the tests build the engine directly
         : local_op(local_op_),
           comm(comm_),
           R(R_),
@@ -357,6 +361,7 @@ struct LayerBuildEngine {
           combined_size(combined_size_),
           queries_r(R_),
           src_idx_r(R_),
+          plan(plan_),
           sink(std::move(sink_)) {
         matched.begin_gate(combined_size);
     }
@@ -402,11 +407,12 @@ struct LayerBuildEngine {
         }
         std::vector<VecZ> &send = sink.send_buffer(queries_r, src_val_r, combined_qv_);
         std::vector<std::vector<size_t>> inc_q;
-        mpi::begin_alltoallv(send, comm).wait_into(inc_q);
+        mpi::begin_alltoallv(send, comm, /*skip_self=*/false, /*known_recv_counts=*/nullptr, plan).wait_into(inc_q);
         auto resp = resolve_incoming<NumModes>(inc_q, local_op, R, is_leader_pass, matched, combined_size, sink);
         std::vector<int> resp_recv = response_recv_counts();
         std::vector<std::vector<typename Sink::Response>> inc_r;
-        mpi::begin_alltoallv(resp, comm, /*skip_self=*/false, &resp_recv).wait_into(inc_r);
+        // The answers retrace the queries, and the pairing is an XOR involution, so the same plan holds.
+        mpi::begin_alltoallv(resp, comm, /*skip_self=*/false, &resp_recv, plan).wait_into(inc_r);
         process_responses<NumModes>(inc_r, src_idx_r, queries_r, R, my_rank, sink);
     }
 
@@ -611,6 +617,11 @@ auto build_layer(MPOperator<NumModes> &local_op,
     // chemical potential alone contributes 60 of the 60-site Hubbard's 476 generators per Trotter
     // layer.) No gate is merged: a no-op gate is simply not exchanged for, and the layer is still built.
     const bool identity_gen = !gen.any();
+    // Under linear routing every query for THIS generator lands on the rank whose index is this rank's
+    // own XOR rank_shift(gen), so the exchange knows its peer before it starts. Dense otherwise, which
+    // is today's collective.
+    const auto plan =
+        mpi::PeerPlan{.sparse = router.is_linear(), .shift = static_cast<int>(router.rank_shift<NumModes>(gen))};
 
     FusedScanResult<NumModes> fused;
     CosMask cos_all;
@@ -650,7 +661,8 @@ auto build_layer(MPOperator<NumModes> &local_op,
                                              my_rank,
                                              matched_scratch,
                                              /*combined_size=*/local_op.store->size(),
-                                             std::move(sink));
+                                             std::move(sink),
+                                             plan);
         // LayerBuildEngine construction stays outside the test: its ctor sizes the caller-owned matched
         // scratch, which is reported as matched_scratch_bytes, so skipping it would move that telemetry
         // when a propagator's first gate is identity. The ctor is O(R).

--- a/cpp/monoprop/detail/mpi/CMakeLists.txt
+++ b/cpp/monoprop/detail/mpi/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
         "CpuRelax.h"
         "Exchange.h"
         "HybridComm.h"
+        "HybridStaging.h"
         "MPICompat.h"
         "MPIUtils.h"
         "PartitionBarrier.h"

--- a/cpp/monoprop/detail/mpi/CMakeLists.txt
+++ b/cpp/monoprop/detail/mpi/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
         "HybridStaging.h"
         "MPICompat.h"
         "MPIUtils.h"
+        "Pairwise.h"
         "PartitionBarrier.h"
         "Routing.h"
         "ShmComm.h"

--- a/cpp/monoprop/detail/mpi/Comm.h
+++ b/cpp/monoprop/detail/mpi/Comm.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -62,6 +63,84 @@ struct Comm {
         c.hyb = group;
         c.shm_rank = local_partition;
         return c;
+    }
+};
+
+/*!
+ * @brief A window-relative index. Distinct from a flat slot on purpose: the two are the same number
+ * only when the window starts at 0, so a swap addresses the wrong peer while staying in bounds.
+ */
+struct WindowIndex {
+    size_t value = 0;
+
+    constexpr WindowIndex() = default;
+    explicit constexpr WindowIndex(size_t v) noexcept : value(v) {}
+};
+
+/*!
+ * @brief The contiguous run of flat destination slots a round can reach.
+ *
+ * Slots are rank-major (slot = rank * S + partition), so one rank's S partitions are contiguous and
+ * the single peer sparse routing leaves is exactly one such run; dense is the count == P value of the
+ * same run, not a second shape. See PeerPlan::window.
+ */
+struct SlotWindow {
+    size_t base = 0;  //!< First reachable flat slot.
+    size_t count = 0; //!< Slots in the run.
+
+    [[nodiscard]] constexpr auto stop() const -> size_t { return base + count; }
+    [[nodiscard]] constexpr auto contains(size_t slot) const -> bool { return slot >= base && slot < stop(); }
+    //! @brief The one flat-slot door: it asserts membership, so a slot from outside cannot become
+    //! another's entry.
+    [[nodiscard]] constexpr auto index(size_t slot) const -> WindowIndex {
+        assert(contains(slot) && "flat slot outside the window it is being re-based into");
+        return WindowIndex{slot - base};
+    }
+    [[nodiscard]] constexpr auto slot(WindowIndex i) const -> size_t {
+        assert(i.value < count);
+        return base + i.value;
+    }
+};
+
+/*!
+ * @brief Which destination RANKS a round can touch, when the caller knows.
+ *
+ * Two states, matching routing::Router: dense, or sparse over the single peer GF(2)-linear routing
+ * implies. Sparse means the destination rank of every block is determined by the generator -- this
+ * rank's own index XOR `shift`, so `peer = me ^ shift` with `count == 1`. XOR is an involution, so
+ * the pairing is symmetric and every rank derives it with no communication; that is what lets a verb
+ * replace a dense collective with point-to-point. Linear routing takes ALL log2(ranks) rank bits, so
+ * there is no intermediate fanout to express here.
+ *
+ * Dense is the default: `peer(k) == k` and `count == ranks`, so the same loops walk every rank and the
+ * verbs take their collective path. Every single-rank run is dense (Router::is_linear is false at
+ * R == 1), so the collectives are the common case rather than a fallback.
+ *
+ * Two distinct failure modes if `shift` is wrong, which is why the plan is derived in one place. Ranks
+ * that DISAGREE deadlock: the pairing stops being symmetric and someone waits on a send never posted.
+ * Ranks that all agree on the same wrong shift stay symmetric and never hang -- they silently DROP the
+ * blocks outside the peer set, because every staging sweep only ever touches peers. HybridStaging's
+ * pack_count_matrix asserts the non-peer remainder is empty to catch that one.
+ */
+struct PeerPlan {
+    bool sparse = false;
+    int shift = 0;
+
+    [[nodiscard]] constexpr auto dense() const -> bool { return !sparse; }
+    [[nodiscard]] constexpr auto count(int ranks) const -> int { return sparse ? 1 : ranks; }
+    //! @brief `k` indexes the peer set, which is a singleton when sparse.
+    [[nodiscard]] constexpr auto peer(int me, int k) const -> int { return sparse ? (me ^ shift) : k; }
+    [[nodiscard]] constexpr auto contains(int me, int b) const -> bool { return !sparse || b == (me ^ shift); }
+    /*!
+     * @brief The flat slots reachable from @a me_flat over a @a ranks x @a parts world.
+     *
+     * One expression per field: sparse names the peer rank's `parts` slots, dense is the same with peer
+     * rank 0 and count(ranks) == ranks, i.e. the whole world.
+     */
+    [[nodiscard]] constexpr auto window(size_t me_flat, size_t ranks, size_t parts) const -> SlotWindow {
+        const size_t peer_rank = sparse ? ((me_flat / parts) ^ static_cast<size_t>(shift)) : 0;
+        return SlotWindow{.base = peer_rank * parts,
+                          .count = static_cast<size_t>(count(static_cast<int>(ranks))) * parts};
     }
 };
 

--- a/cpp/monoprop/detail/mpi/Exchange.h
+++ b/cpp/monoprop/detail/mpi/Exchange.h
@@ -14,11 +14,15 @@
 
 #pragma once
 
+#include <cstddef>
 #include <span>
 #include <utility>
 #include <vector>
 
 #include "monoprop/detail/mpi/MPICompat.h"
+#ifdef monoprop_ENABLE_MPI
+#include "monoprop/detail/mpi/Pairwise.h"
+#endif
 
 // Keeps #ifdef monoprop_ENABLE_MPI out of the consumers; non-MPI builds get self-copy stubs.
 
@@ -28,11 +32,21 @@ namespace monoprop::mpi {
 // whatever the span holds, so a layout built for a differently sized communicator reads out of bounds.
 auto check_exchange_layout_width(std::span<const int> send_counts, const Comm &comm) -> void;
 
+// Legs carrying a payload in either direction, i.e. an upper bound on what the pairwise path posts.
+[[nodiscard]] inline auto active_leg_count(const int *send_counts, const int *recv_counts, int num_ranks) -> int {
+    int legs = 0;
+    for (int i = 0; i < num_ranks; ++i) {
+        legs += static_cast<int>(send_counts[i] != 0 || recv_counts[i] != 0);
+    }
+    return legs;
+}
+
 // Idempotent completion handle for a posted payload transfer; move-only, so a request is waited on
-// exactly once. wait() is a no-op on the blocking path and in non-MPI builds. Owns its request: the
-// destructor completes anything still in flight, because a dropped in-flight MPI_Ialltoallv -- what an
+// exactly once. wait() is a no-op on the blocking path and in non-MPI builds. Owns its requests: the
+// destructor completes anything still in flight, because a dropped in-flight transfer -- what an
 // exception between post and wait does -- keeps writing into a thread_local buffer the next exchange
-// reallocates.
+// reallocates. The pairwise arm's request vector lives here for the same reason: MPI reads it until the
+// wait, and a vector move keeps its heap block, so the handle can travel.
 class [[nodiscard("call wait() on the Ticket to complete the posted transfer")]] Ticket {
 public:
     Ticket() = default;
@@ -45,6 +59,8 @@ public:
             wait(); // never drop a request this handle already owns
             request_ = other.request_;
             other.request_ = MPI_REQUEST_NULL;
+            requests_ = std::move(other.requests_);
+            posted_ = std::exchange(other.posted_, 0);
         }
 #endif
         (void)other;
@@ -58,22 +74,47 @@ public:
             MPI_Wait(&request_, MPI_STATUS_IGNORE);
             request_ = MPI_REQUEST_NULL;
         }
+        if (posted_ != 0) {
+            MPI_Waitall(posted_, requests_.data(), MPI_STATUSES_IGNORE);
+            posted_ = 0;
+        }
+#endif
+    }
+
+    // Requests wait() still has to drain: 1 for the collective, two per pairwise leg, 0 for nothing
+    // posted. The only handle on which transport a post took.
+    [[nodiscard]] auto in_flight() const -> int {
+#ifdef monoprop_ENABLE_MPI
+        return static_cast<int>(request_ != MPI_REQUEST_NULL) + posted_;
+#else
+        return 0;
 #endif
     }
 
 #ifdef monoprop_ENABLE_MPI
     explicit Ticket(MPI_Request request) : request_(request) {}
+    Ticket(std::vector<MPI_Request> requests, int posted) : requests_(std::move(requests)), posted_(posted) {}
 
 private:
-    MPI_Request request_ = MPI_REQUEST_NULL;
+    MPI_Request request_ = MPI_REQUEST_NULL; // the dense collective
+    std::vector<MPI_Request> requests_;      // the pairwise arm's pairs; `posted_` of them are live
+    int posted_ = 0;
 #endif
 };
 
-// Never skipped on zero total: all ranks must participate or the collective deadlocks. Non-blocking
-// (MPI_Ialltoallv) in an MPI build (the Ticket completes it); non-MPI build does a per-rank self-copy
-// (recv layout == send layout).
+// Never skipped on zero total: the collective arm needs all ranks or it deadlocks. Non-blocking in an
+// MPI build -- MPI_Ialltoallv, or Isend/Irecv over the legs that carry a payload (the Ticket completes
+// either); non-MPI build does a per-rank self-copy (recv layout == send layout).
+//
+// `wire_bits` picks the transport and MUST be RANK-UNIFORM: a rank choosing MPI_Ialltoallv waits forever
+// on ranks that chose point-to-point, and no predicate over a rank's OWN row can promise that (rows
+// vary, so any threshold on one straddles). It is the resolved linear-routing bit count when that
+// routing gives fanout 1 -- one destination rank per generator, which is what empties the other legs --
+// and 0, today's collective, for every other geometry. The caller owns that derivation; see
+// Evolution.cpp's layer_exchange_wire_bits.
 template <typename T>
-inline auto post_flat_alltoallv(const FlatAlltoallvArgs<T> &args, int num_ranks, Comm comm) -> Ticket {
+inline auto post_flat_alltoallv(const FlatAlltoallvArgs<T> &args, int num_ranks, Comm comm, int wire_bits = 0)
+    -> Ticket {
     // The in-process transports address the buffers as raw bytes; MPI_Ialltoallv below still takes the
     // typed pointers plus a datatype. Offsets stay in elements on both paths.
     if (comm.kind == Comm::Kind::Shm) {
@@ -91,8 +132,33 @@ inline auto post_flat_alltoallv(const FlatAlltoallvArgs<T> &args, int num_ranks,
     }
 #ifdef monoprop_ENABLE_MPI
     if (comm.kind == Comm::Kind::Hybrid) {
-        comm.hyb->alltoallv(comm.shm_rank, args.bytes(), datatype<T>::get());
+        // The wire is narrowed inside the verb, not here: only partition 0 reaches MPI, and it cannot
+        // name the rank's peer from its own row alone (its row may be the empty one). See HybridComm.
+        comm.hyb->alltoallv(comm.shm_rank, args.bytes(), datatype<T>::get(), PeerPlan{}, wire_bits);
         return Ticket{};
+    }
+    if (wire_bits > 0) {
+        // Which legs to drop needs no plan and no count round: the count matrix is symmetric, so what
+        // this rank sends a peer IS that peer's recv count and both ends drop the same legs on the same
+        // value. The plan stays DENSE -- it walks all N and posts only the non-zero legs, which is
+        // exactly that -- so a mis-derived shift cannot drop a block here; `wire_bits` only chooses the
+        // transport. `legs` sizes the request vector, which a dense plan would otherwise take to 2N.
+        const int legs = active_leg_count(args.send_counts, args.recv_counts, num_ranks);
+        std::vector<MPI_Request> requests;
+        const int posted = sparse_pairwise(PeerPlan{},
+                                           rank(comm),
+                                           num_ranks,
+                                           comm.mpi,
+                                           kFlatReplayTag,
+                                           datatype<T>::get(),
+                                           sizeof(T),
+                                           reinterpret_cast<const std::byte *>(args.send),
+                                           PeerLayout{.counts = args.send_counts, .displs = args.send_displs},
+                                           reinterpret_cast<std::byte *>(args.recv),
+                                           PeerLayout{.counts = args.recv_counts, .displs = args.recv_displs},
+                                           requests,
+                                           legs);
+        return Ticket(std::move(requests), posted);
     }
     (void)num_ranks;
     MPI_Request request = MPI_REQUEST_NULL;
@@ -108,6 +174,7 @@ inline auto post_flat_alltoallv(const FlatAlltoallvArgs<T> &args, int num_ranks,
                    &request);
     return Ticket(request);
 #else
+    (void)wire_bits; // single participant: the self copy is the only transport
     for (int i = 0; i < num_ranks; ++i) {
         const int c = args.recv_counts[i];
         for (int j = 0; j < c; ++j) {

--- a/cpp/monoprop/detail/mpi/HybridComm.h
+++ b/cpp/monoprop/detail/mpi/HybridComm.h
@@ -15,23 +15,23 @@
 #pragma once
 
 #include <algorithm>
-#include <atomic>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <optional>
 #include <print>
 #include <stdexcept>
-#include <thread>
+#include <type_traits>
 #include <vector>
 
 #include <mpi.h>
 
 #include "monoprop/detail/mpi/CheckedCount.h"
 #include "monoprop/detail/mpi/Comm.h"
+#include "monoprop/detail/mpi/HybridStaging.h"
 #include "monoprop/detail/mpi/PartitionBarrier.h"
 
 // Composes R MPI ranks x S in-process partitions into one flat P=R*S SPMD world. Global id is rank-major
@@ -39,6 +39,10 @@
 // contract Resolve.h's positional pairing relies on. Only partition-0 masters call MPI (bracketed by
 // intra-rank barriers ⇒ requires MPI_THREAD_SERIALIZED); ascending-order local sums + order-preserving
 // MPI ⇒ bit-identical, repeatable results for fixed (R, S).
+//
+// The staging tables and the sweeps over them live in HybridStaging.h; this file owns the barrier
+// discipline, the verbs and the reductions. Phase names used throughout: P0 is the pre-barrier publish
+// each partition does into its own row, then B1..B4 are the four barriers a payload verb takes.
 
 namespace monoprop::mpi {
 
@@ -64,33 +68,7 @@ public:
                                             "MPI while peers are parked); provided level is lower. Ensure "
                                             "mpi::init / mpi4py requests SERIALIZED or MULTIPLE.");
         }
-        // Size all (R,S)-fixed scratch once so per-call paths never allocate; staging grows on demand.
-        const size_t rss = static_cast<size_t>(r_) * static_cast<size_t>(s_) * static_cast<size_t>(s_);
-        const size_t p = static_cast<size_t>(r_) * static_cast<size_t>(s_);
-        counts_send_.resize(rss);
-        counts_recv_.resize(rss);
-        mpi_send_counts_.resize(static_cast<size_t>(r_));
-        mpi_recv_counts_.resize(static_cast<size_t>(r_));
-        mpi_send_displs_.resize(static_cast<size_t>(r_));
-        mpi_recv_displs_.resize(static_cast<size_t>(r_));
-        pack_off_.resize(static_cast<size_t>(s_) * p); // same S*R*S elements as before, indexed (u, g)
-        base_send_.resize(p);
-        base_recv_.resize(p);
-        col_sum_.resize(p);
-        recv_col_.resize(p);
-        // Rounded up to whole 64-byte lines: each row has its own writer, so a shared line false-shares.
-        counts_stride_ = round_up_(p, kIntsPerLine);
-        rows_stride_ = round_up_(static_cast<size_t>(r_), kLongsPerLine);
-        // One spare line each: the allocator guarantees alignof(T), not 64, so row 0 must be realigned.
-        counts_matrix_store_.assign(static_cast<size_t>(s_) * counts_stride_ + kIntsPerLine, 0);
-        counts_matrix_ = align_to_line_(counts_matrix_store_.data());
-        rows_store_.assign(static_cast<size_t>(s_) * rows_stride_ + kLongsPerLine, 0LL);
-        rows_ = align_to_line_(rows_store_.data());
-        assert(reinterpret_cast<uintptr_t>(counts_matrix_) % kLineBytes == 0);
-        assert(reinterpret_cast<uintptr_t>(rows_) % kLineBytes == 0);
-        assert(counts_matrix_ + static_cast<size_t>(s_) * counts_stride_
-               <= counts_matrix_store_.data() + counts_matrix_store_.size());
-        assert(rows_ + static_cast<size_t>(s_) * rows_stride_ <= rows_store_.data() + rows_store_.size());
+        staging_.emplace(parent_, mpi_rank_, r_, s_);
     }
 
     HybridComm(const HybridComm &) = delete;
@@ -142,7 +120,7 @@ public:
     auto reset() -> void { barrier_.reset(); }
 
 private:
-    // Counts travel through counts_matrix_ / rows_, not through here.
+    // Counts travel through the staging tables, not through here.
     struct alignas(64) Slot {
         const std::byte *ptr = nullptr; // byte view of this partition's send buffer; null until published
         const int *send_displs = nullptr;
@@ -172,82 +150,56 @@ private:
         }
     }
 
-    // recv_counts[g] = amount global partition g sends to this partition. 2 barriers + one S*S-int MPI_Alltoall.
+    // recv_counts[g] = amount global partition g sends to this partition. 2 barriers + one count round.
     auto alltoall_counts_impl_(int local_partition, const int *send_counts /*[P]*/, int *recv_counts /*[P]*/) -> void {
-        publish_counts_row_(local_partition, send_counts);
+        staging_->publish_counts_row(local_partition, send_counts);
         sync();
         if (local_partition == 0) {
-            pack_count_matrix_();
-            MPI_Alltoall(counts_send_.data(), s_ * s_, MPI_INT, counts_recv_.data(), s_ * s_, MPI_INT, parent_);
+            staging_->pack_count_matrix();
+            staging_->exchange_count_blocks();
         }
         sync();
         // Partition t extracts its row: recv from (rank a, partition su) is contiguous per source rank a.
         const int t = local_partition;
         for (int a = 0; a < r_; ++a) {
             for (int su = 0; su < s_; ++su) {
-                recv_counts[a * s_ + su] = counts_recv_[counts_idx_(a, t, su)];
+                recv_counts[a * s_ + su] = staging_->count_from(a, t, su);
             }
         }
-        // No trailing barrier: past the last sync only counts_recv_ is read, and partition 0 cannot rewrite
-        // it until a future call's second barrier — unreachable until every extractor here has arrived.
-        // send_counts is consumed before the first sync, so peers may free or reuse it on return.
+        // No trailing barrier: past the last sync only the count message is read, and partition 0 cannot
+        // rewrite it until a future call's second barrier — unreachable until every extractor here has
+        // arrived. send_counts is consumed before the first sync, so peers may free it on return.
     }
 
     // Flat variable all-to-all over caller-owned buffers; see AlltoallvArgs for the conventions.
     auto alltoallv_impl_(int local_partition, const AlltoallvArgs &args, MPI_Datatype dt) -> void {
-        const size_t u = static_cast<size_t>(local_partition);
-        Slot &me = slots_[u];
+        Slot &me = slots_[static_cast<size_t>(local_partition)];
         me.ptr = args.send;
         me.send_displs = args.send_displs;
-        publish_counts_row_(local_partition, args.send_counts);
-        publish_recv_rows_(local_partition, args.recv_counts);
+        staging_->publish_counts_row(local_partition, args.send_counts);
+        staging_->publish_recv_rows(local_partition, args.recv_counts);
         sync(); // B1
 
-        // B2: partition 0 sizes/reallocates staging; must finish before any partition packs into stage_send_.
+        // B2: partition 0 sizes/reallocates staging; must finish before any partition packs into it.
         if (local_partition == 0) {
-            size_staging_send_(args.elem);
-            fill_recv_col_from_rows_();
-            size_staging_recv_(args.elem);
+            staging_->size_send(args.elem);
+            staging_->fill_recv_col([this](int a, int t) { return staging_->published_recv(a, t); });
+            staging_->size_recv(args.elem);
         }
         sync(); // B2
 
-        // B3: each partition packs its own cross-rank blocks into stage_send_ (disjoint writes).
+        // B3: each partition packs its own cross-rank blocks into the send staging (disjoint writes).
         pack_send_(local_partition, args.elem);
         sync(); // B3
 
-        // B4: partition 0 runs the single MPI_Alltoallv while peers park at the barrier.
+        // B4: partition 0 moves the payload while peers park at the barrier.
         if (local_partition == 0) {
-            MPI_Alltoallv(stage_send_.data(),
-                          mpi_send_counts_.data(),
-                          mpi_send_displs_.data(),
-                          dt,
-                          stage_recv_.data(),
-                          mpi_recv_counts_.data(),
-                          mpi_recv_displs_.data(),
-                          dt,
-                          parent_);
+            staging_->exchange_payload(dt);
         }
         sync(); // B4
 
-        // Scatter each global source's contiguous run from stage_recv_ to recv_displs[g] (all legs, incl.
-        // self-rank, go through staging). Walks (a, su) in accumulation order, so `cur` re-derives the
-        // block starts from base_recv_ and this partition's own counts.
-        std::byte *dst = args.recv;
-        const int t = local_partition;
-        for (int a = 0; a < r_; ++a) {
-            size_t cur = base_recv_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)];
-            for (int su = 0; su < s_; ++su) {
-                const int g = a * s_ + su;
-                const int cnt = args.recv_counts[g];
-                if (cnt != 0) {
-                    std::memcpy(dst + static_cast<size_t>(args.recv_displs[g]) * args.elem,
-                                stage_recv_.data() + cur * args.elem,
-                                static_cast<size_t>(cnt) * args.elem);
-                }
-                cur += static_cast<size_t>(cnt);
-            }
-        }
-        // No trailing barrier: base_recv_ is rewritten only in a later verb's B1→B2 window.
+        staging_->scatter_recv(local_partition, args.recv, args.recv_counts, args.recv_displs, args.elem);
+        // No trailing barrier: the recv bases are rewritten only in a later verb's B1→B2 window.
     }
 
     // Fused count-resolve + payload alltoallv: folds the standalone count exchange into this verb's
@@ -257,22 +209,21 @@ private:
     auto alltoallv_resolve_impl_(int local_partition, const AlltoallvResolveArgs<T> &args, MPI_Datatype dt) -> void {
         // Typed verb: element bytes are sizeof(T) by construction, so they are derived rather than passed.
         constexpr size_t elem = sizeof(T);
-        const size_t u = static_cast<size_t>(local_partition);
-        Slot &me = slots_[u];
-        // Typed here but byte-addressed in the slot: pack_send_ copies by (displ, count) in elements and
+        Slot &me = slots_[static_cast<size_t>(local_partition)];
+        // Typed here but byte-addressed in the slot: pack_send copies by (displ, count) in elements and
         // never reconstructs T, so the slot stays type-erased for the untyped alltoallv_impl_ above.
         me.ptr = reinterpret_cast<const std::byte *>(args.send);
         me.send_displs = args.send_displs;
-        // Count row only: the recv counts do not exist until the count Alltoall in B1→B2.
-        publish_counts_row_(local_partition, args.send_counts);
+        // Count row only: the recv counts do not exist until the count round in B1→B2.
+        staging_->publish_counts_row(local_partition, args.send_counts);
         sync(); // B1
 
         if (local_partition == 0) {
-            pack_count_matrix_();
-            MPI_Alltoall(counts_send_.data(), s_ * s_, MPI_INT, counts_recv_.data(), s_ * s_, MPI_INT, parent_);
-            size_staging_send_(elem);
-            fill_recv_col_from_counts_recv_();
-            size_staging_recv_(elem);
+            staging_->pack_count_matrix();
+            staging_->exchange_count_blocks();
+            staging_->size_send(elem);
+            staging_->fill_recv_col([this](int a, int t) { return staging_->block_sum(a, t); });
+            staging_->size_recv(elem);
         }
         sync(); // B2
 
@@ -281,7 +232,7 @@ private:
         for (int a = 0; a < r_; ++a) {
             for (int su = 0; su < s_; ++su) {
                 const int g = a * s_ + su;
-                const int c = counts_recv_[counts_idx_(a, t, su)];
+                const int c = staging_->count_from(a, t, su);
                 args.recv_counts[g] = c;
                 args.recv_displs[g] = checked_mpi_count(total, "Recv displacement");
                 total += c;
@@ -293,33 +244,21 @@ private:
         sync(); // B3
 
         if (local_partition == 0) {
-            MPI_Alltoallv(stage_send_.data(),
-                          mpi_send_counts_.data(),
-                          mpi_send_displs_.data(),
-                          dt,
-                          stage_recv_.data(),
-                          mpi_recv_counts_.data(),
-                          mpi_recv_displs_.data(),
-                          dt,
-                          parent_);
+            staging_->exchange_payload(dt);
         }
         sync(); // B4
 
-        std::byte *dst = reinterpret_cast<std::byte *>(args.recv.data()); // after the resize: it may reallocate
-        for (int a = 0; a < r_; ++a) {
-            size_t cur = base_recv_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)];
-            for (int su = 0; su < s_; ++su) {
-                const int g = a * s_ + su;
-                const int cnt = args.recv_counts[g];
-                if (cnt != 0) {
-                    std::memcpy(dst + static_cast<size_t>(args.recv_displs[g]) * elem,
-                                stage_recv_.data() + cur * elem,
-                                static_cast<size_t>(cnt) * elem);
-                }
-                cur += static_cast<size_t>(cnt);
-            }
-        }
+        staging_->scatter_recv(local_partition,
+                               reinterpret_cast<std::byte *>(args.recv.data()), // after the resize: it may realloc
+                               args.recv_counts,
+                               args.recv_displs,
+                               elem);
         // No trailing barrier: same discipline as alltoallv_impl_.
+    }
+
+    auto pack_send_(int local_partition, size_t elem) -> void {
+        const Slot &me = slots_[static_cast<size_t>(local_partition)];
+        staging_->pack_send(local_partition, elem, me.ptr, me.send_displs);
     }
 
     template <typename T>
@@ -366,7 +305,7 @@ private:
         slots_[static_cast<size_t>(local_partition)].vec = values;
         sync(); // all inputs published
         if (local_partition == 0) {
-            grow_(red_vec_, len);
+            grow_to(red_vec_, len);
         }
         sync(); // red_vec_ sized
         constexpr size_t kLine = 64 / sizeof(double);
@@ -390,192 +329,6 @@ private:
         // No trailing barrier: red_vec_ is rewritten only inside a future verb's barriered phases.
     }
 
-    static constexpr size_t kLineBytes = 64;
-    static constexpr size_t kIntsPerLine = kLineBytes / sizeof(int);
-    static constexpr size_t kLongsPerLine = kLineBytes / sizeof(long long);
-
-    static auto round_up_(size_t n, size_t m) -> size_t { return ((n + m - 1) / m) * m; }
-
-    template <typename T>
-    static auto align_to_line_(T *p) -> T * {
-        static_assert(kLineBytes % sizeof(T) == 0);
-        const auto addr = reinterpret_cast<uintptr_t>(p);
-        const size_t pad = (kLineBytes - static_cast<size_t>(addr % kLineBytes)) % kLineBytes;
-        return p + pad / sizeof(T);
-    }
-
-    // (rank, dest partition, source partition) in the R*S*S count matrices: the count message's wire layout.
-    auto counts_idx_(int b, int t, int su) const -> size_t {
-        return (static_cast<size_t>(b) * static_cast<size_t>(s_) + static_cast<size_t>(t)) * static_cast<size_t>(s_)
-               + static_cast<size_t>(su);
-    }
-
-    // [S x P] payload offset table: row u is source partition u's staging starts, one per destination g.
-    auto pack_idx_(int u, int g) const -> size_t {
-        return static_cast<size_t>(u) * static_cast<size_t>(r_) * static_cast<size_t>(s_) + static_cast<size_t>(g);
-    }
-
-    auto counts_row_(int u) -> int * { return counts_matrix_ + static_cast<size_t>(u) * counts_stride_; }
-    auto row_recv_(int u) -> long long * { return rows_ + static_cast<size_t>(u) * rows_stride_; }
-
-    // Phase P0: partition u writes only its own row, so the pre-barrier write needs no barrier. The one
-    // cross-partition reader is partition 0 inside B1→B2, and no peer reaches verb k+1's P0 without
-    // passing verb k's B2, so the rewrite always follows the read.
-    auto publish_counts_row_(int local_partition, const int *send_counts) -> void {
-        std::memcpy(counts_row_(local_partition),
-                    send_counts,
-                    static_cast<size_t>(r_) * static_cast<size_t>(s_) * sizeof(int));
-    }
-
-    // long long: it sums S int counts.
-    auto publish_recv_rows_(int local_partition, const int *recv_counts) -> void {
-        long long *rr = row_recv_(local_partition);
-        for (int a = 0; a < r_; ++a) {
-            long long sum = 0;
-            for (int su = 0; su < s_; ++su) {
-                sum += recv_counts[a * s_ + su];
-            }
-            rr[a] = sum;
-        }
-    }
-
-    // Transpose the published count rows into counts_send_, dest-major then source-minor, for the one
-    // S*S-int MPI_Alltoall. Partition 0 only, inside a barriered window. Source partition outer, so the
-    // peer-owned side streams. Every element is written here, so no pre-zeroing.
-    auto pack_count_matrix_() -> void {
-        for (int su = 0; su < s_; ++su) {
-            const int *row = counts_row_(su);
-            for (int b = 0; b < r_; ++b) {
-                for (int t = 0; t < s_; ++t) {
-                    counts_send_[counts_idx_(b, t, su)] = row[b * s_ + t];
-                }
-            }
-        }
-    }
-
-    template <typename V>
-    static auto grow_(V &v, size_t need) -> void {
-        if (v.size() < need) {
-            v.resize(need);
-        }
-    }
-
-    // Partition 0's send-side staging sizing, between B1 and B2, in two sweeps of counts_matrix_. Wire
-    // block order is destination major, source minor: a per-destination base plus a per-source prefix.
-    auto size_staging_send_(size_t elem) -> void {
-        const size_t p = static_cast<size_t>(r_) * static_cast<size_t>(s_);
-        // Pass A: the column sums W over source partitions, u outer so both sides sweep in address order.
-        std::fill(col_sum_.begin(), col_sum_.end(), 0LL);
-        for (int u = 0; u < s_; ++u) {
-            const int *row = counts_row_(u);
-            for (size_t g = 0; g < p; ++g) {
-                col_sum_[g] += row[g];
-            }
-        }
-        for (int b = 0; b < r_; ++b) {
-            const long long *col = col_sum_.data() + static_cast<size_t>(b) * static_cast<size_t>(s_);
-            long long send_sum = 0;
-            for (int t = 0; t < s_; ++t) {
-                send_sum += col[t];
-            }
-            mpi_send_counts_[static_cast<size_t>(b)] = checked_mpi_count(send_sum, "Per-rank send count");
-        }
-        long long send_running = 0;
-        for (int b = 0; b < r_; ++b) {
-            mpi_send_displs_[static_cast<size_t>(b)] = checked_mpi_count(send_running, "Send displacement");
-            send_running += mpi_send_counts_[static_cast<size_t>(b)];
-        }
-        const size_t total_send = static_cast<size_t>(checked_mpi_count(send_running, "Total send count"));
-        for (int b = 0; b < r_; ++b) {
-            size_t cur = static_cast<size_t>(mpi_send_displs_[static_cast<size_t>(b)]);
-            for (int t = 0; t < s_; ++t) {
-                const size_t g = static_cast<size_t>(b) * static_cast<size_t>(s_) + static_cast<size_t>(t);
-                base_send_[g] = cur;
-                cur += static_cast<size_t>(col_sum_[g]);
-            }
-        }
-        // Pass B: the exclusive prefix over source partitions; col_sum_ is free to be reused for it here.
-        std::fill(col_sum_.begin(), col_sum_.end(), 0LL);
-        for (int u = 0; u < s_; ++u) {
-            const int *row = counts_row_(u);
-            size_t *off = pack_off_.data() + pack_idx_(u, 0);
-            for (size_t g = 0; g < p; ++g) {
-                off[g] = base_send_[g] + static_cast<size_t>(col_sum_[g]);
-                col_sum_[g] += row[g];
-            }
-        }
-        // Grow-only, no zero-fill: pack_send_'s blocks tile [0, total_send) exactly.
-        grow_(stage_send_, total_send * elem);
-    }
-
-    // recv_col_[a*S + t] = what partition t receives from rank a: the rows published in Phase P0.
-    auto fill_recv_col_from_rows_() -> void {
-        for (int a = 0; a < r_; ++a) {
-            for (int t = 0; t < s_; ++t) {
-                recv_col_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)] = row_recv_(t)[a];
-            }
-        }
-    }
-
-    auto fill_recv_col_from_counts_recv_() -> void {
-        for (int a = 0; a < r_; ++a) {
-            for (int t = 0; t < s_; ++t) {
-                const int *blk = counts_recv_.data() + counts_idx_(a, t, 0);
-                long long sum = 0;
-                for (int su = 0; su < s_; ++su) {
-                    sum += blk[su];
-                }
-                recv_col_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)] = sum;
-            }
-        }
-    }
-
-    // Partition 0's recv-side staging sizing, from recv_col_. Only the per-(rank, partition) base; the
-    // post-B4 scatter re-derives the per-source offsets as it walks (a, su).
-    auto size_staging_recv_(size_t elem) -> void {
-        for (int a = 0; a < r_; ++a) {
-            long long recv_sum = 0;
-            for (int t = 0; t < s_; ++t) {
-                recv_sum += recv_col_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)];
-            }
-            mpi_recv_counts_[static_cast<size_t>(a)] = checked_mpi_count(recv_sum, "Per-rank recv count");
-        }
-        long long recv_running = 0;
-        for (int a = 0; a < r_; ++a) {
-            mpi_recv_displs_[static_cast<size_t>(a)] = checked_mpi_count(recv_running, "Recv displacement");
-            recv_running += mpi_recv_counts_[static_cast<size_t>(a)];
-        }
-        const size_t total_recv = static_cast<size_t>(checked_mpi_count(recv_running, "Total recv count"));
-        for (int a = 0; a < r_; ++a) {
-            size_t cur = static_cast<size_t>(mpi_recv_displs_[static_cast<size_t>(a)]);
-            for (int t = 0; t < s_; ++t) {
-                const size_t g = static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t);
-                base_recv_[g] = cur;
-                cur += static_cast<size_t>(recv_col_[g]);
-            }
-        }
-        grow_(stage_recv_, total_recv * elem);
-    }
-
-    auto pack_send_(int local_partition, size_t elem) -> void {
-        const int u = local_partition;
-        // Own slot only — no peer's published send buffer is read here, which is what lets every
-        // partition pack concurrently in the B2→B3 window.
-        const std::byte *src = slots_[static_cast<size_t>(u)].ptr;
-        const int *my_send_counts = counts_row_(u);
-        const int *my_send_displs = slots_[static_cast<size_t>(u)].send_displs;
-        const size_t *off = pack_off_.data() + pack_idx_(u, 0);
-        const int p = r_ * s_;
-        for (int g = 0; g < p; ++g) {
-            const int cnt = my_send_counts[g];
-            if (cnt != 0) {
-                std::memcpy(stage_send_.data() + off[g] * elem,
-                            src + static_cast<size_t>(my_send_displs[g]) * elem,
-                            static_cast<size_t>(cnt) * elem);
-            }
-        }
-    }
-
     [[noreturn]] auto abort_rank_(const char *verb, const char *what) -> void {
         std::print(stderr,
                    "monoprop: rank {} cannot complete the collective '{}' ({}). Its peer ranks are "
@@ -595,37 +348,8 @@ private:
     int r_ = 1;
     int mpi_rank_ = 0;
     std::vector<Slot> slots_;
-
-    // Partition-0-managed, except the two Phase P0 tables at the end, whose rows each partition owns.
-    // S*S per rank, the counts alltoall.
-    std::vector<int> counts_send_;
-    std::vector<int> counts_recv_;
-    // Per-rank [R] counts/displs for the aggregated payload alltoallv.
-    std::vector<int> mpi_send_counts_;
-    std::vector<int> mpi_send_displs_;
-    std::vector<int> mpi_recv_counts_;
-    std::vector<int> mpi_recv_displs_;
-    // [S x P] payload block starts in stage_send_, row u per global destination g. No scatter-side
-    // table: see size_staging_recv_.
-    std::vector<size_t> pack_off_;
-    // [P] staging bases: base_send_[b*S+t] starts partition (b,t)'s region of the message to rank b,
-    // base_recv_[a*S+t] starts local partition t's region of the message from rank a.
-    std::vector<size_t> base_send_;
-    std::vector<size_t> base_recv_;
-    std::vector<long long> col_sum_;
-    std::vector<long long> recv_col_;
-    // [S x counts_stride_] send-count matrix, row u owned by partition u; padded so no two rows share a
-    // 64-byte line. Lifetime rule: publish_counts_row_.
-    std::vector<int> counts_matrix_store_;
-    int *counts_matrix_ = nullptr;
-    size_t counts_stride_ = 0;
-    // [S x rows_stride_] per-partition per-rank recv totals, same ownership and padding rules.
-    std::vector<long long> rows_store_;
-    long long *rows_ = nullptr;
-    size_t rows_stride_ = 0;
-    // Aggregated MPI payload staging, HWM-sized.
-    std::vector<std::byte> stage_send_;
-    std::vector<std::byte> stage_recv_;
+    // Sized from (R, S), which MPI_Comm_size only answers inside the constructor body.
+    std::optional<HybridStaging> staging_;
     double red_f64_ = 0.0;
     uint64_t red_u64_ = 0;
     std::vector<double> red_vec_;

--- a/cpp/monoprop/detail/mpi/HybridComm.h
+++ b/cpp/monoprop/detail/mpi/HybridComm.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -79,27 +80,43 @@ public:
     auto partitions() const -> int { return s_; }
     auto global_rank(int local_partition) const -> int { return mpi_rank_ * s_ + local_partition; }
 
-    auto alltoall_counts(int local_partition, const int *send_counts /*[P]*/, int *recv_counts /*[P]*/) -> void {
-        guard_partition0_(local_partition, "alltoall_counts", [this, local_partition, send_counts, recv_counts] {
-            alltoall_counts_impl_(local_partition, send_counts, recv_counts);
+    auto alltoall_counts(int local_partition,
+                         const int *send_counts /*[P]*/,
+                         int *recv_counts /*[P]*/,
+                         PeerPlan plan = {}) -> void {
+        guard_partition0_(local_partition, "alltoall_counts", [this, local_partition, send_counts, recv_counts, plan] {
+            alltoall_counts_impl_(local_partition, send_counts, recv_counts, plan);
         });
     }
 
     // See AlltoallvArgs for the send-buffer lifetime and the element-vs-byte convention; `dt` is the MPI
     // datatype whose extent is args.elem, and it stays a separate argument because the bundle is shared
     // with the non-MPI-capable transport.
-    auto alltoallv(int local_partition, const AlltoallvArgs &args, MPI_Datatype dt) -> void {
-        guard_partition0_(local_partition, "alltoallv", [this, local_partition, &args, dt] {
-            alltoallv_impl_(local_partition, args, dt);
+    //
+    // `derive_wire_bits` > 0 asks partition 0 to narrow the WIRE itself, to that many linear bits, from
+    // the destination ranks the whole rank actually uses. A caller cannot supply that plan: only
+    // partition 0 reaches MPI, and its own row may be the empty one while a sibling partition has the
+    // rank's only traffic. Legal only for a SYMMETRIC layout (the recv counts are the send counts),
+    // which is what lets the peer set be read off the published recv rows; asserted against the send rows.
+    auto alltoallv(int local_partition,
+                   const AlltoallvArgs &args,
+                   MPI_Datatype dt,
+                   PeerPlan plan = {},
+                   int derive_wire_bits = 0) -> void {
+        guard_partition0_(local_partition, "alltoallv", [this, local_partition, &args, dt, plan, derive_wire_bits] {
+            alltoallv_impl_(local_partition, args, dt, plan, derive_wire_bits);
         });
     }
 
     // See AlltoallvResolveArgs: the recv side is an output, and args.recv is resized here.
     template <typename T>
-    auto alltoallv_resolve(int local_partition, const AlltoallvResolveArgs<T> &args, MPI_Datatype dt) -> void {
+    auto alltoallv_resolve(int local_partition,
+                           const AlltoallvResolveArgs<T> &args,
+                           MPI_Datatype dt,
+                           PeerPlan plan = {}) -> void {
         // `args` by reference, not by value: the impl resizes args.recv and then writes through it.
-        guard_partition0_(local_partition, "alltoallv_resolve", [this, local_partition, &args, dt] {
-            alltoallv_resolve_impl_<T>(local_partition, args, dt);
+        guard_partition0_(local_partition, "alltoallv_resolve", [this, local_partition, &args, dt, plan] {
+            alltoallv_resolve_impl_<T>(local_partition, args, dt, plan);
         });
     }
 
@@ -151,17 +168,24 @@ private:
     }
 
     // recv_counts[g] = amount global partition g sends to this partition. 2 barriers + one count round.
-    auto alltoall_counts_impl_(int local_partition, const int *send_counts /*[P]*/, int *recv_counts /*[P]*/) -> void {
+    auto alltoall_counts_impl_(int local_partition,
+                               const int *send_counts /*[P]*/,
+                               int *recv_counts /*[P]*/,
+                               PeerPlan plan) -> void {
         staging_->publish_counts_row(local_partition, send_counts);
         sync();
         if (local_partition == 0) {
-            staging_->pack_count_matrix();
-            staging_->exchange_count_blocks();
+            staging_->fill_peers(plan);
+            staging_->pack_count_matrix(plan);
+            staging_->exchange_count_blocks(plan);
         }
         sync();
         // Partition t extracts its row: recv from (rank a, partition su) is contiguous per source rank a.
+        // Under a plan only the peer ranks were exchanged, so the rest of the row is zero by definition
+        // (a non-peer cannot own the partner of any term this rank owns).
         const int t = local_partition;
-        for (int a = 0; a < r_; ++a) {
+        std::fill(recv_counts, recv_counts + static_cast<size_t>(r_) * static_cast<size_t>(s_), 0);
+        for (const int a : staging_->peers()) {
             for (int su = 0; su < s_; ++su) {
                 recv_counts[a * s_ + su] = staging_->count_from(a, t, su);
             }
@@ -172,16 +196,28 @@ private:
     }
 
     // Flat variable all-to-all over caller-owned buffers; see AlltoallvArgs for the conventions.
-    auto alltoallv_impl_(int local_partition, const AlltoallvArgs &args, MPI_Datatype dt) -> void {
+    auto alltoallv_impl_(int local_partition,
+                         const AlltoallvArgs &args,
+                         MPI_Datatype dt,
+                         PeerPlan plan,
+                         int derive_wire_bits) -> void {
         Slot &me = slots_[static_cast<size_t>(local_partition)];
         me.ptr = args.send;
         me.send_displs = args.send_displs;
         staging_->publish_counts_row(local_partition, args.send_counts);
-        staging_->publish_recv_rows(local_partition, args.recv_counts);
+        staging_->publish_recv_rows(local_partition, args.recv_counts, plan);
         sync(); // B1
 
         // B2: partition 0 sizes/reallocates staging; must finish before any partition packs into it.
         if (local_partition == 0) {
+            // Written here, read again in the B3->B4 window: partition 0 is this member's only toucher.
+            wire_plan_ = plan;
+            if (derive_wire_bits > 0) {
+                wire_plan_ = staging_->derived_wire_plan(derive_wire_bits);
+                // The recv rows it was read off against the send rows: the symmetry the parameter needs.
+                assert(staging_->narrowing_is_lossless(wire_plan_));
+            }
+            staging_->fill_peers(wire_plan_);
             staging_->size_send(args.elem);
             staging_->fill_recv_col([this](int a, int t) { return staging_->published_recv(a, t); });
             staging_->size_recv(args.elem);
@@ -194,7 +230,7 @@ private:
 
         // B4: partition 0 moves the payload while peers park at the barrier.
         if (local_partition == 0) {
-            staging_->exchange_payload(dt);
+            staging_->exchange_payload(dt, args.elem, wire_plan_);
         }
         sync(); // B4
 
@@ -203,10 +239,18 @@ private:
     }
 
     // Fused count-resolve + payload alltoallv: folds the standalone count exchange into this verb's
-    // B1→B2 window (4 syncs instead of 6). recv_counts / recv_displs and `recv` (resized) are outputs.
-    // Bit-identical to alltoall_counts + alltoallv.
+    // barriered windows (4 syncs instead of 6). recv_counts / recv_displs and `recv` (resized) are
+    // outputs. Bit-identical to alltoall_counts + alltoallv.
+    //
+    // The count round is POSTED in B1→B2 and only waited on in B3→B4, so the whole B2→B3 packing runs
+    // underneath it. Split, not fused, because nothing before fill_recv_col reads the count blocks: the
+    // send side sizes from the locally published rows, and pack_send from that sizing. The dense arm is
+    // MPI_Alltoall, blocking, and completes inside post_count_blocks regardless.
     template <typename T>
-    auto alltoallv_resolve_impl_(int local_partition, const AlltoallvResolveArgs<T> &args, MPI_Datatype dt) -> void {
+    auto alltoallv_resolve_impl_(int local_partition,
+                                 const AlltoallvResolveArgs<T> &args,
+                                 MPI_Datatype dt,
+                                 PeerPlan plan) -> void {
         // Typed verb: element bytes are sizeof(T) by construction, so they are derived rather than passed.
         constexpr size_t elem = sizeof(T);
         Slot &me = slots_[static_cast<size_t>(local_partition)];
@@ -214,22 +258,40 @@ private:
         // never reconstructs T, so the slot stays type-erased for the untyped alltoallv_impl_ above.
         me.ptr = reinterpret_cast<const std::byte *>(args.send);
         me.send_displs = args.send_displs;
-        // Count row only: the recv counts do not exist until the count round in B1→B2.
+        // Count row only: the recv counts do not exist until the count round is drained in B3→B4.
         staging_->publish_counts_row(local_partition, args.send_counts);
         sync(); // B1
 
         if (local_partition == 0) {
-            staging_->pack_count_matrix();
-            staging_->exchange_count_blocks();
+            staging_->fill_peers(plan);
+            staging_->pack_count_matrix(plan);
+            staging_->post_count_blocks(plan);
             staging_->size_send(elem);
-            staging_->fill_recv_col([this](int a, int t) { return staging_->block_sum(a, t); });
-            staging_->size_recv(elem);
         }
         sync(); // B2
 
+        // B3: each partition packs its own blocks into the send staging, the count round in flight.
+        pack_send_(local_partition, elem);
+        sync(); // B3
+
+        // B4: the counts land here -- fill_recv_col is their first reader -- then the payload moves.
+        if (local_partition == 0) {
+            staging_->wait_count_blocks();
+            staging_->fill_recv_col([this](int a, int t) { return staging_->block_sum(a, t); });
+            staging_->size_recv(elem);
+            staging_->exchange_payload(dt, elem, plan);
+        }
+        sync(); // B4
+
+        // Past B4 now, not before B3: the count blocks do not exist until the wait above. Partition 0
+        // cannot rewrite them before a later verb's B1→B2 window, unreachable until every reader here
+        // has arrived at that verb's B1.
         const int t = local_partition;
         long long total = 0;
-        for (int a = 0; a < r_; ++a) {
+        const size_t p = static_cast<size_t>(r_) * static_cast<size_t>(s_);
+        std::fill(args.recv_counts, args.recv_counts + p, 0);
+        std::fill(args.recv_displs, args.recv_displs + p, 0);
+        for (const int a : staging_->peers()) {
             for (int su = 0; su < s_; ++su) {
                 const int g = a * s_ + su;
                 const int c = staging_->count_from(a, t, su);
@@ -239,14 +301,6 @@ private:
             }
         }
         args.recv.resize(static_cast<size_t>(checked_mpi_count(total, "Total recv count")));
-
-        pack_send_(local_partition, elem);
-        sync(); // B3
-
-        if (local_partition == 0) {
-            staging_->exchange_payload(dt);
-        }
-        sync(); // B4
 
         staging_->scatter_recv(local_partition,
                                reinterpret_cast<std::byte *>(args.recv.data()), // after the resize: it may realloc
@@ -353,6 +407,8 @@ private:
     double red_f64_ = 0.0;
     uint64_t red_u64_ = 0;
     std::vector<double> red_vec_;
+    // alltoallv's wire plan, partition 0 only: written in B1->B2, read in B3->B4. See derived_wire_plan.
+    PeerPlan wire_plan_;
 
     PartitionBarrier barrier_;
 };

--- a/cpp/monoprop/detail/mpi/HybridComm.h
+++ b/cpp/monoprop/detail/mpi/HybridComm.h
@@ -80,6 +80,17 @@ public:
     auto partitions() const -> int { return s_; }
     auto global_rank(int local_partition) const -> int { return mpi_rank_ * s_ + local_partition; }
 
+    /*! @brief Bytes this rank's transport holds: the grow-only payload staging plus the fixed tables.
+     *
+     *  Diagnostic only. The two payload buffers are sized to the widest message the run has needed and
+     *  never shrink, so on a run whose widest gate came early they are resident for the whole of it
+     *  while nothing resting names them. One HybridComm serves all S partitions of a rank, so this is
+     *  a per-RANK figure: a caller summing over partitions must ask exactly one of them.
+     */
+    [[nodiscard]] auto staging_bytes() const -> size_t {
+        return staging_->bytes() + slots_.capacity() * sizeof(Slot) + red_vec_.capacity() * sizeof(double);
+    }
+
     auto alltoall_counts(int local_partition,
                          const int *send_counts /*[P]*/,
                          int *recv_counts /*[P]*/,

--- a/cpp/monoprop/detail/mpi/HybridStaging.h
+++ b/cpp/monoprop/detail/mpi/HybridStaging.h
@@ -26,6 +26,7 @@
 
 #include "monoprop/detail/mpi/CheckedCount.h"
 #include "monoprop/detail/mpi/Comm.h"
+#include "monoprop/detail/mpi/Pairwise.h"
 
 // The staging half of HybridComm (see HybridComm.h for the barrier discipline the phase names refer to).
 // Everything here is partition 0's, written and read inside a barriered window, EXCEPT the two published
@@ -55,7 +56,10 @@ auto grow_to(V &v, size_t need) -> void {
 class HybridStaging {
 public:
     HybridStaging(MPI_Comm parent, int mpi_rank, int ranks, int partitions)
-        : parent_(parent), mpi_rank_(mpi_rank), r_(ranks), s_(partitions) {
+        : parent_(parent),
+          mpi_rank_(mpi_rank),
+          r_(ranks),
+          s_(partitions) {
         // Size all (R, S)-fixed scratch once so per-call paths never allocate; staging grows on demand.
         const size_t p = static_cast<size_t>(r_) * static_cast<size_t>(s_);
         counts_send_.resize(p * static_cast<size_t>(s_));
@@ -92,7 +96,7 @@ public:
         return cap(stage_send_) + cap(stage_recv_) + cap(counts_send_) + cap(counts_recv_) + cap(mpi_send_counts_)
                + cap(mpi_send_displs_) + cap(mpi_recv_counts_) + cap(mpi_recv_displs_) + cap(pack_off_)
                + cap(base_send_) + cap(base_recv_) + cap(col_sum_) + cap(recv_col_) + cap(counts_matrix_store_)
-               + cap(rows_store_);
+               + cap(rows_store_) + cap(reqs_) + cap(count_reqs_) + cap(peers_);
     }
 
     /*!
@@ -106,11 +110,20 @@ public:
         std::memcpy(counts_row(u), send_counts, static_cast<size_t>(r_) * static_cast<size_t>(s_) * sizeof(int));
     }
 
-    //! @brief Publish partition @a u's per-rank recv totals (Phase P0), same ownership rule as above.
-    //! `long long` because it sums S int counts.
-    auto publish_recv_rows(int u, const int *recv_counts) -> void {
+    /*!
+     * @brief Publish partition @a u's per-rank recv totals (Phase P0), same ownership rule as above.
+     * `long long` because it sums S int counts.
+     *
+     * Masked through @a plan, symmetric with its one reader (fill_recv_col): a non-peer's row is zero by
+     * definition, and a count left there would size staging for a block no receive is posted for. Every
+     * entry is written, not just the peers', because derived_wire_plan reads the whole row.
+     */
+    auto publish_recv_rows(int u, const int *recv_counts, PeerPlan plan) -> void {
         long long *rr = row_recv_(u);
-        for (int a = 0; a < r_; ++a) {
+        std::fill_n(rr, r_, 0LL);
+        const int f = plan.count(r_);
+        for (int k = 0; k < f; ++k) {
+            const int a = plan.peer(mpi_rank_, k);
             long long sum = 0;
             for (int su = 0; su < s_; ++su) {
                 sum += recv_counts[a * s_ + su];
@@ -119,18 +132,79 @@ public:
         }
     }
 
+    /*!
+     * @brief Materialise @a plan's peer ranks; every sweep below walks this set.
+     *
+     * Written by partition 0 in the B1->B2 window, like the recv bases, so every reader past B2 sees it.
+     * The sizing sweeps index it S times each, which is why it is a list rather than a predicate.
+     */
+    auto fill_peers(PeerPlan plan) -> void {
+        const int f = plan.count(r_);
+        peers_.resize(static_cast<size_t>(f));
+        for (int k = 0; k < f; ++k) {
+            peers_[static_cast<size_t>(k)] = plan.peer(mpi_rank_, k);
+        }
+    }
+
+    //! @brief The peer ranks fill_peers resolved, for the callers that extract a row per peer.
+    [[nodiscard]] auto peers() const -> const std::vector<int> & { return peers_; }
+
+    /*!
+     * @brief The rank-level peer set read off the recv rows every partition published before B1 -- the
+     * first point with a view wider than one partition's row.
+     *
+     * Under fanout-1 routing a layer's traffic is all on ONE rank, so this resolves to a shift; with
+     * nothing occupied it resolves to the self peer, whose legs are then all zero, and that keeps the
+     * collective-vs-pairwise branch a function of the caller's `bits` alone rather than of a rank's data
+     * (a data-dependent branch straddles and hangs). A set wider than one rank contradicts the caller's
+     * fanout claim, so it answers dense and nothing is dropped.
+     */
+    [[nodiscard]] auto derived_wire_plan(int bits) -> PeerPlan {
+        int found = -1;
+        for (int u = 0; u < s_; ++u) {
+            const long long *rr = row_recv_(u);
+            for (int a = 0; a < r_; ++a) {
+                if (rr[a] != 0 && a != found) {
+                    if (found >= 0) {
+                        assert(false && "fanout claimed 1, but this rank's layer spans several peer ranks");
+                        return PeerPlan{};
+                    }
+                    found = a;
+                }
+            }
+        }
+        // The plan is a boolean, so every rank bit is a linear bit and the mask is the rank index.
+        return PeerPlan{.sparse = bits > 0, .shift = found < 0 ? 0 : (mpi_rank_ ^ found)};
+    }
+
+    //! @brief Do the published send rows put anything outside @a plan's peers? If so, narrowing to it
+    //! would drop those blocks in silence -- the failure mode a wrong-but-agreed shift produces.
+    [[nodiscard]] auto narrowing_is_lossless(PeerPlan plan) const -> bool {
+        for (int su = 0; su < s_; ++su) {
+            const int *row = counts_matrix_ + static_cast<size_t>(su) * counts_stride_;
+            for (int g = 0; g < r_ * s_; ++g) {
+                if (row[g] != 0 && !plan.contains(mpi_rank_, g / s_)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     //! @brief What rank @a a's count block says (@a su -> @a t): the extraction the callers hand back.
     [[nodiscard]] auto count_from(int a, int t, int su) const -> int { return counts_recv_[counts_idx_(a, t, su)]; }
 
     /*!
      * @brief Transpose the published count rows into the count message, dest-major then source-minor.
      *
-     * Source partition outer, so the peer-owned side streams. Every element is written, so no pre-zeroing.
+     * Source partition outer, so the peer-owned side streams. Only the peers' blocks are written, and
+     * only they are ever read back, so no pre-zeroing.
      */
-    auto pack_count_matrix() -> void {
+    auto pack_count_matrix([[maybe_unused]] PeerPlan plan) -> void {
+        assert(narrowing_is_lossless(plan)); // a wrong shift every rank agrees on drops blocks silently
         for (int su = 0; su < s_; ++su) {
             const int *row = counts_row(su);
-            for (int b = 0; b < r_; ++b) {
+            for (const int b : peers_) {
                 for (int t = 0; t < s_; ++t) {
                     counts_send_[counts_idx_(b, t, su)] = row[b * s_ + t];
                 }
@@ -138,9 +212,48 @@ public:
         }
     }
 
-    //! @brief Move the S*S-int count blocks. One MPI_Alltoall, blocking: complete on return.
-    auto exchange_count_blocks() -> void {
-        MPI_Alltoall(counts_send_.data(), s_ * s_, MPI_INT, counts_recv_.data(), s_ * s_, MPI_INT, parent_);
+    /*!
+     * @brief Post the S*S-int count blocks: one MPI_Alltoall when dense, else a pair per peer.
+     *
+     * The sparse arm POSTS ONLY, so both count matrices must stay put until wait_count_blocks; the dense
+     * MPI_Alltoall is blocking and has completed on return, which is why plan.dense() leaves nothing
+     * live. The requests go in their own vector, never the payload one: see the member declaration.
+     */
+    auto post_count_blocks(PeerPlan plan) -> void {
+        assert(count_posted_ == 0); // an un-drained round would be waited on twice
+        const int block = s_ * s_;
+        if (plan.dense()) {
+            MPI_Alltoall(counts_send_.data(), block, MPI_INT, counts_recv_.data(), block, MPI_INT, parent_);
+            return;
+        }
+        const PeerLayout blocks{.block = block};
+        count_posted_ = sparse_pairwise(plan,
+                                        mpi_rank_,
+                                        r_,
+                                        parent_,
+                                        kHybridCountTag,
+                                        MPI_INT,
+                                        sizeof(int),
+                                        reinterpret_cast<const std::byte *>(counts_send_.data()),
+                                        blocks,
+                                        reinterpret_cast<std::byte *>(counts_recv_.data()),
+                                        blocks,
+                                        count_reqs_);
+    }
+
+    //! @brief Drain post_count_blocks. A no-op on the dense arm, and on a plan whose only peer is this
+    //! rank itself -- a count block is a fixed S*S ints, so no other peer can be skipped for a zero count.
+    auto wait_count_blocks() -> void {
+        if (count_posted_ != 0) {
+            MPI_Waitall(count_posted_, count_reqs_.data(), MPI_STATUSES_IGNORE);
+            count_posted_ = 0;
+        }
+    }
+
+    //! @brief Post and drain in one step, for callers with no work to overlap.
+    auto exchange_count_blocks(PeerPlan plan) -> void {
+        post_count_blocks(plan);
+        wait_count_blocks();
     }
 
     /*!
@@ -150,24 +263,30 @@ public:
      * pass B takes the exclusive prefix over source partitions, which is each partition's block start.
      */
     auto size_send(size_t elem) -> void {
-        const size_t p = static_cast<size_t>(r_) * static_cast<size_t>(s_);
         // Pass A: u outer so both sides sweep in address order.
-        std::ranges::fill(col_sum_, 0LL);
+        zero_peer_slots_(col_sum_);
         for (int u = 0; u < s_; ++u) {
             const int *row = counts_row(u);
-            for (size_t g = 0; g < p; ++g) {
-                col_sum_[g] += row[g];
+            for (const int b : peers_) {
+                const size_t base = static_cast<size_t>(b) * static_cast<size_t>(s_);
+                for (int t = 0; t < s_; ++t) {
+                    col_sum_[base + static_cast<size_t>(t)] += row[base + static_cast<size_t>(t)];
+                }
             }
         }
         const size_t total_send = layout_peers_(col_sum_, mpi_send_counts_, mpi_send_displs_, base_send_, kSendLabels);
         // Pass B: col_sum_ is free to be reused as the running prefix here.
-        std::ranges::fill(col_sum_, 0LL);
+        zero_peer_slots_(col_sum_);
         for (int u = 0; u < s_; ++u) {
             const int *row = counts_row(u);
             size_t *off = pack_off_.data() + pack_idx_(u, 0);
-            for (size_t g = 0; g < p; ++g) {
-                off[g] = base_send_[g] + static_cast<size_t>(col_sum_[g]);
-                col_sum_[g] += row[g];
+            for (const int b : peers_) {
+                const size_t base = static_cast<size_t>(b) * static_cast<size_t>(s_);
+                for (int t = 0; t < s_; ++t) {
+                    const size_t g = base + static_cast<size_t>(t);
+                    off[g] = base_send_[g] + static_cast<size_t>(col_sum_[g]);
+                    col_sum_[g] += row[g];
+                }
             }
         }
         // Grow-only, no zero-fill: pack_send's blocks tile [0, total_send) exactly.
@@ -182,7 +301,8 @@ public:
      */
     template <typename Value>
     auto fill_recv_col(Value &&value) -> void {
-        for (int a = 0; a < r_; ++a) {
+        zero_peer_slots_(recv_col_);
+        for (const int a : peers_) {
             for (int t = 0; t < s_; ++t) {
                 recv_col_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)] = value(a, t);
             }
@@ -209,18 +329,40 @@ public:
         grow_to(stage_recv_, total_recv * elem);
     }
 
-    //! @brief Move the staged payload. One MPI_Alltoallv, blocking. `dt`'s extent must be the `elem`
-    //! the two sizing sweeps were given.
-    auto exchange_payload(MPI_Datatype dt) -> void {
-        MPI_Alltoallv(stage_send_.data(),
-                      mpi_send_counts_.data(),
-                      mpi_send_displs_.data(),
-                      dt,
-                      stage_recv_.data(),
-                      mpi_recv_counts_.data(),
-                      mpi_recv_displs_.data(),
-                      dt,
-                      parent_);
+    /*!
+     * @brief Move the staged payload: one MPI_Alltoallv when dense, else a pair per peer over the same
+     * per-rank counts and displacements. Blocking either way.
+     *
+     * A non-peer's count is zero, so the sparse arm drops nothing. @a elem is @a dt's extent: needed to
+     * reach a block, and the same one the two sizing sweeps were given.
+     */
+    auto exchange_payload(MPI_Datatype dt, size_t elem, PeerPlan plan) -> void {
+        if (plan.dense()) {
+            MPI_Alltoallv(stage_send_.data(),
+                          mpi_send_counts_.data(),
+                          mpi_send_displs_.data(),
+                          dt,
+                          stage_recv_.data(),
+                          mpi_recv_counts_.data(),
+                          mpi_recv_displs_.data(),
+                          dt,
+                          parent_);
+            return;
+        }
+        const int posted =
+            sparse_pairwise(plan,
+                            mpi_rank_,
+                            r_,
+                            parent_,
+                            kHybridPayloadTag,
+                            dt,
+                            elem,
+                            stage_send_.data(),
+                            PeerLayout{.counts = mpi_send_counts_.data(), .displs = mpi_send_displs_.data()},
+                            stage_recv_.data(),
+                            PeerLayout{.counts = mpi_recv_counts_.data(), .displs = mpi_recv_displs_.data()},
+                            reqs_);
+        MPI_Waitall(posted, reqs_.data(), MPI_STATUSES_IGNORE);
     }
 
     /*!
@@ -232,13 +374,16 @@ public:
     auto pack_send(int u, size_t elem, const std::byte *src, const int *send_displs) -> void {
         const int *my_send_counts = counts_row(u);
         const size_t *off = pack_off_.data() + pack_idx_(u, 0);
-        const int p = r_ * s_;
-        for (int g = 0; g < p; ++g) {
-            const int cnt = my_send_counts[g];
-            if (cnt != 0) {
-                std::memcpy(stage_send_.data() + off[g] * elem,
-                            src + static_cast<size_t>(send_displs[g]) * elem,
-                            static_cast<size_t>(cnt) * elem);
+        for (const int b : peers_) {
+            const int base = b * s_;
+            for (int t = 0; t < s_; ++t) {
+                const int g = base + t;
+                const int cnt = my_send_counts[g];
+                if (cnt != 0) {
+                    std::memcpy(stage_send_.data() + off[g] * elem,
+                                src + static_cast<size_t>(send_displs[g]) * elem,
+                                static_cast<size_t>(cnt) * elem);
+                }
             }
         }
     }
@@ -250,7 +395,7 @@ public:
      * `cur` re-derives the block starts from the recv bases and this partition's own counts.
      */
     auto scatter_recv(int t, std::byte *dst, const int *recv_counts, const int *recv_displs, size_t elem) -> void {
-        for (int a = 0; a < r_; ++a) {
+        for (const int a : peers_) {
             size_t cur = base_recv_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)];
             for (int su = 0; su < s_; ++su) {
                 const int g = a * s_ + su;
@@ -285,7 +430,11 @@ private:
                        std::vector<int> &displs,
                        std::vector<size_t> &base,
                        CountLabels what) -> size_t {
-        for (int b = 0; b < r_; ++b) {
+        // The [R] arrays stay fully zeroed: MPI_Alltoallv reads every entry on the dense arm, and the
+        // zeros are what make the peer-only prefix below equal the full 0..R one at the peers' positions.
+        std::ranges::fill(counts, 0);
+        std::ranges::fill(displs, 0);
+        for (const int b : peers_) {
             const long long *slots = col.data() + static_cast<size_t>(b) * static_cast<size_t>(s_);
             long long sum = 0;
             for (int t = 0; t < s_; ++t) {
@@ -293,13 +442,15 @@ private:
             }
             counts[static_cast<size_t>(b)] = checked_mpi_count(sum, what.per_rank);
         }
+        // peers_ is ascending (dense is 0..R-1, sparse a singleton), so a prefix over it takes the same
+        // value at every peer as a prefix over all R: a non-peer contributes zero.
         long long running = 0;
-        for (int b = 0; b < r_; ++b) {
+        for (const int b : peers_) {
             displs[static_cast<size_t>(b)] = checked_mpi_count(running, what.displ);
             running += counts[static_cast<size_t>(b)];
         }
         const auto total = static_cast<size_t>(checked_mpi_count(running, what.total));
-        for (int b = 0; b < r_; ++b) {
+        for (const int b : peers_) {
             size_t cur = static_cast<size_t>(displs[static_cast<size_t>(b)]);
             for (int t = 0; t < s_; ++t) {
                 const size_t g = static_cast<size_t>(b) * static_cast<size_t>(s_) + static_cast<size_t>(t);
@@ -308,6 +459,19 @@ private:
             }
         }
         return total;
+    }
+
+    /*!
+     * @brief Zero only the peer ranks' slots of a [P] table.
+     *
+     * Every sweep that writes one of these tables and every sweep that reads it walks the same peer set,
+     * so the rest is never looked at -- and these run SERIALLY on partition 0 while S-1 partitions park,
+     * so the width is the cost.
+     */
+    auto zero_peer_slots_(std::vector<long long> &table) -> void {
+        for (const int b : peers_) {
+            std::fill_n(table.begin() + (static_cast<std::ptrdiff_t>(b) * s_), s_, 0LL);
+        }
     }
 
     static constexpr size_t kLineBytes = 64;
@@ -372,6 +536,15 @@ private:
     // Aggregated MPI payload staging, HWM-sized.
     std::vector<std::byte> stage_send_;
     std::vector<std::byte> stage_recv_;
+    // Point-to-point request scratch for the sparse payload round; grown on demand.
+    std::vector<MPI_Request> reqs_;
+    // The count round's own scratch, separate from reqs_ by construction and not merely by the current
+    // ordering: it stays live across B2 and B3, and sparse_pairwise's resize would move the buffer MPI
+    // holds pointers into the moment a payload post ever preceded the count wait.
+    std::vector<MPI_Request> count_reqs_;
+    int count_posted_ = 0; // live requests in count_reqs_; always 0 on the dense (blocking) arm
+    // This verb's peer ranks; see fill_peers.
+    std::vector<int> peers_;
 };
 
 } // namespace monoprop::mpi

--- a/cpp/monoprop/detail/mpi/HybridStaging.h
+++ b/cpp/monoprop/detail/mpi/HybridStaging.h
@@ -1,0 +1,377 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+#include <vector>
+
+#include <mpi.h>
+
+#include "monoprop/detail/mpi/CheckedCount.h"
+#include "monoprop/detail/mpi/Comm.h"
+
+// The staging half of HybridComm (see HybridComm.h for the barrier discipline the phase names refer to).
+// Everything here is partition 0's, written and read inside a barriered window, EXCEPT the two published
+// tables whose rows each partition owns -- see publish_counts_row / publish_recv_rows.
+
+namespace monoprop::mpi {
+
+//! @brief Grow-only resize: staging is high-water-mark sized and never shrinks within a run.
+template <typename V>
+auto grow_to(V &v, size_t need) -> void {
+    if (v.size() < need) {
+        v.resize(need);
+    }
+}
+
+/*!
+ * @brief HybridComm's payload staging: the count matrices, the per-rank wire layout, the two grow-only
+ * payload buffers, and the sweeps that size, pack, move and scatter them.
+ *
+ * Wire block order is destination major, source minor, so one destination's region of a rank's message
+ * is contiguous and one source partition's blocks within it are a prefix. Counts and displacements are
+ * in ELEMENTS; `elem` scales them to bytes, and the buffers carry no element type to scale by.
+ *
+ * Held by one HybridComm and driven only from inside its barriered windows: this class takes no
+ * barrier and asserts no ordering of its own.
+ */
+class HybridStaging {
+public:
+    HybridStaging(MPI_Comm parent, int mpi_rank, int ranks, int partitions)
+        : parent_(parent), mpi_rank_(mpi_rank), r_(ranks), s_(partitions) {
+        // Size all (R, S)-fixed scratch once so per-call paths never allocate; staging grows on demand.
+        const size_t p = static_cast<size_t>(r_) * static_cast<size_t>(s_);
+        counts_send_.resize(p * static_cast<size_t>(s_));
+        counts_recv_.resize(p * static_cast<size_t>(s_));
+        mpi_send_counts_.resize(static_cast<size_t>(r_));
+        mpi_recv_counts_.resize(static_cast<size_t>(r_));
+        mpi_send_displs_.resize(static_cast<size_t>(r_));
+        mpi_recv_displs_.resize(static_cast<size_t>(r_));
+        pack_off_.resize(static_cast<size_t>(s_) * p); // S * R * S elements, indexed (u, g)
+        base_send_.resize(p);
+        base_recv_.resize(p);
+        col_sum_.resize(p);
+        recv_col_.resize(p);
+        // Rounded up to whole 64-byte lines: each row has its own writer, so a shared line false-shares.
+        counts_stride_ = round_up_(p, kIntsPerLine);
+        rows_stride_ = round_up_(static_cast<size_t>(r_), kLongsPerLine);
+        // One spare line each: the allocator guarantees alignof(T), not 64, so row 0 must be realigned.
+        counts_matrix_store_.assign(static_cast<size_t>(s_) * counts_stride_ + kIntsPerLine, 0);
+        counts_matrix_ = align_to_line_(counts_matrix_store_.data());
+        rows_store_.assign(static_cast<size_t>(s_) * rows_stride_ + kLongsPerLine, 0LL);
+        rows_ = align_to_line_(rows_store_.data());
+        assert(reinterpret_cast<uintptr_t>(counts_matrix_) % kLineBytes == 0);
+        assert(reinterpret_cast<uintptr_t>(rows_) % kLineBytes == 0);
+        assert(counts_matrix_ + static_cast<size_t>(s_) * counts_stride_
+               <= counts_matrix_store_.data() + counts_matrix_store_.size());
+        assert(rows_ + static_cast<size_t>(s_) * rows_stride_ <= rows_store_.data() + rows_store_.size());
+    }
+
+    //! @brief Bytes these tables and buffers hold; see HybridComm::staging_bytes for what it is for.
+    [[nodiscard]] auto bytes() const -> size_t {
+        const auto cap = [](const auto &v) {
+            return v.capacity() * sizeof(typename std::decay_t<decltype(v)>::value_type);
+        };
+        return cap(stage_send_) + cap(stage_recv_) + cap(counts_send_) + cap(counts_recv_) + cap(mpi_send_counts_)
+               + cap(mpi_send_displs_) + cap(mpi_recv_counts_) + cap(mpi_recv_displs_) + cap(pack_off_)
+               + cap(base_send_) + cap(base_recv_) + cap(col_sum_) + cap(recv_col_) + cap(counts_matrix_store_)
+               + cap(rows_store_);
+    }
+
+    /*!
+     * @brief Publish partition @a u's [P] send-count row (Phase P0).
+     *
+     * Partition u writes only its own row, so this pre-barrier write needs no barrier of its own. The
+     * one cross-partition reader is partition 0 inside B1->B2, and no peer reaches verb k+1's P0 without
+     * passing verb k's B2, so the rewrite always follows the read.
+     */
+    auto publish_counts_row(int u, const int *send_counts) -> void {
+        std::memcpy(counts_row(u), send_counts, static_cast<size_t>(r_) * static_cast<size_t>(s_) * sizeof(int));
+    }
+
+    //! @brief Publish partition @a u's per-rank recv totals (Phase P0), same ownership rule as above.
+    //! `long long` because it sums S int counts.
+    auto publish_recv_rows(int u, const int *recv_counts) -> void {
+        long long *rr = row_recv_(u);
+        for (int a = 0; a < r_; ++a) {
+            long long sum = 0;
+            for (int su = 0; su < s_; ++su) {
+                sum += recv_counts[a * s_ + su];
+            }
+            rr[a] = sum;
+        }
+    }
+
+    //! @brief What rank @a a's count block says (@a su -> @a t): the extraction the callers hand back.
+    [[nodiscard]] auto count_from(int a, int t, int su) const -> int { return counts_recv_[counts_idx_(a, t, su)]; }
+
+    /*!
+     * @brief Transpose the published count rows into the count message, dest-major then source-minor.
+     *
+     * Source partition outer, so the peer-owned side streams. Every element is written, so no pre-zeroing.
+     */
+    auto pack_count_matrix() -> void {
+        for (int su = 0; su < s_; ++su) {
+            const int *row = counts_row(su);
+            for (int b = 0; b < r_; ++b) {
+                for (int t = 0; t < s_; ++t) {
+                    counts_send_[counts_idx_(b, t, su)] = row[b * s_ + t];
+                }
+            }
+        }
+    }
+
+    //! @brief Move the S*S-int count blocks. One MPI_Alltoall, blocking: complete on return.
+    auto exchange_count_blocks() -> void {
+        MPI_Alltoall(counts_send_.data(), s_ * s_, MPI_INT, counts_recv_.data(), s_ * s_, MPI_INT, parent_);
+    }
+
+    /*!
+     * @brief Size the send side, in two sweeps of the published count rows (partition 0, B1->B2).
+     *
+     * Pass A takes the column sums over source partitions and lays the per-rank wire out from them;
+     * pass B takes the exclusive prefix over source partitions, which is each partition's block start.
+     */
+    auto size_send(size_t elem) -> void {
+        const size_t p = static_cast<size_t>(r_) * static_cast<size_t>(s_);
+        // Pass A: u outer so both sides sweep in address order.
+        std::ranges::fill(col_sum_, 0LL);
+        for (int u = 0; u < s_; ++u) {
+            const int *row = counts_row(u);
+            for (size_t g = 0; g < p; ++g) {
+                col_sum_[g] += row[g];
+            }
+        }
+        const size_t total_send = layout_peers_(col_sum_, mpi_send_counts_, mpi_send_displs_, base_send_, kSendLabels);
+        // Pass B: col_sum_ is free to be reused as the running prefix here.
+        std::ranges::fill(col_sum_, 0LL);
+        for (int u = 0; u < s_; ++u) {
+            const int *row = counts_row(u);
+            size_t *off = pack_off_.data() + pack_idx_(u, 0);
+            for (size_t g = 0; g < p; ++g) {
+                off[g] = base_send_[g] + static_cast<size_t>(col_sum_[g]);
+                col_sum_[g] += row[g];
+            }
+        }
+        // Grow-only, no zero-fill: pack_send's blocks tile [0, total_send) exactly.
+        grow_to(stage_send_, total_send * elem);
+    }
+
+    /*!
+     * @brief Fill the recv column: what local partition t receives from rank a.
+     *
+     * @a value reads it from the rows published in Phase P0 (alltoallv) or from the count blocks just
+     * exchanged (the fused resolve), which is the only difference between the two verbs' recv sides.
+     */
+    template <typename Value>
+    auto fill_recv_col(Value &&value) -> void {
+        for (int a = 0; a < r_; ++a) {
+            for (int t = 0; t < s_; ++t) {
+                recv_col_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)] = value(a, t);
+            }
+        }
+    }
+
+    //! @brief The Phase P0 rows, as fill_recv_col's `value`.
+    [[nodiscard]] auto published_recv(int a, int t) -> long long { return row_recv_(t)[a]; }
+
+    //! @brief Rank @a a's count block for partition @a t, summed over source partitions; the other one.
+    [[nodiscard]] auto block_sum(int a, int t) const -> long long {
+        const int *blk = counts_recv_.data() + counts_idx_(a, t, 0);
+        long long sum = 0;
+        for (int su = 0; su < s_; ++su) {
+            sum += blk[su];
+        }
+        return sum;
+    }
+
+    //! @brief Size the recv side from the recv column. Only the per-(rank, partition) base: the scatter
+    //! re-derives the per-source offsets as it walks (a, su).
+    auto size_recv(size_t elem) -> void {
+        const size_t total_recv = layout_peers_(recv_col_, mpi_recv_counts_, mpi_recv_displs_, base_recv_, kRecvLabels);
+        grow_to(stage_recv_, total_recv * elem);
+    }
+
+    //! @brief Move the staged payload. One MPI_Alltoallv, blocking. `dt`'s extent must be the `elem`
+    //! the two sizing sweeps were given.
+    auto exchange_payload(MPI_Datatype dt) -> void {
+        MPI_Alltoallv(stage_send_.data(),
+                      mpi_send_counts_.data(),
+                      mpi_send_displs_.data(),
+                      dt,
+                      stage_recv_.data(),
+                      mpi_recv_counts_.data(),
+                      mpi_recv_displs_.data(),
+                      dt,
+                      parent_);
+    }
+
+    /*!
+     * @brief Partition @a u copies its own blocks into the send staging (B2->B3).
+     *
+     * Own slot only -- no peer's published send buffer is read here, which is what lets every partition
+     * pack concurrently.
+     */
+    auto pack_send(int u, size_t elem, const std::byte *src, const int *send_displs) -> void {
+        const int *my_send_counts = counts_row(u);
+        const size_t *off = pack_off_.data() + pack_idx_(u, 0);
+        const int p = r_ * s_;
+        for (int g = 0; g < p; ++g) {
+            const int cnt = my_send_counts[g];
+            if (cnt != 0) {
+                std::memcpy(stage_send_.data() + off[g] * elem,
+                            src + static_cast<size_t>(send_displs[g]) * elem,
+                            static_cast<size_t>(cnt) * elem);
+            }
+        }
+    }
+
+    /*!
+     * @brief Scatter each global source's contiguous run out of the recv staging to recv_displs[g].
+     *
+     * All legs, the self-rank one included, go through staging. Walks (a, su) in accumulation order, so
+     * `cur` re-derives the block starts from the recv bases and this partition's own counts.
+     */
+    auto scatter_recv(int t, std::byte *dst, const int *recv_counts, const int *recv_displs, size_t elem) -> void {
+        for (int a = 0; a < r_; ++a) {
+            size_t cur = base_recv_[static_cast<size_t>(a) * static_cast<size_t>(s_) + static_cast<size_t>(t)];
+            for (int su = 0; su < s_; ++su) {
+                const int g = a * s_ + su;
+                const int cnt = recv_counts[g];
+                if (cnt != 0) {
+                    std::memcpy(dst + static_cast<size_t>(recv_displs[g]) * elem,
+                                stage_recv_.data() + cur * elem,
+                                static_cast<size_t>(cnt) * elem);
+                }
+                cur += static_cast<size_t>(cnt);
+            }
+        }
+    }
+
+private:
+    // checked_mpi_count's message prefixes, so the shared layout sweep names the side it is laying out.
+    struct CountLabels {
+        const char *per_rank;
+        const char *displ;
+        const char *total;
+    };
+    static constexpr CountLabels kSendLabels{"Per-rank send count", "Send displacement", "Total send count"};
+    static constexpr CountLabels kRecvLabels{"Per-rank recv count", "Recv displacement", "Total recv count"};
+
+    /*!
+     * @brief The per-rank wire layout both sides share: sum @a col over each rank's S slots into
+     * @a counts, take the ascending prefix into @a displs, and lay each slot's block start into
+     * @a base. Returns the total, in elements.
+     */
+    auto layout_peers_(const std::vector<long long> &col,
+                       std::vector<int> &counts,
+                       std::vector<int> &displs,
+                       std::vector<size_t> &base,
+                       CountLabels what) -> size_t {
+        for (int b = 0; b < r_; ++b) {
+            const long long *slots = col.data() + static_cast<size_t>(b) * static_cast<size_t>(s_);
+            long long sum = 0;
+            for (int t = 0; t < s_; ++t) {
+                sum += slots[t];
+            }
+            counts[static_cast<size_t>(b)] = checked_mpi_count(sum, what.per_rank);
+        }
+        long long running = 0;
+        for (int b = 0; b < r_; ++b) {
+            displs[static_cast<size_t>(b)] = checked_mpi_count(running, what.displ);
+            running += counts[static_cast<size_t>(b)];
+        }
+        const auto total = static_cast<size_t>(checked_mpi_count(running, what.total));
+        for (int b = 0; b < r_; ++b) {
+            size_t cur = static_cast<size_t>(displs[static_cast<size_t>(b)]);
+            for (int t = 0; t < s_; ++t) {
+                const size_t g = static_cast<size_t>(b) * static_cast<size_t>(s_) + static_cast<size_t>(t);
+                base[g] = cur;
+                cur += static_cast<size_t>(col[g]);
+            }
+        }
+        return total;
+    }
+
+    static constexpr size_t kLineBytes = 64;
+    static constexpr size_t kIntsPerLine = kLineBytes / sizeof(int);
+    static constexpr size_t kLongsPerLine = kLineBytes / sizeof(long long);
+
+    static auto round_up_(size_t n, size_t m) -> size_t { return ((n + m - 1) / m) * m; }
+
+    template <typename T>
+    static auto align_to_line_(T *p) -> T * {
+        static_assert(kLineBytes % sizeof(T) == 0);
+        const auto addr = reinterpret_cast<uintptr_t>(p);
+        const size_t pad = (kLineBytes - static_cast<size_t>(addr % kLineBytes)) % kLineBytes;
+        return p + pad / sizeof(T);
+    }
+
+    // (rank, dest partition, source partition) in the R*S*S count matrices: the count message's wire layout.
+    [[nodiscard]] auto counts_idx_(int b, int t, int su) const -> size_t {
+        return (static_cast<size_t>(b) * static_cast<size_t>(s_) + static_cast<size_t>(t)) * static_cast<size_t>(s_)
+               + static_cast<size_t>(su);
+    }
+
+    // [S x P] payload offset table: row u is source partition u's staging starts, one per destination g.
+    [[nodiscard]] auto pack_idx_(int u, int g) const -> size_t {
+        return static_cast<size_t>(u) * static_cast<size_t>(r_) * static_cast<size_t>(s_) + static_cast<size_t>(g);
+    }
+
+    [[nodiscard]] auto counts_row(int u) -> int * { return counts_matrix_ + static_cast<size_t>(u) * counts_stride_; }
+    [[nodiscard]] auto row_recv_(int u) -> long long * { return rows_ + static_cast<size_t>(u) * rows_stride_; }
+
+    MPI_Comm parent_;
+    int mpi_rank_;
+    int r_;
+    int s_;
+
+    // S*S per rank, the count message both ways.
+    std::vector<int> counts_send_;
+    std::vector<int> counts_recv_;
+    // Per-rank [R] counts/displs for the aggregated payload alltoallv.
+    std::vector<int> mpi_send_counts_;
+    std::vector<int> mpi_send_displs_;
+    std::vector<int> mpi_recv_counts_;
+    std::vector<int> mpi_recv_displs_;
+    // [S x P] payload block starts in stage_send_, row u per global destination g. No scatter-side
+    // table: see size_recv.
+    std::vector<size_t> pack_off_;
+    // [P] staging bases: base_send_[b*S+t] starts partition (b,t)'s region of the message to rank b,
+    // base_recv_[a*S+t] starts local partition t's region of the message from rank a.
+    std::vector<size_t> base_send_;
+    std::vector<size_t> base_recv_;
+    std::vector<long long> col_sum_;
+    std::vector<long long> recv_col_;
+    // [S x counts_stride_] send-count matrix, row u owned by partition u; padded so no two rows share a
+    // 64-byte line. Lifetime rule: publish_counts_row.
+    std::vector<int> counts_matrix_store_;
+    int *counts_matrix_ = nullptr;
+    size_t counts_stride_ = 0;
+    // [S x rows_stride_] per-partition per-rank recv totals, same ownership and padding rules.
+    std::vector<long long> rows_store_;
+    long long *rows_ = nullptr;
+    size_t rows_stride_ = 0;
+    // Aggregated MPI payload staging, HWM-sized.
+    std::vector<std::byte> stage_send_;
+    std::vector<std::byte> stage_recv_;
+};
+
+} // namespace monoprop::mpi

--- a/cpp/monoprop/detail/mpi/MPICompat.cpp
+++ b/cpp/monoprop/detail/mpi/MPICompat.cpp
@@ -14,9 +14,14 @@
 
 #include "monoprop/detail/mpi/Exchange.h"
 
+#include <algorithm>
 #include <format>
 #include <print>
 #include <stdexcept>
+
+#ifdef monoprop_ENABLE_MPI
+#include "monoprop/detail/mpi/Pairwise.h"
+#endif
 
 namespace monoprop::mpi {
 
@@ -114,19 +119,45 @@ auto allreduce_sum_inplace(VecD &values, Comm comm) -> void {
 #endif
 }
 
-auto alltoall_counts(const int *send_counts, int *recv_counts, int n, Comm comm) -> void {
+auto alltoall_counts(const int *send_counts, int *recv_counts, int n, Comm comm, PeerPlan plan) -> void {
     if (comm.kind == Comm::Kind::Shm) {
         comm.shm->alltoall_counts(comm.shm_rank, send_counts, recv_counts);
         return;
     }
 #ifdef monoprop_ENABLE_MPI
     if (comm.kind == Comm::Kind::Hybrid) {
-        comm.hyb->alltoall_counts(comm.shm_rank, send_counts, recv_counts);
+        comm.hyb->alltoall_counts(comm.shm_rank, send_counts, recv_counts, plan);
+        return;
+    }
+    if (!plan.dense()) {
+        // S == 1 world: exchange one int with each reachable peer; the rest of the row is zero by
+        // definition, so it must be cleared rather than left from a previous round.
+        int me = 0;
+        MPI_Comm_rank(comm.mpi, &me);
+        std::fill(recv_counts, recv_counts + n, 0);
+        const PeerLayout one{.block = 1};
+        // Eager by contract: recv_counts is caller memory the caller reads on return, so unlike the
+        // payload round this one cannot be handed on in a handle.
+        std::vector<MPI_Request> reqs;
+        const int posted = sparse_pairwise(plan,
+                                           me,
+                                           n,
+                                           comm.mpi,
+                                           kFlatCountTag,
+                                           MPI_INT,
+                                           sizeof(int),
+                                           reinterpret_cast<const std::byte *>(send_counts),
+                                           one,
+                                           reinterpret_cast<std::byte *>(recv_counts),
+                                           one,
+                                           reqs);
+        MPI_Waitall(posted, reqs.data(), MPI_STATUSES_IGNORE);
         return;
     }
     (void)n;
     MPI_Alltoall(send_counts, 1, MPI_INT, recv_counts, 1, MPI_INT, comm.mpi);
 #else
+    (void)plan; // single participant: nothing to narrow
     for (int i = 0; i < n; ++i) {
         recv_counts[i] = send_counts[i];
     }

--- a/cpp/monoprop/detail/mpi/MPICompat.h
+++ b/cpp/monoprop/detail/mpi/MPICompat.h
@@ -126,6 +126,23 @@ inline auto allreduce_sum(T local_val, Comm comm) -> T {
 
 monoprop_EXPORT auto allreduce_sum_inplace(VecD &values, Comm comm) -> void;
 
+/*! @brief Bytes the transport behind @a comm holds, for the memory ledger's diagnostics.
+ *
+ *  Only the in-process transports own buffers of their own; Kind::Mpi has none, because its payload
+ *  buffers belong to the in-flight PendingAlltoallv handle and die with the gate that opened the round.
+ */
+inline auto staging_bytes(Comm comm) -> size_t {
+    if (comm.kind == Comm::Kind::Shm) {
+        return comm.shm->staging_bytes();
+    }
+#ifdef monoprop_ENABLE_MPI
+    if (comm.kind == Comm::Kind::Hybrid) {
+        return comm.hyb->staging_bytes();
+    }
+#endif
+    return 0;
+}
+
 // `n` is the comm size. `plan` narrows the exchange to the destination ranks it can reach (see
 // PeerPlan); the default is dense, i.e. today's collective.
 monoprop_EXPORT auto alltoall_counts(const int *send_counts, int *recv_counts, int n, Comm comm, PeerPlan plan = {})

--- a/cpp/monoprop/detail/mpi/MPICompat.h
+++ b/cpp/monoprop/detail/mpi/MPICompat.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -32,6 +33,7 @@
 #include "monoprop/detail/mpi/ShmComm.h"
 #ifdef monoprop_ENABLE_MPI
 #include "monoprop/detail/mpi/HybridComm.h"
+#include "monoprop/detail/mpi/Pairwise.h"
 #endif
 
 // These includes are here on purpose and should not be moved to the top
@@ -124,8 +126,10 @@ inline auto allreduce_sum(T local_val, Comm comm) -> T {
 
 monoprop_EXPORT auto allreduce_sum_inplace(VecD &values, Comm comm) -> void;
 
-// `n` is the comm size.
-monoprop_EXPORT auto alltoall_counts(const int *send_counts, int *recv_counts, int n, Comm comm) -> void;
+// `n` is the comm size. `plan` narrows the exchange to the destination ranks it can reach (see
+// PeerPlan); the default is dense, i.e. today's collective.
+monoprop_EXPORT auto alltoall_counts(const int *send_counts, int *recv_counts, int n, Comm comm, PeerPlan plan = {})
+    -> void;
 
 // In-flight variable-size all-to-all owning its buffers + layout, so several can be in flight.
 // recv_counts is valid on return from begin_alltoallv; wait_into completes the payload transfer (a
@@ -133,6 +137,8 @@ monoprop_EXPORT auto alltoall_counts(const int *send_counts, int *recv_counts, i
 template <typename T>
 struct PendingAlltoallv {
     int num_ranks = 0;
+    // The slots this round touches; counts and displs are zero outside it. Set by begin_alltoallv.
+    SlotWindow window;
     std::vector<int> send_counts;
     std::vector<int> send_displs;
     std::vector<int> recv_counts;
@@ -140,7 +146,10 @@ struct PendingAlltoallv {
     std::vector<T> send_buffer;
     std::vector<T> recv_buffer;
 #ifdef monoprop_ENABLE_MPI
-    MPI_Request request = MPI_REQUEST_NULL; // set only on the Kind::Mpi async path
+    MPI_Request request = MPI_REQUEST_NULL; // set only on the Kind::Mpi dense async path
+    std::vector<MPI_Request> requests;      // the Kind::Mpi sparse path's pairs; `posted` of them live
+    int posted = 0;                         // MPI reads send_buffer/recv_buffer until these complete,
+                                            // and both move with the handle, so the pointers hold
 #endif
 
     auto wait_into(std::vector<std::vector<T>> &recv_data) -> void {
@@ -149,14 +158,33 @@ struct PendingAlltoallv {
             MPI_Wait(&request, MPI_STATUS_IGNORE);
             request = MPI_REQUEST_NULL;
         }
+        if (posted != 0) {
+            MPI_Waitall(posted, requests.data(), MPI_STATUSES_IGNORE);
+            posted = 0;
+        }
 #endif
-        recv_data.resize(static_cast<size_t>(num_ranks));
-        for (int i = 0; i < num_ranks; ++i) {
-            const auto lo = recv_buffer.begin() + recv_displs[static_cast<size_t>(i)];
-            recv_data[static_cast<size_t>(i)].assign(lo, lo + recv_counts[static_cast<size_t>(i)]);
+        // Full-world shape whatever the window was: a non-peer's block is empty, not absent.
+        recv_data.assign(static_cast<size_t>(num_ranks), std::vector<T>{});
+        for (size_t k = 0; k < window.count; ++k) {
+            const size_t i = window.slot(WindowIndex{k});
+            const auto lo = recv_buffer.begin() + recv_displs[i];
+            recv_data[i].assign(lo, lo + recv_counts[i]);
         }
     }
 };
+
+// Debug-only: a caller may supply the whole [P] array under a sparse plan, and anything it left outside
+// the window is DROPPED rather than refused -- the silent failure mode a wrong-but-agreed shift produces.
+template <typename T>
+inline auto assert_outside_window_is_empty_([[maybe_unused]] const std::vector<std::vector<T>> &send_data,
+                                            [[maybe_unused]] SlotWindow window) -> void {
+#ifndef NDEBUG
+    for (size_t i = 0; i < send_data.size(); ++i) {
+        assert((window.contains(i) || send_data[i].empty())
+               && "a block outside the plan's peer window would be dropped in silence");
+    }
+#endif
+}
 
 // The count exchange runs eagerly (recv_counts known on return); the Kind::Mpi payload is non-blocking
 // (wait_into completes it), Shm / single-process transfer here.
@@ -167,8 +195,11 @@ template <typename T>
 inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
                             Comm comm,
                             bool skip_self = false,
-                            const std::vector<int> *known_recv_counts = nullptr) -> PendingAlltoallv<T> {
+                            const std::vector<int> *known_recv_counts = nullptr,
+                            PeerPlan plan = {}) -> PendingAlltoallv<T> {
     const int num_ranks = size(comm);
+    const int me = rank(comm);
+    const auto geom = geometry(comm);
     if (static_cast<int>(send_data.size()) != num_ranks) {
         throw CollectiveArgumentError(
             std::format("begin_alltoallv: send_data size ({}) must equal number of ranks ({})",
@@ -177,37 +208,41 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
     }
     PendingAlltoallv<T> h;
     h.num_ranks = num_ranks;
-    h.send_counts.resize(static_cast<size_t>(num_ranks));
-    h.send_displs.resize(static_cast<size_t>(num_ranks));
-    h.recv_displs.resize(static_cast<size_t>(num_ranks));
+    // The plan IS the mask, dense included -- it is the count == P value of the same window. The caller
+    // still hands a whole [P] array; assert_outside_window_is_empty_ catches what it leaves outside,
+    // which is the silent drop a wrong-but-agreed shift produces.
+    h.window =
+        plan.window(static_cast<size_t>(me), static_cast<size_t>(geom.ranks), static_cast<size_t>(geom.partitions));
+    assert(h.window.stop() <= static_cast<size_t>(num_ranks));
+    assert_outside_window_is_empty_(send_data, h.window);
+    h.send_counts.assign(static_cast<size_t>(num_ranks), 0);
+    h.send_displs.assign(static_cast<size_t>(num_ranks), 0);
+    h.recv_displs.assign(static_cast<size_t>(num_ranks), 0);
 
-    const int self = skip_self ? rank(comm) : -1;
+    const int self = skip_self ? me : -1;
+    // Counts and their prefix in ONE sweep over the window; the rest stay zero from the assign above.
     // Wide accumulator + checked narrowing: a wrapped count would size send_buffer short and then feed
     // MPI a negative count/displacement.
-    long long total_send = 0;
-    for (int i = 0; i < num_ranks; ++i) {
-        const size_t n = (i == self) ? 0 : send_data[static_cast<size_t>(i)].size();
-        const int c = checked_mpi_count(n, "Send count");
-        h.send_counts[static_cast<size_t>(i)] = c;
-        total_send += c;
-    }
     long long running_send = 0;
-    for (int i = 0; i < num_ranks; ++i) {
-        h.send_displs[static_cast<size_t>(i)] = checked_mpi_count(running_send, "Send displacement");
-        running_send += h.send_counts[static_cast<size_t>(i)];
+    for (size_t k = 0; k < h.window.count; ++k) {
+        const size_t i = h.window.slot(WindowIndex{k});
+        const size_t n = (static_cast<int>(i) == self) ? 0 : send_data[i].size();
+        const int c = checked_mpi_count(n, "Send count");
+        h.send_counts[i] = c;
+        h.send_displs[i] = checked_mpi_count(running_send, "Send displacement");
+        running_send += c;
     }
-    h.send_buffer.resize(static_cast<size_t>(checked_mpi_count(total_send, "Total send count")));
-    for (int i = 0; i < num_ranks; ++i) {
-        const int c = h.send_counts[static_cast<size_t>(i)];
+    h.send_buffer.resize(static_cast<size_t>(checked_mpi_count(running_send, "Total send count")));
+    for (size_t k = 0; k < h.window.count; ++k) {
+        const size_t i = h.window.slot(WindowIndex{k});
+        const int c = h.send_counts[i];
         if (c == 0) {
             continue;
         }
-        std::copy(send_data[static_cast<size_t>(i)].begin(),
-                  send_data[static_cast<size_t>(i)].begin() + c,
-                  h.send_buffer.begin() + h.send_displs[static_cast<size_t>(i)]);
+        std::copy(send_data[i].begin(), send_data[i].begin() + c, h.send_buffer.begin() + h.send_displs[i]);
     }
 
-    h.recv_counts.resize(static_cast<size_t>(num_ranks));
+    h.recv_counts.assign(static_cast<size_t>(num_ranks), 0);
 
     const AlltoallvResolveArgs<T> resolve_args{.send = h.send_buffer.data(),
                                                .send_counts = h.send_counts.data(),
@@ -224,29 +259,36 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
     }
 #ifdef monoprop_ENABLE_MPI
     if (known_recv_counts == nullptr && comm.kind == Comm::Kind::Hybrid) {
-        comm.hyb->alltoallv_resolve<T>(comm.shm_rank, resolve_args, datatype<T>::get());
+        comm.hyb->alltoallv_resolve<T>(comm.shm_rank, resolve_args, datatype<T>::get(), plan);
         return h;
     }
 #endif
 
     if (known_recv_counts != nullptr) {
-        std::copy(
-            known_recv_counts->begin(),
-            known_recv_counts->begin() + std::min<size_t>(known_recv_counts->size(), static_cast<size_t>(num_ranks)),
-            h.recv_counts.begin());
+        // The caller's array is FLAT [P]; the window is the mask, as alltoall_counts already masks the
+        // counts it exchanges. No receive is ever posted for a non-peer, so a non-zero count there sizes
+        // recv_buffer for bytes nothing writes and wait_into hands the caller uninitialised memory.
+        const size_t avail = known_recv_counts->size();
+        for (size_t k = 0; k < h.window.count; ++k) {
+            const size_t i = h.window.slot(WindowIndex{k});
+            if (i < avail) {
+                h.recv_counts[i] = (*known_recv_counts)[i];
+            }
+        }
         if (self >= 0) {
             h.recv_counts[static_cast<size_t>(self)] = 0;
         }
     }
     else {
-        alltoall_counts(h.send_counts.data(), h.recv_counts.data(), num_ranks, comm);
+        alltoall_counts(h.send_counts.data(), h.recv_counts.data(), num_ranks, comm, plan);
     }
 
     // Wide accumulator + checked narrowing: see checked_mpi_count.
     long long running = 0;
-    for (int i = 0; i < num_ranks; ++i) {
-        h.recv_displs[static_cast<size_t>(i)] = checked_mpi_count(running, "Recv displacement");
-        running += h.recv_counts[static_cast<size_t>(i)];
+    for (size_t k = 0; k < h.window.count; ++k) {
+        const size_t i = h.window.slot(WindowIndex{k});
+        h.recv_displs[i] = checked_mpi_count(running, "Recv displacement");
+        running += h.recv_counts[i];
     }
     h.recv_buffer.resize(static_cast<size_t>(checked_mpi_count(running, "Total recv count")));
 
@@ -270,21 +312,41 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
     }
 #ifdef monoprop_ENABLE_MPI
     else if (comm.kind == Comm::Kind::Hybrid) {
-        comm.hyb->alltoallv(comm.shm_rank, flat, datatype<T>::get());
+        comm.hyb->alltoallv(comm.shm_rank, flat, datatype<T>::get(), plan);
     }
 #endif
     else {
 #ifdef monoprop_ENABLE_MPI
-        MPI_Ialltoallv(h.send_buffer.data(),
-                       h.send_counts.data(),
-                       h.send_displs.data(),
-                       datatype<T>::get(),
-                       h.recv_buffer.data(),
-                       h.recv_counts.data(),
-                       h.recv_displs.data(),
-                       datatype<T>::get(),
-                       comm.mpi,
-                       &h.request);
+        if (plan.dense()) {
+            MPI_Ialltoallv(h.send_buffer.data(),
+                           h.send_counts.data(),
+                           h.send_displs.data(),
+                           datatype<T>::get(),
+                           h.recv_buffer.data(),
+                           h.recv_counts.data(),
+                           h.recv_displs.data(),
+                           datatype<T>::get(),
+                           comm.mpi,
+                           &h.request);
+        }
+        else {
+            // S == 1 world: the same pairing as the Hybrid path, one message per reachable peer, left in
+            // flight in the handle exactly as MPI_Ialltoallv is. The buffers MPI holds live in `h` and
+            // travel with it: a vector move keeps its heap block, so returning `h` moves nothing MPI is
+            // reading.
+            h.posted = sparse_pairwise(plan,
+                                       me,
+                                       num_ranks,
+                                       comm.mpi,
+                                       kFlatPayloadTag,
+                                       datatype<T>::get(),
+                                       sizeof(T),
+                                       reinterpret_cast<const std::byte *>(h.send_buffer.data()),
+                                       PeerLayout{.counts = h.send_counts.data(), .displs = h.send_displs.data()},
+                                       reinterpret_cast<std::byte *>(h.recv_buffer.data()),
+                                       PeerLayout{.counts = h.recv_counts.data(), .displs = h.recv_displs.data()},
+                                       h.requests);
+        }
 #else
         h.recv_buffer = h.send_buffer; // single participant: self round-trip (layouts identical)
 #endif

--- a/cpp/monoprop/detail/mpi/Pairwise.h
+++ b/cpp/monoprop/detail/mpi/Pairwise.h
@@ -1,0 +1,116 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <vector>
+
+#include <mpi.h>
+
+#include "monoprop/detail/mpi/Comm.h"
+
+namespace monoprop::mpi {
+
+// One tag per (transport, verb), all five here so no two can collide unseen: one thread per rank calls
+// MPI, so the tag is all that keeps a count round in flight from being matched by a payload receive.
+//
+// Why consecutive gate exchanges (one round per gate) may reuse kFlatPayloadTag on one communicator:
+// MPI does not overtake within a (src, dst, tag, comm); a gate's MPI_Waitall completes before the next
+// gate posts; and both ends skip a zero-count leg on the same value -- what one sends a peer IS that
+// peer's recv count, by transpose -- so the two posted sequences match element for element and a later
+// receive cannot match an earlier send.
+inline constexpr int kHybridCountTag = 0x6D70; // 'mp'
+inline constexpr int kHybridPayloadTag = 0x6D71;
+inline constexpr int kFlatPayloadTag = 0x6D72;
+inline constexpr int kFlatCountTag = 0x6D73;
+// Graph REPLAY payload (Exchange.h). Its own value, so a replay leg can match neither the build path's
+// counts nor its payload even though both run over the same communicator.
+inline constexpr int kFlatReplayTag = 0x6D74;
+
+//! @brief Per-peer element counts and offsets. Null @c counts is the fixed-block case: @c block each,
+//! at @c b*block.
+struct PeerLayout {
+    const int *counts = nullptr;
+    const int *displs = nullptr;
+    int block = 0;
+
+    [[nodiscard]] auto count(int b) const -> int { return counts != nullptr ? counts[b] : block; }
+    [[nodiscard]] auto displ(int b) const -> size_t {
+        return static_cast<size_t>(displs != nullptr ? displs[b] : b * block);
+    }
+};
+
+/*!
+ * @brief A variable all-to-all as point-to-point over @a plan's peers: one Irecv/Isend pair each, the
+ * self peer copied in place. Returns how many of @a reqs are live.
+ *
+ * Counts and displacements are in ELEMENTS of @a dt, whose extent must be @a elem. @a reqs is caller
+ * storage, grown then INDEXED: MPI holds these pointers until the wait, so a reallocating push_back
+ * would dangle them.
+ *
+ * POSTS ONLY. The caller waits, so @a send, @a recv and @a reqs must all outlive that wait -- which is
+ * what lets a caller hold the round open the same way the dense branch holds an MPI_Ialltoallv.
+ *
+ * @a active_legs is an UPPER BOUND on the peers that will post, for a caller that already knows it (a
+ * dense plan over a mostly-empty layout would otherwise size @a reqs at 2 * n_ranks); negative means
+ * "assume every peer posts". Too small a bound is caught by an assert, not silently.
+ */
+[[nodiscard]] inline auto sparse_pairwise(PeerPlan plan,
+                                          int me,
+                                          int n_ranks,
+                                          MPI_Comm comm,
+                                          int tag,
+                                          MPI_Datatype dt,
+                                          size_t elem,
+                                          const std::byte *send,
+                                          PeerLayout send_lay,
+                                          std::byte *recv,
+                                          PeerLayout recv_lay,
+                                          std::vector<MPI_Request> &reqs,
+                                          int active_legs = -1) -> int {
+    const int f = plan.count(n_ranks);
+    const auto cap = static_cast<size_t>(2 * (active_legs < 0 || active_legs > f ? f : active_legs));
+    if (reqs.size() < cap) {
+        reqs.resize(cap);
+    }
+    int n_req = 0;
+    for (int k = 0; k < f; ++k) {
+        const int b = plan.peer(me, k);
+        const int sc = send_lay.count(b);
+        const int rc = recv_lay.count(b);
+        std::byte *rbuf = recv + recv_lay.displ(b) * elem;
+        const std::byte *sbuf = send + send_lay.displ(b) * elem;
+        if (b == me) {
+            // The self slot is a copy, not a message: its two counts are each other's transpose.
+            assert(sc == rc);
+            if (rc != 0) {
+                std::memcpy(rbuf, sbuf, static_cast<size_t>(rc) * elem);
+            }
+            continue;
+        }
+        assert(static_cast<size_t>(n_req) + 2 <= reqs.size() || (rc == 0 && sc == 0)); // active_legs too small
+        if (rc != 0) {
+            MPI_Irecv(rbuf, rc, dt, b, tag, comm, &reqs[static_cast<size_t>(n_req++)]);
+        }
+        if (sc != 0) {
+            MPI_Isend(sbuf, sc, dt, b, tag, comm, &reqs[static_cast<size_t>(n_req++)]);
+        }
+    }
+    return n_req;
+}
+
+} // namespace monoprop::mpi

--- a/cpp/monoprop/detail/mpi/Routing.h
+++ b/cpp/monoprop/detail/mpi/Routing.h
@@ -187,6 +187,12 @@ public:
         return is_flat_linear() ? linear_bits() + parts_log2_ : linear_bits();
     }
 
+    //! @brief The same number for a geometry alone, with no monomial width to bind: it IS the private
+    //! constructor, so the resolution and the non-power-of-two throw cannot drift from a router's.
+    [[nodiscard]] static auto bits_for(size_t ranks, bool linear) -> size_t {
+        return Router{ranks, 1, linear}.linear_bits();
+    }
+
     /*!
      * @brief Flat destination slot in [0, flat_world) for a dense monomial. The branch is on a member,
      * so it is perfectly predicted; the splitmix arm is bit-for-bit `monomial_hash % P`.
@@ -268,6 +274,11 @@ private:
 //! @brief The mode, before any geometry: linear unless monoprop_ROUTING asks for splitmix.
 inline auto linear_requested() -> bool {
     return config::get().routing_mode.value_or(config::RoutingMode::Linear) == config::RoutingMode::Linear;
+}
+
+//! @brief Resolved rank bits for a geometry, without a router: the replay transport gates on the number.
+inline auto linear_bits_for(size_t ranks) -> size_t {
+    return Router::bits_for(ranks, linear_requested());
 }
 
 //! @brief The router a geometry resolves to under the environment's mode.

--- a/cpp/monoprop/detail/mpi/ShmComm.h
+++ b/cpp/monoprop/detail/mpi/ShmComm.h
@@ -45,6 +45,14 @@ public:
 
     auto size() const -> int { return n_; }
 
+    /*! @brief Bytes this transport holds: the publish slots, and nothing else.
+     *
+     *  Diagnostic, the ShmComm half of mpi::staging_bytes(). There is no payload staging to report --
+     *  a peer reads the publisher's own send buffer in place through `slots_` -- so the only bytes here
+     *  are one cache-line slot per partition.
+     */
+    [[nodiscard]] auto staging_bytes() const -> size_t { return slots_.capacity() * sizeof(Slot); }
+
     // recv_counts[s] = what rank s sends to me (the transpose of the send-count matrix).
     auto alltoall_counts(int rank, const int *send_counts, int *recv_counts) -> void {
         slots_[static_cast<size_t>(rank)].counts = send_counts;

--- a/cpp/monoprop/detail/operator/MPOperator.h
+++ b/cpp/monoprop/detail/operator/MPOperator.h
@@ -345,6 +345,14 @@ struct MPOperatorMemoryBreakdown final {
     // so these bytes are what the kernel charges even where no named field prices them.
     size_t pool_mapped_bytes{0uz};
     size_t pool_free_chunk_bytes{0uz};
+    /*! @brief The transport's persistent staging: the in-process transports' grow-only payload buffers
+     *  and their (R, S)-fixed tables. Zero for plain MPI, whose payload buffers are the gate's own.
+     *
+     *  A per-RANK figure, so exactly one partition reports it and the sum over partitions counts a
+     *  rank's transport once (MonomialPropagator::operator_memory_usage). Not in total_bytes(): it is
+     *  the comm's memory, not the operator's, and total_bytes() is an operator figure.
+     */
+    size_t wire_staging_bytes{0uz};
     // of op_coeffs_bytes: the most capacity the coefficient array held beyond its live rows at any
     // point in the last propagate or build_graph call. A high-water mark, not a resting figure: the
     // array is shrunk to fit at the end of every call, so measured at quiescence the slack is always 0.
@@ -378,6 +386,8 @@ struct MPOperatorMemoryBreakdown final {
         row_inline_width = std::max(row_inline_width, o.row_inline_width);
         pool_mapped_bytes += o.pool_mapped_bytes;
         pool_free_chunk_bytes += o.pool_free_chunk_bytes;
+        // Summed although it is per-rank, because only one partition reports a nonzero: see the field.
+        wire_staging_bytes += o.wire_staging_bytes;
         // Summed, not maxed, across partitions: the partitions grow together within a call, so the sum
         // is the figure a per-process footprint wants. An upper bound, and it errs the safe way.
         op_coeffs_slack_bytes += o.op_coeffs_slack_bytes;

--- a/cpp/tests/README.md
+++ b/cpp/tests/README.md
@@ -125,7 +125,13 @@ name and cannot address suite-nested cases, tests use flat
   `mp_graph_tests.cpp` (MPGraph slice_graph/slice_view transforms, the
   front_offset lazy-compaction arms, MPGraphView reverse mapping + OOB throw).
 - **Transports / distribution**: `shm_comm_tests.cpp`, `hybrid_comm_tests.cpp`
-  (MPI-only), `partition_equivalence_tests.cpp`,
+  (MPI-only; the sparse cases drive a `PeerPlan` through both the staged hybrid
+  verbs and the plain-MPI ones, covering the peer-only delivery, an empty leg,
+  the self peer at shift 0, back-to-back rounds on one tag and the wire plan
+  partition 0 derives from a sibling's row -- all self-skipping below two ranks
+  or off a power-of-two rank count), `flat_exchange_tests.cpp` (the graph replay
+  path's transport gate: which arm `wire_bits` picks and what the ticket has to
+  drain, never inferred from the layout), `partition_equivalence_tests.cpp`,
   `mpi_distributed_layer_equivalence.cpp`, `mpi_fresh_insert_equivalence.cpp`
   (serial↔world equivalence of the Schrödinger fused-resolve fresh-insert arms,
   Majorana + native Pauli; self-skips at world size 1).

--- a/cpp/tests/boost-test.cmake
+++ b/cpp/tests/boost-test.cmake
@@ -1,6 +1,8 @@
+# 4 as well as 2: at R = 2 the peer plan can only ever resolve one peer, so every `for k in [0, f)` in
+# the sparse transport stays a single iteration and the f > 1 cases never run.
 set(
   monoprop_MPI_TEST_PROCS
-  "2"
+  "2;4"
   CACHE STRING
   "Semicolon-separated list of ranks for MPI test variants"
 )

--- a/cpp/tests/flat_exchange_tests.cpp
+++ b/cpp/tests/flat_exchange_tests.cpp
@@ -1,0 +1,230 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// post_flat_alltoallv's transport choice (the graph REPLAY path). `wire_bits` alone picks it -- never the
+// layout -- because a data-dependent branch straddles: a rank inside MPI_Ialltoallv waits forever on one
+// that chose point-to-point. Ticket::in_flight() is what tells the two apart: 1 for the collective, two
+// requests per posted leg, 0 for a round with nothing to move.
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+#include "monoprop/detail/mpi/Comm.h"
+#include "monoprop/detail/mpi/Exchange.h"
+
+#ifdef monoprop_ENABLE_MPI
+#include <bit>
+
+#include <mpi.h>
+#endif
+
+using monoprop::mpi::active_leg_count;
+using monoprop::mpi::Comm;
+using monoprop::mpi::post_flat_alltoallv;
+
+namespace {
+
+// The prefix sum post_flat_alltoallv takes on both sides of a symmetric layout.
+auto displs_of(const std::vector<int> &counts) -> std::vector<int> {
+    std::vector<int> displs(counts.size());
+    int running = 0;
+    for (size_t i = 0; i < counts.size(); ++i) {
+        displs[i] = running;
+        running += counts[i];
+    }
+    return displs;
+}
+
+auto total_of(const std::vector<int> &counts) -> int {
+    return std::accumulate(counts.begin(), counts.end(), 0);
+}
+
+#ifdef monoprop_ENABLE_MPI
+auto world_size() -> int {
+    int n = 0;
+    MPI_Comm_size(MPI_COMM_WORLD, &n);
+    return n;
+}
+auto world_rank() -> int {
+    int r = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &r);
+    return r;
+}
+// What Evolution's gate resolves to when routing gives fanout 1, which is the default at a power-of-two
+// rank count. Tests must not derive it from their own layout -- that is the straddle.
+auto wire_bits_for(int n) -> int {
+    return std::countr_zero(static_cast<unsigned>(n));
+}
+#endif
+
+} // namespace
+
+// The upper bound the request vector is sized from: a leg counts if EITHER side carries a payload, so a
+// bound too small can never be handed to sparse_pairwise.
+BOOST_AUTO_TEST_CASE(flat_exchange_active_legs_take_either_side) {
+    constexpr int n = 8;
+    std::vector<int> send(static_cast<size_t>(n), 0);
+    std::vector<int> recv(static_cast<size_t>(n), 0);
+    BOOST_CHECK_EQUAL(active_leg_count(send.data(), recv.data(), n), 0);
+    send[1] = 4;
+    recv[6] = 4;
+    BOOST_CHECK_EQUAL(active_leg_count(send.data(), recv.data(), n), 2);
+    recv[1] = 4; // same leg, both sides
+    BOOST_CHECK_EQUAL(active_leg_count(send.data(), recv.data(), n), 2);
+}
+
+// The self leg is a copy, not a message, so a one-rank world posts nothing at all and wait() is a no-op.
+// Same on the non-MPI build, where the fallback self-copy runs instead.
+BOOST_AUTO_TEST_CASE(flat_exchange_self_leg_is_copied_with_nothing_posted) {
+    Comm c{MPI_COMM_SELF};
+    const std::vector<int> counts{3};
+    const auto displs = displs_of(counts);
+    const std::vector<int> send{7, 8, 9};
+    std::vector<int> out(static_cast<size_t>(total_of(counts)), -1);
+    auto ticket = post_flat_alltoallv<int>({.send = send.data(),
+                                            .send_counts = counts.data(),
+                                            .send_displs = displs.data(),
+                                            .recv = out.data(),
+                                            .recv_counts = counts.data(),
+                                            .recv_displs = displs.data()},
+                                           1,
+                                           c,
+                                           /*wire_bits=*/1);
+    BOOST_CHECK_EQUAL(ticket.in_flight(), 0);
+    ticket.wait();
+    BOOST_CHECK(out == send);
+}
+
+#ifdef monoprop_ENABLE_MPI
+
+namespace {
+
+// One round over a symmetric layout, returning what wait() had to drain. `counts` is both sides.
+auto run_round(int n,
+               int wire_bits,
+               const std::vector<int> &counts,
+               const std::vector<int> &send,
+               std::vector<int> &out) -> int {
+    Comm c{MPI_COMM_WORLD};
+    const auto displs = displs_of(counts);
+    auto ticket = post_flat_alltoallv<int>({.send = send.data(),
+                                            .send_counts = counts.data(),
+                                            .send_displs = displs.data(),
+                                            .recv = out.data(),
+                                            .recv_counts = counts.data(),
+                                            .recv_displs = displs.data()},
+                                           n,
+                                           c,
+                                           wire_bits);
+    const int drained = ticket.in_flight();
+    ticket.wait();
+    return drained;
+}
+
+} // namespace
+
+// wire_bits == 0 is today's collective whatever the layout holds -- including the sparse layout the
+// pairwise arm exists for. The layout must not be able to move the branch.
+BOOST_AUTO_TEST_CASE(flat_exchange_zero_wire_bits_always_takes_the_collective) {
+    const int n = world_size();
+    if (n < 2 || (n % 2) != 0) {
+        return;
+    }
+    const int me = world_rank();
+    const int peer = me ^ 1;
+    for (const bool dense : {true, false}) {
+        std::vector<int> counts(static_cast<size_t>(n), 0);
+        if (dense) {
+            std::fill(counts.begin(), counts.end(), 1);
+        }
+        else {
+            counts[static_cast<size_t>(peer)] = 1; // one leg: the shape the pairwise arm is for
+        }
+        const auto displs = displs_of(counts);
+        std::vector<int> send(static_cast<size_t>(total_of(counts)), me);
+        std::vector<int> out(static_cast<size_t>(total_of(counts)), -1);
+        BOOST_CHECK_EQUAL(run_round(n, 0, counts, send, out), 1);
+        for (int i = 0; i < n; ++i) {
+            if (counts[static_cast<size_t>(i)] != 0) {
+                BOOST_CHECK_EQUAL(out[static_cast<size_t>(displs[static_cast<size_t>(i)])], i);
+            }
+        }
+    }
+}
+
+// One peer, me ^ 1 -- an involution, so the count matrix stays symmetric and both ends drop the same
+// n - 1 legs. Two requests (one Irecv, one Isend) and the same bytes delivered.
+BOOST_AUTO_TEST_CASE(flat_exchange_single_leg_takes_the_pairwise_path) {
+    const int n = world_size();
+    if (n < 2 || (n % 2) != 0) {
+        return;
+    }
+    const int me = world_rank();
+    const int peer = me ^ 1;
+    constexpr int len = 3;
+    std::vector<int> counts(static_cast<size_t>(n), 0);
+    counts[static_cast<size_t>(peer)] = len;
+    std::vector<int> send(static_cast<size_t>(len));
+    for (int j = 0; j < len; ++j) {
+        send[static_cast<size_t>(j)] = (me * 1000) + j;
+    }
+    std::vector<int> out(static_cast<size_t>(len), -1);
+    BOOST_CHECK_EQUAL(run_round(n, wire_bits_for(n), counts, send, out), 2);
+    for (int j = 0; j < len; ++j) {
+        BOOST_CHECK_EQUAL(out[static_cast<size_t>(j)], (peer * 1000) + j);
+    }
+}
+
+// Every leg active on the pairwise arm: it posts a pair per non-zero leg rather than falling back, so
+// the transport really is the gate's choice and not the layout's. The self leg is a copy, not a pair.
+BOOST_AUTO_TEST_CASE(flat_exchange_dense_layout_on_the_pairwise_arm) {
+    const int n = world_size();
+    if (n < 2 || (n & (n - 1)) != 0) {
+        return; // off a power of two the gate resolves to 0 bits, i.e. the collective
+    }
+    const int me = world_rank();
+    const std::vector<int> counts(static_cast<size_t>(n), 1);
+    const auto displs = displs_of(counts);
+    std::vector<int> send(static_cast<size_t>(n));
+    for (int d = 0; d < n; ++d) {
+        send[static_cast<size_t>(d)] = (me * 1000) + d;
+    }
+    std::vector<int> out(static_cast<size_t>(n), -1);
+    BOOST_CHECK_EQUAL(run_round(n, wire_bits_for(n), counts, send, out), 2 * (n - 1));
+    for (int src = 0; src < n; ++src) {
+        BOOST_CHECK_EQUAL(out[static_cast<size_t>(src)], (src * 1000) + me);
+    }
+}
+
+// No active leg anywhere: nothing is posted, wait() drains nothing, and the recv buffer is left as the
+// caller sized it. A layer with no cross-rank partners takes this shape on EVERY rank at once -- the
+// symmetric layout is what makes that true -- so the pairwise arm is still the agreed one.
+BOOST_AUTO_TEST_CASE(flat_exchange_empty_layout_posts_nothing) {
+    const int n = world_size();
+    if (n < 2 || (n & (n - 1)) != 0) {
+        return;
+    }
+    const std::vector<int> counts(static_cast<size_t>(n), 0);
+    BOOST_REQUIRE_EQUAL(total_of(counts), 0);
+    const std::vector<int> send(1, 0);
+    std::vector<int> out(1, -1); // Evolution sizes an empty round to 1, not 0
+    BOOST_CHECK_EQUAL(run_round(n, wire_bits_for(n), counts, send, out), 0);
+    BOOST_CHECK_EQUAL(out[0], -1);
+}
+
+#endif // monoprop_ENABLE_MPI

--- a/cpp/tests/hybrid_comm_tests.cpp
+++ b/cpp/tests/hybrid_comm_tests.cpp
@@ -23,6 +23,8 @@
 #ifdef monoprop_ENABLE_MPI
 
 #include <atomic>
+#include <bit>
+#include <cstddef>
 #include <exception>
 #include <numeric>
 #include <thread>
@@ -480,6 +482,672 @@ BOOST_AUTO_TEST_CASE(hybrid_comm_poison_releases_waiters) {
         for (int u = 1; u < S; ++u) {
             BOOST_REQUIRE(errs[static_cast<size_t>(u)] != nullptr);
             BOOST_CHECK_THROW(std::rethrow_exception(errs[static_cast<size_t>(u)]), monoprop::mpi::ShmCommPoisoned);
+        }
+    }
+}
+
+// The pairing is derived independently on both ends, so it must be an involution: whoever I send to
+// sends back to me. A plan on which it fails deadlocks rather than mis-delivers, and no transport case
+// below can distinguish the two.
+BOOST_AUTO_TEST_CASE(hybrid_comm_sparse_plan_peer_is_an_involution) {
+    for (const int shift : {0, 1, 2, 3, 5, 8, 13, 255}) {
+        const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = shift};
+        BOOST_REQUIRE(!plan.dense());
+        BOOST_REQUIRE_EQUAL(plan.count(256), 1);
+        for (int me = 0; me < 256; ++me) {
+            const int peer = plan.peer(me, 0);
+            BOOST_REQUIRE_EQUAL(plan.peer(peer, 0), me);
+            BOOST_REQUIRE(plan.contains(me, peer));
+            BOOST_REQUIRE(plan.contains(peer, me));
+            BOOST_REQUIRE(!plan.contains(me, peer ^ 1)); // the peer set is a singleton
+        }
+    }
+    const monoprop::mpi::PeerPlan dense_plan{};
+    BOOST_REQUIRE(dense_plan.dense());
+    BOOST_REQUIRE_EQUAL(dense_plan.count(7), 7);
+    for (int k = 0; k < 7; ++k) {
+        BOOST_REQUIRE_EQUAL(dense_plan.peer(3, k), k); // dense ignores `me`: every rank is a peer
+        BOOST_REQUIRE(dense_plan.contains(3, k));
+    }
+}
+
+// A sparse PeerPlan replaces the collectives with point-to-point over the one peer the plan names, so
+// the two failure modes it can have are DROPPED data and a HANG -- neither of which a dense-path test
+// can see. Every rank derives the same pairing from the same shift, and a block whose destination is
+// not the peer must be empty: send only to the plan's peer and check the delivery is exactly that.
+BOOST_AUTO_TEST_CASE(hybrid_comm_sparse_plan_delivers_only_to_its_peers) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return; // the XOR pairing needs a power-of-two rank count
+    }
+    for (const int S : {1, 2, 3}) {
+        const int P = R * S;
+        for (int shift = 0; shift < R; ++shift) {
+            const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = shift};
+            const int peer = plan.peer(world_rank(), 0);
+            BOOST_REQUIRE_EQUAL(plan.count(R), 1); // sparse is always pairwise
+            std::vector<std::vector<std::vector<int>>> recv(static_cast<size_t>(S));
+            auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+                Comm c = Comm::make_hybrid(&hyb, u);
+                const int g = monoprop::mpi::rank(c);
+                std::vector<std::vector<int>> send(static_cast<size_t>(P));
+                for (int t = 0; t < S; ++t) {
+                    auto &blk = send[static_cast<size_t>(peer * S + t)];
+                    for (int j = 0; j <= t; ++j) {
+                        blk.push_back(g * 1000 + t * 10 + j);
+                    }
+                }
+                auto h = monoprop::mpi::begin_alltoallv(send,
+                                                        c,
+                                                        /*skip_self=*/false,
+                                                        /*known_recv_counts=*/nullptr,
+                                                        plan);
+                std::vector<std::vector<int>> out;
+                h.wait_into(out);
+                recv[static_cast<size_t>(u)] = out;
+            });
+            for (const auto &e : errs) {
+                BOOST_CHECK(e == nullptr);
+            }
+            // XOR is an involution, so whoever I send to sends to me: my sources are exactly `peer`'s
+            // partitions, and the block from (peer, su) to my partition t has t+1 entries.
+            for (int t = 0; t < S; ++t) {
+                const auto &out = recv[static_cast<size_t>(t)];
+                BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), P);
+                for (int src = 0; src < P; ++src) {
+                    const auto &blk = out[static_cast<size_t>(src)];
+                    if (src / S != peer) {
+                        BOOST_CHECK(blk.empty()); // a non-peer must not appear at all
+                        continue;
+                    }
+                    BOOST_REQUIRE_EQUAL(static_cast<int>(blk.size()), t + 1);
+                    for (int j = 0; j <= t; ++j) {
+                        BOOST_CHECK_EQUAL(blk[static_cast<size_t>(j)], src * 1000 + t * 10 + j);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Same contract on the S == 1 world, which takes the pure-MPI branch (MPI_Ialltoallv vs Isend/Irecv)
+// rather than HybridComm's staged one, and on the KNOWN-recv-counts path the response round uses.
+BOOST_AUTO_TEST_CASE(hybrid_comm_sparse_plan_on_the_plain_mpi_path) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return;
+    }
+    Comm c{MPI_COMM_WORLD};
+    for (int shift = 0; shift < R; ++shift) {
+        const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = shift};
+        const int peer = plan.peer(world_rank(), 0);
+        std::vector<std::vector<int>> send(static_cast<size_t>(R));
+        for (int j = 0; j < 4; ++j) {
+            send[static_cast<size_t>(peer)].push_back(world_rank() * 1000 + j);
+        }
+        // Unknown recv layout: the counts round is point-to-point too.
+        std::vector<std::vector<int>> out;
+        monoprop::mpi::begin_alltoallv(send, c, false, nullptr, plan).wait_into(out);
+        BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), R);
+        for (int src = 0; src < R; ++src) {
+            if (src != peer) {
+                BOOST_CHECK(out[static_cast<size_t>(src)].empty());
+                continue;
+            }
+            BOOST_REQUIRE_EQUAL(static_cast<int>(out[static_cast<size_t>(src)].size()), 4);
+            for (int j = 0; j < 4; ++j) {
+                BOOST_CHECK_EQUAL(out[static_cast<size_t>(src)][static_cast<size_t>(j)], src * 1000 + j);
+            }
+        }
+        // Known recv layout (the response round): counts are the transpose, so peer-only again.
+        std::vector<int> known(static_cast<size_t>(R), 0);
+        known[static_cast<size_t>(peer)] = 4;
+        std::vector<std::vector<int>> out2;
+        monoprop::mpi::begin_alltoallv(send, c, false, &known, plan).wait_into(out2);
+        BOOST_REQUIRE_EQUAL(static_cast<int>(out2.size()), R);
+        BOOST_CHECK(out2[static_cast<size_t>(peer)] == out[static_cast<size_t>(peer)]);
+    }
+}
+
+// known_recv_counts is CALLER-supplied, so it can carry a count for a rank the plan does not name --
+// the response round's transpose is only as masked as whatever produced it. No receive is ever posted
+// for a non-peer, so an unmasked count sizes recv_buffer for bytes nothing writes and wait_into would
+// hand that slot to the caller as data. Both the plain-MPI and the staged HybridComm path must drop it.
+BOOST_AUTO_TEST_CASE(hybrid_comm_known_recv_counts_are_masked_through_the_plan) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return;
+    }
+    constexpr int kReal = 4;
+    constexpr int kBogus = 7; // what a stale or unmasked transpose would claim a non-peer is sending
+    for (int shift = 0; shift < R; ++shift) {
+        const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = shift};
+        const int peer = plan.peer(world_rank(), 0);
+        const int bad = (peer + 1) % R; // the peer set is exactly {peer}
+        BOOST_REQUIRE(bad != peer);
+
+        // S == 1: the plain-MPI Isend/Irecv branch of begin_alltoallv.
+        {
+            Comm c{MPI_COMM_WORLD};
+            std::vector<std::vector<int>> send(static_cast<size_t>(R));
+            for (int j = 0; j < kReal; ++j) {
+                send[static_cast<size_t>(peer)].push_back(world_rank() * 1000 + j);
+            }
+            std::vector<int> known(static_cast<size_t>(R), 0);
+            known[static_cast<size_t>(peer)] = kReal;
+            known[static_cast<size_t>(bad)] = kBogus;
+            std::vector<std::vector<int>> out;
+            monoprop::mpi::begin_alltoallv(send, c, false, &known, plan).wait_into(out);
+            BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), R);
+            BOOST_CHECK(out[static_cast<size_t>(bad)].empty()); // unmasked, this holds kBogus elements
+            BOOST_REQUIRE_EQUAL(static_cast<int>(out[static_cast<size_t>(peer)].size()), kReal);
+            for (int j = 0; j < kReal; ++j) {
+                BOOST_CHECK_EQUAL(out[static_cast<size_t>(peer)][static_cast<size_t>(j)], peer * 1000 + j);
+            }
+        }
+
+        // S == 2: the same array through HybridComm's staged alltoallv.
+        constexpr int S = 2;
+        const int P = R * S;
+        std::vector<std::vector<std::vector<int>>> recv(static_cast<size_t>(S));
+        auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+            Comm c = Comm::make_hybrid(&hyb, u);
+            const int g = monoprop::mpi::rank(c);
+            std::vector<std::vector<int>> send(static_cast<size_t>(P));
+            std::vector<int> known(static_cast<size_t>(P), 0);
+            for (int t = 0; t < S; ++t) {
+                for (int j = 0; j < kReal; ++j) {
+                    send[static_cast<size_t>((peer * S) + t)].push_back((g * 1000) + j);
+                }
+                known[static_cast<size_t>((peer * S) + t)] = kReal;
+                known[static_cast<size_t>((bad * S) + t)] = kBogus;
+            }
+            std::vector<std::vector<int>> out;
+            monoprop::mpi::begin_alltoallv(send, c, false, &known, plan).wait_into(out);
+            recv[static_cast<size_t>(u)] = out;
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        for (int t = 0; t < S; ++t) {
+            const auto &out = recv[static_cast<size_t>(t)];
+            BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), P);
+            for (int su = 0; su < S; ++su) {
+                BOOST_CHECK(out[static_cast<size_t>((bad * S) + su)].empty());
+                const auto &blk = out[static_cast<size_t>((peer * S) + su)];
+                BOOST_REQUIRE_EQUAL(static_cast<int>(blk.size()), kReal);
+                for (int j = 0; j < kReal; ++j) {
+                    BOOST_CHECK_EQUAL(blk[static_cast<size_t>(j)], (((peer * S) + su) * 1000) + j);
+                }
+            }
+        }
+    }
+}
+
+namespace {
+
+// Varies along BOTH ends and hits 0, so a block landing on the wrong peer or the wrong partition
+// changes a length, not just a value.
+auto sparse_count(int src, int dst) -> int {
+    return ((src * 3) + (dst * 5)) % 4;
+}
+auto sparse_tag(int src, int dst, int j) -> int {
+    return (((src * 128) + dst) * 1000) + j;
+}
+
+} // namespace
+
+// A zero-count leg is where a send/recv posting asymmetry deadlocks rather than mis-delivers: both ends
+// must skip on the SAME value. Nothing above ever sends an empty block over a real message, so force
+// one -- the lower-numbered end of every pair sends nothing while its peer sends four.
+BOOST_AUTO_TEST_CASE(hybrid_comm_sparse_plan_with_an_empty_leg) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return;
+    }
+    const int me = world_rank();
+    constexpr int kLen = 4;
+    for (int shift = 1; shift < R; ++shift) { // shift 0 is the self peer, covered separately
+        const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = shift};
+        const int peer = plan.peer(me, 0);
+        BOOST_REQUIRE(peer != me);
+        const int my_len = me < peer ? 0 : kLen; // exactly one end of the pair is silent
+        const int peer_len = peer < me ? 0 : kLen;
+
+        {
+            Comm c{MPI_COMM_WORLD};
+            std::vector<std::vector<int>> send(static_cast<size_t>(R));
+            for (int j = 0; j < my_len; ++j) {
+                send[static_cast<size_t>(peer)].push_back(sparse_tag(me, peer, j));
+            }
+            std::vector<std::vector<int>> out;
+            monoprop::mpi::begin_alltoallv(send, c, false, nullptr, plan).wait_into(out);
+            BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), R);
+            BOOST_REQUIRE_EQUAL(static_cast<int>(out[static_cast<size_t>(peer)].size()), peer_len);
+            for (int j = 0; j < peer_len; ++j) {
+                BOOST_CHECK_EQUAL(out[static_cast<size_t>(peer)][static_cast<size_t>(j)], sparse_tag(peer, me, j));
+            }
+        }
+
+        for (const int S : {1, 2}) {
+            const int P = R * S;
+            std::vector<std::vector<std::vector<int>>> recv(static_cast<size_t>(S));
+            auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+                Comm c = Comm::make_hybrid(&hyb, u);
+                const int g = monoprop::mpi::rank(c);
+                std::vector<std::vector<int>> send(static_cast<size_t>(P));
+                for (int t = 0; t < S; ++t) {
+                    const int d = (peer * S) + t;
+                    for (int j = 0; j < my_len; ++j) {
+                        send[static_cast<size_t>(d)].push_back(sparse_tag(g, d, j));
+                    }
+                }
+                std::vector<std::vector<int>> out;
+                monoprop::mpi::begin_alltoallv(send, c, false, nullptr, plan).wait_into(out);
+                recv[static_cast<size_t>(u)] = out;
+            });
+            for (const auto &e : errs) {
+                BOOST_CHECK(e == nullptr);
+            }
+            for (int t = 0; t < S; ++t) {
+                const int g = (me * S) + t;
+                const auto &out = recv[static_cast<size_t>(t)];
+                BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), P);
+                for (int su = 0; su < S; ++su) {
+                    const auto &blk = out[static_cast<size_t>((peer * S) + su)];
+                    BOOST_REQUIRE_EQUAL(static_cast<int>(blk.size()), peer_len);
+                    for (int j = 0; j < peer_len; ++j) {
+                        BOOST_CHECK_EQUAL(blk[static_cast<size_t>(j)], sparse_tag((peer * S) + su, g, j));
+                    }
+                }
+            }
+        }
+    }
+}
+
+// shift == 0 makes every rank its own and only peer, so the sparse path's self slot is the whole
+// exchange -- and skip_self then removes the one leg that would have moved anything for a partition.
+// The remaining S-1 in-rank legs must still arrive.
+BOOST_AUTO_TEST_CASE(hybrid_comm_sparse_plan_skip_self_at_shift_zero) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return;
+    }
+    const int me = world_rank();
+    const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = 0};
+    BOOST_REQUIRE_EQUAL(plan.peer(me, 0), me);
+
+    {
+        Comm c{MPI_COMM_WORLD}; // the self peer is the ONLY peer, and skip_self drops it
+        std::vector<std::vector<int>> send(static_cast<size_t>(R));
+        for (int j = 0; j < 5; ++j) {
+            send[static_cast<size_t>(me)].push_back(sparse_tag(me, me, j));
+        }
+        std::vector<std::vector<int>> out;
+        monoprop::mpi::begin_alltoallv(send, c, /*skip_self=*/true, nullptr, plan).wait_into(out);
+        BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), R);
+        for (const auto &blk : out) {
+            BOOST_CHECK(blk.empty());
+        }
+    }
+
+    for (const int S : {2, 3}) {
+        const int P = R * S;
+        std::vector<std::vector<std::vector<int>>> recv(static_cast<size_t>(S));
+        auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+            Comm c = Comm::make_hybrid(&hyb, u);
+            const int g = monoprop::mpi::rank(c);
+            std::vector<std::vector<int>> send(static_cast<size_t>(P));
+            for (int t = 0; t < S; ++t) {
+                const int d = (me * S) + t;
+                for (int j = 0; j <= t; ++j) {
+                    send[static_cast<size_t>(d)].push_back(sparse_tag(g, d, j));
+                }
+            }
+            std::vector<std::vector<int>> out;
+            monoprop::mpi::begin_alltoallv(send, c, /*skip_self=*/true, nullptr, plan).wait_into(out);
+            recv[static_cast<size_t>(u)] = out;
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        for (int t = 0; t < S; ++t) {
+            const int g = (me * S) + t;
+            const auto &out = recv[static_cast<size_t>(t)];
+            BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), P);
+            for (int src = 0; src < P; ++src) {
+                const bool in_rank = (src / S) == me;
+                const int want = (in_rank && src != g) ? t + 1 : 0; // own slot dropped by skip_self
+                BOOST_REQUIRE_EQUAL(static_cast<int>(out[static_cast<size_t>(src)].size()), want);
+                for (int j = 0; j < want; ++j) {
+                    BOOST_CHECK_EQUAL(out[static_cast<size_t>(src)][static_cast<size_t>(j)], sparse_tag(src, g, j));
+                }
+            }
+        }
+    }
+}
+
+// Consecutive gate exchanges post their rounds on ONE communicator under kFlatPayloadTag, and the
+// non-overtaking argument in Pairwise.h is what says a later receive cannot match an earlier send.
+// Two back-to-back sparse rounds, the second on the transpose of the first's counts, assert it.
+BOOST_AUTO_TEST_CASE(hybrid_comm_sparse_plan_back_to_back_rounds) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return;
+    }
+    const int me = world_rank();
+    Comm c{MPI_COMM_WORLD};
+    for (int shift = 0; shift < R; ++shift) {
+        const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = shift};
+        const int peer = plan.peer(me, 0);
+        const int len = 3 + (me % 2); // asymmetric, so a swapped round is a length mismatch
+
+        std::vector<std::vector<int>> q(static_cast<size_t>(R));
+        for (int j = 0; j < len; ++j) {
+            q[static_cast<size_t>(peer)].push_back(sparse_tag(me, peer, j));
+        }
+        std::vector<std::vector<int>> q_out;
+        monoprop::mpi::begin_alltoallv(q, c, false, nullptr, plan).wait_into(q_out);
+
+        // Round 2 immediately, same comm and tag, sized from round 1's transpose -- the response shape.
+        std::vector<int> known(static_cast<size_t>(R), 0);
+        known[static_cast<size_t>(peer)] = len;
+        std::vector<std::vector<int>> r(static_cast<size_t>(R));
+        const int back = static_cast<int>(q_out[static_cast<size_t>(peer)].size());
+        for (int j = 0; j < back; ++j) {
+            r[static_cast<size_t>(peer)].push_back(q_out[static_cast<size_t>(peer)][static_cast<size_t>(j)] + 7);
+        }
+        std::vector<std::vector<int>> r_out;
+        monoprop::mpi::begin_alltoallv(r, c, false, &known, plan).wait_into(r_out);
+
+        BOOST_REQUIRE_EQUAL(back, 3 + (peer % 2));
+        BOOST_REQUIRE_EQUAL(static_cast<int>(r_out[static_cast<size_t>(peer)].size()), len);
+        for (int j = 0; j < len; ++j) {
+            BOOST_CHECK_EQUAL(r_out[static_cast<size_t>(peer)][static_cast<size_t>(j)], sparse_tag(me, peer, j) + 7);
+        }
+        for (int src = 0; src < R; ++src) {
+            if (src != peer) {
+                BOOST_CHECK(r_out[static_cast<size_t>(src)].empty());
+            }
+        }
+    }
+}
+
+namespace {
+
+// One fused-resolve round under `plan`: flattens send_blocks, runs the verb, and re-splits the payload
+// by global source using the resolved counts, so a case compares delivered BLOCKS rather than offsets.
+auto resolve_round(HybridComm &hyb,
+                   int u,
+                   int P,
+                   const std::vector<std::vector<int>> &send_blocks,
+                   monoprop::mpi::PeerPlan plan) -> std::vector<std::vector<int>> {
+    std::vector<int> send;
+    std::vector<int> sc(static_cast<size_t>(P)), sd(static_cast<size_t>(P));
+    for (int d = 0; d < P; ++d) {
+        const auto &blk = send_blocks[static_cast<size_t>(d)];
+        sc[static_cast<size_t>(d)] = static_cast<int>(blk.size());
+        sd[static_cast<size_t>(d)] = static_cast<int>(send.size());
+        send.insert(send.end(), blk.begin(), blk.end());
+    }
+    std::vector<int> recv;
+    std::vector<int> rc(static_cast<size_t>(P)), rd(static_cast<size_t>(P));
+    hyb.alltoallv_resolve<int>(u,
+                               {.send = send.data(),
+                                .send_counts = sc.data(),
+                                .send_displs = sd.data(),
+                                .recv = recv,
+                                .recv_counts = rc.data(),
+                                .recv_displs = rd.data()},
+                               monoprop::mpi::datatype<int>::get(),
+                               plan);
+    std::vector<std::vector<int>> out(static_cast<size_t>(P));
+    for (int src = 0; src < P; ++src) {
+        const auto off = static_cast<size_t>(rd[static_cast<size_t>(src)]);
+        const auto n = static_cast<size_t>(rc[static_cast<size_t>(src)]);
+        out[static_cast<size_t>(src)].assign(recv.begin() + static_cast<std::ptrdiff_t>(off),
+                                             recv.begin() + static_cast<std::ptrdiff_t>(off + n));
+    }
+    return out;
+}
+
+// Every leg INTO an odd rank is empty, so a multi-peer plan always has a peer whose payload legs are
+// skipped entirely while its S*S-int count block still travels. Both ends read the same function of
+// (src, dst), which is what keeps the skip symmetric.
+auto muted_count(int src, int dst, int S) -> int {
+    return (dst / S) % 2 == 1 ? 0 : sparse_count(src, dst);
+}
+
+} // namespace
+
+// The fused resolve POSTS its count round in B1→B2 and drains it in B3→B4, with every partition's
+// pack_send_ running underneath. Only the sparse arm splits -- plan.dense() is a blocking MPI_Alltoall
+// -- so drive the SAME peer-masked layout through both arms and require the delivered blocks to agree
+// element for element. A dropped or torn count block changes a length here, not just a value.
+BOOST_AUTO_TEST_CASE(hybrid_comm_resolve_split_count_round_matches_the_dense_arm) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return; // the XOR pairing needs a power-of-two rank count
+    }
+    const int me = world_rank();
+    int cases = 0;
+    {
+        constexpr int f = 1; // a sparse plan is fanout 1 by construction; f > 1 is no longer expressible
+        for (int shift = 0; shift < R; ++shift) {
+            const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = shift};
+            BOOST_REQUIRE_EQUAL(plan.count(R), f);
+            ++cases;
+            for (const int S : {1, 2, 3}) {
+                const int P = R * S;
+                // Peer-masked, so the dense plan carries the identical bytes: its non-peer blocks are
+                // empty rather than absent, and a dense count of zero and a sparse absence must agree.
+                const auto fill = [&](int g) {
+                    std::vector<std::vector<int>> send(static_cast<size_t>(P));
+                    for (int k = 0; k < f; ++k) {
+                        const int b = plan.peer(me, k);
+                        for (int t = 0; t < S; ++t) {
+                            const int d = (b * S) + t;
+                            for (int j = 0; j < muted_count(g, d, S); ++j) {
+                                send[static_cast<size_t>(d)].push_back(sparse_tag(g, d, j));
+                            }
+                        }
+                    }
+                    return send;
+                };
+                std::vector<std::vector<std::vector<int>>> dense(static_cast<size_t>(S));
+                std::vector<std::vector<std::vector<int>>> sparse(static_cast<size_t>(S));
+                auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+                    const int g = (me * S) + u;
+                    dense[static_cast<size_t>(u)] = resolve_round(hyb, u, P, fill(g), {});
+                    sparse[static_cast<size_t>(u)] = resolve_round(hyb, u, P, fill(g), plan);
+                });
+                for (const auto &e : errs) {
+                    BOOST_CHECK(e == nullptr);
+                }
+                for (int t = 0; t < S; ++t) {
+                    const int g = (me * S) + t;
+                    const auto &got = sparse[static_cast<size_t>(t)];
+                    const auto &want_dense = dense[static_cast<size_t>(t)];
+                    BOOST_REQUIRE_EQUAL(static_cast<int>(got.size()), P);
+                    BOOST_REQUIRE_EQUAL(static_cast<int>(want_dense.size()), P);
+                    for (int src = 0; src < P; ++src) {
+                        const int want = plan.contains(me, src / S) ? muted_count(src, g, S) : 0;
+                        const auto &blk = got[static_cast<size_t>(src)];
+                        BOOST_REQUIRE_EQUAL(static_cast<int>(blk.size()), want);
+                        BOOST_REQUIRE_EQUAL(static_cast<int>(want_dense[static_cast<size_t>(src)].size()), want);
+                        for (int j = 0; j < want; ++j) {
+                            BOOST_CHECK_EQUAL(blk[static_cast<size_t>(j)], sparse_tag(src, g, j));
+                            BOOST_CHECK_EQUAL(blk[static_cast<size_t>(j)],
+                                              want_dense[static_cast<size_t>(src)][static_cast<size_t>(j)]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    BOOST_TEST(cases > 0); // at R < 2 the case is a no-op and must not read as coverage
+}
+
+// shift == 0 at full bits makes this rank its own and only peer, so the count round posts NOTHING:
+// sparse_pairwise memcpys the S*S-int block in place and the B3→B4 wait must be a no-op rather than a
+// wait on stale requests. The S^2 in-rank payload legs still have to arrive.
+BOOST_AUTO_TEST_CASE(hybrid_comm_resolve_split_count_round_self_peer_only) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return;
+    }
+    const int me = world_rank();
+    const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = 0};
+    BOOST_REQUIRE_EQUAL(plan.peer(me, 0), me);
+    for (const int S : {1, 2, 3}) {
+        const int P = R * S;
+        std::vector<std::vector<std::vector<int>>> recv(static_cast<size_t>(S));
+        auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+            const int g = (me * S) + u;
+            std::vector<std::vector<int>> send(static_cast<size_t>(P));
+            for (int t = 0; t < S; ++t) {
+                const int d = (me * S) + t;
+                for (int j = 0; j <= t; ++j) {
+                    send[static_cast<size_t>(d)].push_back(sparse_tag(g, d, j));
+                }
+            }
+            recv[static_cast<size_t>(u)] = resolve_round(hyb, u, P, send, plan);
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        for (int t = 0; t < S; ++t) {
+            const int g = (me * S) + t;
+            const auto &out = recv[static_cast<size_t>(t)];
+            BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), P);
+            for (int src = 0; src < P; ++src) {
+                const int want = (src / S) == me ? t + 1 : 0; // block (su -> t) has t+1 entries
+                const auto &blk = out[static_cast<size_t>(src)];
+                BOOST_REQUIRE_EQUAL(static_cast<int>(blk.size()), want);
+                for (int j = 0; j < want; ++j) {
+                    BOOST_CHECK_EQUAL(blk[static_cast<size_t>(j)], sparse_tag(src, g, j));
+                }
+            }
+        }
+    }
+}
+
+// A peer with nothing to send is where the split can hang: pack_send_ copies zero bytes in B2→B3 while
+// the count round is still live, and the payload round posts no leg for it at all. Back-to-back rounds,
+// the second silent, so the second also runs over the first's staging high-water bytes.
+BOOST_AUTO_TEST_CASE(hybrid_comm_resolve_split_count_round_zero_count_peer) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return;
+    }
+    const int me = world_rank();
+    for (int shift = 1; shift < R; ++shift) { // shift 0 is the self peer, covered above
+        const monoprop::mpi::PeerPlan plan{.sparse = true, .shift = shift};
+        const int peer = plan.peer(me, 0);
+        BOOST_REQUIRE(peer != me);
+        const int my_len = me < peer ? 0 : 4; // exactly one end of the pair is silent
+        const int peer_len = peer < me ? 0 : 4;
+        for (const int S : {1, 2}) {
+            const int P = R * S;
+            std::vector<std::vector<std::vector<int>>> loud(static_cast<size_t>(S));
+            std::vector<std::vector<std::vector<int>>> quiet(static_cast<size_t>(S));
+            auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+                const int g = (me * S) + u;
+                std::vector<std::vector<int>> send(static_cast<size_t>(P));
+                for (int t = 0; t < S; ++t) {
+                    const int d = (peer * S) + t;
+                    for (int j = 0; j < my_len; ++j) {
+                        send[static_cast<size_t>(d)].push_back(sparse_tag(g, d, j));
+                    }
+                }
+                loud[static_cast<size_t>(u)] = resolve_round(hyb, u, P, send, plan);
+                quiet[static_cast<size_t>(u)] =
+                    resolve_round(hyb, u, P, std::vector<std::vector<int>>(static_cast<size_t>(P)), plan);
+            });
+            for (const auto &e : errs) {
+                BOOST_CHECK(e == nullptr);
+            }
+            for (int t = 0; t < S; ++t) {
+                const int g = (me * S) + t;
+                const auto &out = loud[static_cast<size_t>(t)];
+                BOOST_REQUIRE_EQUAL(static_cast<int>(out.size()), P);
+                for (int su = 0; su < S; ++su) {
+                    const auto &blk = out[static_cast<size_t>((peer * S) + su)];
+                    BOOST_REQUIRE_EQUAL(static_cast<int>(blk.size()), peer_len);
+                    for (int j = 0; j < peer_len; ++j) {
+                        BOOST_CHECK_EQUAL(blk[static_cast<size_t>(j)], sparse_tag((peer * S) + su, g, j));
+                    }
+                }
+                // The all-silent round: every resolved count is zero, so a stale staged byte cannot hide.
+                for (const auto &blk : quiet[static_cast<size_t>(t)]) {
+                    BOOST_CHECK(blk.empty());
+                }
+            }
+        }
+    }
+}
+
+// derived_wire_plan_ is what lets alltoallv narrow its own wire when the caller cannot: only partition 0
+// reaches MPI, and ITS row may be the empty one while a sibling partition holds the rank's only traffic.
+// Reading the peer set off partition 0's row alone resolves to the SELF peer, whose legs are all zero --
+// every block is then dropped with no hang to show for it. So this case puts the traffic where partition
+// 0 cannot see it, and checks the payload arrives carrying its source's global id.
+//
+// alltoallv's derive_wire_bits has no library caller today, so this is its only exercise.
+BOOST_AUTO_TEST_CASE(hybrid_comm_derived_wire_plan_reads_every_partitions_row) {
+    const int R = world_size();
+    if (R < 2 || (R & (R - 1)) != 0) {
+        return; // the XOR pairing needs a power-of-two rank count
+    }
+    const int bits = std::countr_zero(static_cast<unsigned>(R));
+    const int me = world_rank();
+    const int peer = me ^ 1; // shift 1, so every rank derives the same pairing
+    constexpr int kLen = 5;
+
+    for (const int S : {2, 4}) {
+        const int P = R * S;
+        const int carrier = S - 1; // never partition 0 -- that is the whole point of the case
+        std::vector<std::vector<int>> got(static_cast<size_t>(S));
+        auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+            const int g = (me * S) + u;
+            std::vector<int> counts(static_cast<size_t>(P), 0);
+            const std::vector<int> displs(static_cast<size_t>(P), 0);
+            std::vector<int> send;
+            if (u == carrier) {
+                counts[static_cast<size_t>((peer * S) + carrier)] = kLen;
+                for (int j = 0; j < kLen; ++j) {
+                    send.push_back((g * 1000) + j);
+                }
+            }
+            // Symmetric layout: my peer's carrier partition sends me exactly what I send it, which is
+            // what derive_wire_bits requires and what lets the recv rows name the peer set. One block, so
+            // both displacements are zero.
+            std::vector<int> recv(static_cast<size_t>(u == carrier ? kLen : 0), -1);
+            const monoprop::mpi::AlltoallvArgs args{.send = reinterpret_cast<const std::byte *>(send.data()),
+                                                    .send_counts = counts.data(),
+                                                    .send_displs = displs.data(),
+                                                    .recv = reinterpret_cast<std::byte *>(recv.data()),
+                                                    .recv_counts = counts.data(),
+                                                    .recv_displs = displs.data(),
+                                                    .elem = sizeof(int)};
+            hyb.alltoallv(u, args, MPI_INT, monoprop::mpi::PeerPlan{}, /*derive_wire_bits=*/bits);
+            got[static_cast<size_t>(u)] = recv;
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        for (int u = 0; u < S; ++u) {
+            if (u != carrier) {
+                BOOST_CHECK(got[static_cast<size_t>(u)].empty());
+                continue;
+            }
+            // The values name their sender, so this fails on a plan that named the wrong peer as well as
+            // on one that named none.
+            const int src = (peer * S) + carrier;
+            BOOST_REQUIRE_EQUAL(static_cast<int>(got[static_cast<size_t>(u)].size()), kLen);
+            for (int j = 0; j < kLen; ++j) {
+                BOOST_CHECK_EQUAL(got[static_cast<size_t>(u)][static_cast<size_t>(j)], (src * 1000) + j);
+            }
         }
     }
 }

--- a/cpp/tests/routing_tests.cpp
+++ b/cpp/tests/routing_tests.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "monoprop/algebra/AlgebraCommon.h"
+#include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
 #include "monoprop/detail/mpi/Routing.h"
 
@@ -264,6 +265,80 @@ BOOST_AUTO_TEST_CASE(routing_fanout_is_one_rank_when_partitions_are_not_a_power_
             BOOST_TEST(dest_parts.size() > 1U); // partitions keep full avalanche
         }
     }
+}
+
+// mpi::PeerPlan::window -- the slots a plan can reach, which is what lets a round address one peer
+// rank's partitions instead of the whole P = R*S world. Dense is the count == P value of the same two
+// expressions, so it is checked against the same formula rather than against a second one.
+BOOST_AUTO_TEST_CASE(routing_slot_window_is_the_peer_ranks_partition_run) {
+    for (const auto &[r, s] : {std::pair<size_t, size_t>{8, 16}, {128, 16}, {16, 1}, {1, 1}, {4, 3}}) {
+        const size_t p = r * s;
+        for (size_t me = 0; me < p; ++me) {
+            const mpi::SlotWindow dense = mpi::PeerPlan{}.window(me, r, s);
+            BOOST_REQUIRE_EQUAL(dense.base, 0U);
+            BOOST_REQUIRE_EQUAL(dense.count, p);
+            BOOST_REQUIRE(dense.contains(me));
+
+            for (size_t shift = 0; shift < r; ++shift) {
+                const mpi::PeerPlan plan{.sparse = true, .shift = static_cast<int>(shift)};
+                const mpi::SlotWindow w = plan.window(me, r, s);
+                BOOST_REQUIRE_EQUAL(w.count, s);
+                BOOST_REQUIRE_EQUAL(w.base, ((me / s) ^ shift) * s);
+                // Every slot in the run belongs to the one peer rank the plan names, and no other.
+                for (size_t k = 0; k < w.count; ++k) {
+                    const size_t slot = w.slot(mpi::WindowIndex{k});
+                    BOOST_REQUIRE(w.contains(slot));
+                    BOOST_REQUIRE_EQUAL(w.index(slot).value, k);
+                    BOOST_REQUIRE_EQUAL(slot / s, ((me / s) ^ shift));
+                    BOOST_REQUIRE(plan.contains(static_cast<int>(me / s), static_cast<int>(slot / s)));
+                }
+                BOOST_REQUIRE(!w.contains(w.stop()));
+                // Self is reachable only at shift 0; the exchange's self leg is a copy on exactly those.
+                BOOST_REQUIRE_EQUAL(w.contains(me), shift == 0);
+            }
+        }
+    }
+}
+
+// The window must be symmetric, or the two ends of one exchange size different arrays: XOR is an
+// involution, so the peer's own window points back at this rank's run.
+BOOST_AUTO_TEST_CASE(routing_slot_window_pairing_is_symmetric) {
+    constexpr size_t kRanks = 32;
+    constexpr size_t kParts = 8;
+    for (size_t me = 0; me < kRanks * kParts; me += 3) {
+        for (size_t shift = 0; shift < kRanks; ++shift) {
+            const mpi::PeerPlan plan{.sparse = true, .shift = static_cast<int>(shift)};
+            const mpi::SlotWindow mine = plan.window(me, kRanks, kParts);
+            const mpi::SlotWindow theirs = plan.window(mine.base, kRanks, kParts);
+            BOOST_REQUIRE_EQUAL(theirs.base, (me / kParts) * kParts);
+            BOOST_REQUIRE_EQUAL(theirs.count, kParts);
+        }
+    }
+}
+
+// The property a windowed round rests on: every destination the emit path can produce for one generator
+// lies inside that generator's window, whichever router the geometry resolves to.
+BOOST_AUTO_TEST_CASE(routing_every_dest_lands_inside_the_generators_window) {
+    const auto terms = random_monomials(600, 6, 0x5107500DULL);
+    const auto gens = random_monomials(20, 4, 0x1CE0FF1CEULL);
+    const std::vector<std::pair<size_t, size_t>> geometries{{8, 16}, {16, 1}, {32, 4}, {1, 14}, {4, 3}};
+    size_t checked = 0;
+    for (const auto &[r, s] : geometries) {
+        for (const bool linear : {false, true}) {
+            const auto router = Router::for_modes<kN>(r, s, linear);
+            for (const auto &g : gens) {
+                const auto shift = static_cast<int>(router.rank_shift<kN>(g));
+                const mpi::PeerPlan plan{.sparse = router.is_linear(), .shift = shift};
+                for (const auto &m : terms) {
+                    const size_t me = router.dest<kN>(m);
+                    BOOST_REQUIRE(plan.window(me, r, s).contains(router.dest<kN>(m ^ g)));
+                    ++checked;
+                }
+            }
+        }
+    }
+    BOOST_TEST_MESSAGE("window containment checks: " << checked);
+    BOOST_TEST(checked >= 100000U);
 }
 
 // Without a power-of-two rank count there is no XOR structure to exploit, and there is no partial dial

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -157,6 +157,25 @@ monomial is balanced by construction; imbalance can only come from the operator'
 being non-uniform, which is why balance is measured rather than proved — rank occupancy
 max/mean 1.001 at $R = 128$, with every rank used.
 
+That one peer is what the exchange is then allowed to spend. A gate's query round carries a
+`PeerPlan` -- the rank shift $h_d(G)$, derived once per generator where the generator is held -- and
+the transports read it rather than a rank count: one `Isend`/`Irecv` pair with the peer instead of an
+`MPI_Alltoall` on the counts and an `MPI_Alltoallv` on the payload, and a plain `memcpy` when the
+shift is zero and the peer is this rank itself. The reply round retraces the queries, and XOR is an
+involution, so it takes the same plan. Under the hybrid the larger win is not the messages but the
+*serial* sweeps: the count transpose, the two staging sizers, the recv column and the scatter are all
+$O(R S^2)$ and all run on partition 0 while the other $S - 1$ partitions park at a barrier, and
+restricting them to the reachable ranks makes them $O(S^2)$. Graph replay is narrowed the same way,
+without a plan: its count matrix is symmetric, so what a rank sends a peer is that peer's receive
+count and both ends drop the same legs on the same value.
+
+Which transport a round takes must be the same on every rank, or a rank inside a collective waits
+forever on ranks that chose point-to-point. So it is never a predicate on a rank's own traffic --
+rows vary, and any threshold on one straddles -- but a function of the resolved routing mode and the
+rank count alone, the same two things the propagator's construction-time agreement check reduces
+across the world. A wrong shift that every rank agrees on does not hang; it silently drops the blocks
+outside the peer set, and debug builds assert against exactly that.
+
 The one condition is that the per-generator shifts $\{h_d(G)\}$ span $\mathbb{F}_2^{d}$.
 If they span only $\rho < d$ dimensions, the ranks a query can reach form a coset of a
 $\rho$-dimensional subspace: only $2^{\rho}$ of the $2^{d}$ are ever used and the rest stay

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -80,6 +80,15 @@ than as a measurement of the array as it stands, which would always be 0. Across
 are summed rather than maxed: the partitions grow together within a call, so the sum is the figure a
 per-process footprint wants, and it errs high.
 
+`d_wire_staging_bytes` is not the operator's memory at all but the transport's, which is why it is
+outside the total: the in-process transports keep a payload staging buffer per direction, grown to
+the widest message the run has needed and never shrunk, plus the count and displacement tables that
+are fixed by the rank and partition counts. On a run whose widest gate came early those buffers are
+resident for the whole of it while nothing resting names them. One transport serves all the
+partitions of a rank, so it is a per-rank figure: exactly one partition reports it and a sum over
+partitions counts a rank's staging once. A pure-MPI rank reports 0, because there its payload
+buffers belong to the in-flight exchange handle and die with the gate that opened the round.
+
 ### Peak memory of large runs: pin glibc's `mmap` threshold
 
 Every gate allocates and frees a few large transient buffers: the records it stages, sends, receives

--- a/src/monoprop/bindings/binder.h
+++ b/src/monoprop/bindings/binder.h
@@ -277,6 +277,7 @@ auto bind_monomial_propagator(nb::module_ &mod) -> void {
                                              {"d_row_inline_width", b.row_inline_width},
                                              {"d_row_restrides", b.row_restrides},
                                              {"d_pool_mapped_bytes", b.pool_mapped_bytes},
+                                             {"d_wire_staging_bytes", b.wire_staging_bytes},
                                              {"d_pool_free_chunk_bytes", b.pool_free_chunk_bytes}};
     });
 

--- a/tests/test_monoprop_smoke.py
+++ b/tests/test_monoprop_smoke.py
@@ -196,6 +196,7 @@ _OPERATOR_DIAGNOSTIC_KEYS = (
     "d_row_inline_width",
     "d_row_restrides",
     "d_pool_mapped_bytes",
+    "d_wire_staging_bytes",
     "d_pool_free_chunk_bytes",
 )
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Main's hybrid comm stages and exchanges a gate's payload densely across every rank in the
partition, regardless of how many of them actually hold reachable terms for the router's geometry.
This PR narrows the exchange to point-to-point over the peers the router can reach: a `PeerPlan`
(threaded through a new `HybridStaging.h`) drives sparse `alltoallv` variants and a dedicated
`Pairwise.h` for the two-rank case, so a gate's transport cost scales with its peer count instead of
the partition size.

`HybridComm.h` is split into a ~427-line comm header and the new `HybridStaging.h` (~550 lines) that
carries payload staging; pair-exchange logic (~190 lines) stays out of scope here and is PR 7's.
`monoprop_MPI_TEST_PROCS` gains rank count 4 alongside 2 as this PR's head
commit, so CI exercises the multi-peer paths the sparse transport adds.

This is PR 3 of 7, based on `perf/stack-2-router`. It is transport only: no value, index, or
ordering change. The next PR (`perf/stack-4-term-table`) replaces main's hash index with a
persistent term table, independent of this transport change.

## Changes

**Engine**
- `cpp/monoprop/detail/mpi/Comm.h` (new, 207 lines): `WindowIndex`, `SlotWindow`, `PeerPlan`.
- `cpp/monoprop/detail/mpi/Pairwise.h` (new, 116 lines): tags, `PeerLayout`, `sparse_pairwise`.
- `cpp/monoprop/detail/mpi/HybridComm.h` (636 → 427 lines): split; `size_staging_send_`/`_recv_`
  folded into `layout_peers_`; the two `fill_recv_col_from_*` folded into `fill_recv_col(value)`.
- `cpp/monoprop/detail/mpi/HybridStaging.h` (new, 550 lines): the staging half of the split, with
  the `PeerPlan` threaded through `fill_peers`/`peers`/`zero_peer_slots_`/`derived_wire_plan`/
  `narrowing_is_lossless`, `post`/`wait`/`exchange_count_blocks`, and the sparse `exchange_payload`
  arm.
- `cpp/monoprop/detail/mpi/Exchange.h`, `Evolution.cpp`: the replay path
  (`active_leg_count`/`Ticket`/`in_flight()`/`post_flat_alltoallv(wire_bits)`).
- `cpp/monoprop/detail/mpi/MPICompat.h`/`.cpp`: `begin_alltoallv` gains a window + plan, and a
  sparse `Kind::Mpi` arm; `alltoall_counts` gains a sparse arm.
- `cpp/monoprop/detail/mpi/ShmComm.h`, `Routing.h`: small supporting additions.
- `cpp/monoprop/detail/evolution/layer_build/Engine.h`: a `plan` member, derived in `build_layer`.
- `cpp/monoprop/detail/operator/MPOperator.h`: `wire_staging_bytes` ledger field
  (`HybridComm::staging_bytes`/`ShmComm::staging_bytes`), filled only at `comm_.shm_rank == 0`
  (partition 0) to avoid double-counting.

**Tests**
- `cpp/tests/boost-test.cmake` (head commit): `monoprop_MPI_TEST_PROCS` `"2"` → `"2;4"`.
- `cpp/tests/hybrid_comm_tests.cpp` (+668 lines, 9 cases) and `flat_exchange_tests.cpp` (new, 230
  lines).
- `cpp/tests/routing_tests.cpp`: three `SlotWindow`/`PeerPlan` window cases.
- `cpp/tests/README.md`, `tests/test_monoprop_smoke.py`: `d_wire_staging_bytes` key.

**Docs**
- `docs/content/docs/features/parallelism.mdx`: point-to-point exchange and rank-uniform-gate
  paragraphs of "### Rank routing".
- `AGENTS.md`: the MPI CTest-at-2-and-4 Notes bullet.

## Measurements

Gated multiset vs origin/main c5e88c8's raw bits (PR 2's routing already moved the row layout at
`P > 1`; this transport change adds no further move but inherits the requirement). `gates.sh`
record md5 `cbbe395e5090b3f8ee442a76847bd343` (rebased onto PR 2 at `19bd012`, tip `812b1bc`).

3 interleaved reps, ratios only:

| rung | time st3/mainB | time st2/mainB (predecessor) | peak st3/mainB | peak st2/mainB (predecessor) |
| --- | ---: | ---: | ---: | ---: |
| L1-hubbard (`R=1`) | 1.005 | 0.998 | 0.881 | 0.892 |
| L1-pauli (`R=1`) | 1.028 | 1.010 | 0.854 | 0.854 |
| M2a-hubbard (`R=1`) | 0.991 | 0.990 | 0.958 | 0.957 |
| L2b-hubbard (`R=4×P=4`, 250 M terms) | 0.951 | 0.957 | 0.998 (ranks summed) | 0.994 (ranks summed) |

The first three rungs run at `R=1`, where this PR changes nothing observable — pauli's 1.028 is
noise (p = 0.25 on a rung this PR does not touch). At `R=4` (L2b), where the sparse exchange should
show its effect, this PR is stated plainly: on one node the 4-rank cell is shared memory, so the
point-to-point exchange shows **no separate time effect vs. its predecessor** (0.951 vs. 0.957 — the
~5% gain over main at L2b is PR 1's store effect, carried through, not this PR's transport). The
ranks-summed peak is 0.998 vs. main, essentially unchanged from PR 2's 0.994: at 250 M terms the
store's own gain (PR 1) is eaten by pool and coefficient slack, exactly as PR 1's body states, and
this PR's own `wire_staging_bytes` contribution (80.7 MiB) is small next to that. A time effect from
narrowing the exchange to reachable peers needs more than one node to show, which the single-node
measurements here cannot provide.

## Notes for reviewers

- **Deferred to PR 7:** the array re-basing half of this transport work is not here. It would make
  `FusedScanResult`'s arrays, the engine's `queries_r`/`src_idx_r`/
  `src_val_r`/`combined_qv_`, the probe's `goff`, the resolver's `responses`, and
  `begin_alltoallv`'s sweeps `WindowVec`-typed — and `WindowVec` is PR 7's. Without it, shortening
  those arrays with raw offsets would be exactly the unsafe re-basing `WindowVec` exists to prevent,
  so this PR takes only the transport half: `PendingAlltoallv` gains `window`, and `begin_alltoallv`
  derives it from the plan and masks the caller's flat `[P]` arrays through it. The per-slot arrays
  stay `[P]`-sized here.
- **CI:** `monoprop_MPI_TEST_PROCS` "2" → "2;4" (head commit) because at `R=2` a peer plan can only
  ever resolve one peer, so every multi-peer path in the sparse transport goes untested; cross-rank
  cases self-skip below two ranks, so the same test files still run in the serial variant. This
  roughly doubles CI's MPI ctest time.
- Risk flagged by the implementer: a malformed peer plan produces a hang, not a wrong answer. None
  observed — 351/351 ctest including `mpiexec -n 2` and `-n 4`, and `--with-mpi` pytest at
  `n=1/2/4` under both default and `splitmix` routing.
- Ledger: `wire_staging_bytes` is new (see Changes); `indexing_bytes` is untouched by this PR.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable (n/a — the repository has no `CHANGELOG`)

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (claude-sonnet-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
