### PR TITLE
perf(evolution): ⚡ join a gate's partners in one symmetric round and a half

### DIFF
--- a/cpp/include/monoprop/MonomialPropagator.h
+++ b/cpp/include/monoprop/MonomialPropagator.h
@@ -42,6 +42,7 @@
 #include "monoprop/algebra/PauliAlgebra.h"
 #include "monoprop/core/Monomial.h"
 #include "monoprop/detail/evolution/CosineRecompute.h"
+#include "monoprop/detail/evolution/layer_build/GateScratch.h"
 #include "monoprop/detail/mpi/MPICompat.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
 #include "monoprop/detail/operator/MPOperator.h"
@@ -137,10 +138,12 @@ public:
         if (partition_group_) {
             return partitioned_operator_memory_usage_();
         }
-        // The stamp array is a member of THIS class, not of the operator, so the operator-side estimate
-        // leaves matched_scratch_bytes at 0 and only this level can fill it in.
+        // The gate scratch is a member of THIS class, not of the operator, so the operator-side estimate
+        // leaves gate_scratch_bytes at 0 and only this level can fill it in.
         auto breakdown = detail::estimate_memory_usage(mp_op_);
-        breakdown.matched_scratch_bytes = matched_scratch_.memory_bytes();
+        breakdown.gate_scratch_bytes = gate_scratch_.memory_bytes();
+        // Also propagator-owned, and stamped by the engine during the last call rather than measured now.
+        breakdown.gate_buffers_hwm_bytes = gate_scratch_.buffers_hwm_bytes;
         // The transport is shared by all S partitions of this rank, so only partition 0 reports it and
         // the facade's sum over partitions counts the rank's staging exactly once.
         breakdown.wire_staging_bytes = comm_.shm_rank == 0 ? mpi::staging_bytes(comm_) : 0uz;
@@ -315,7 +318,7 @@ protected:
     detail::MPOperator<NumModes> mp_op_;
     MPGraph graph_;
     // Per-gate layer-build scratch, reused across gates; carries no state between them.
-    detail::MatchedEpochSet matched_scratch_;
+    detail::GateScratch<NumModes> gate_scratch_;
 
     // A perf hint, never a correctness constraint: overflow spills losslessly. Sized to the cutoff's
     // structural position bound when it has one.
@@ -471,6 +474,16 @@ private:
     // Do this call's generator shifts span log2(R)? If not, ranks receive nothing (routing::gf2_rank).
     // Not beside check_routing_agreement: at construction the gate list does not exist yet.
     auto report_routing_coverage_(const std::vector<VecZ> &majoranas) -> void;
+
+    // One COMMPROF line for the call's gate-exchange volume, under monoprop_COMMPROF. Report-only.
+    auto report_comm_profile_() const -> void;
+
+    // Whether a tracked term may fail the structural cutoff during this call: upper_atol can rescue one,
+    // or the initial operator (never filtered) already holds one somewhere in the world. The gate
+    // exchange's send predicate reads it (Engine.h); it is agreed across the comm by run_gate_loop_ once
+    // per call, because a disagreement would drop records one side expects.
+    auto any_local_term_fails_cutoff_() const -> bool;
+    bool over_cutoff_possible_ = false;
 
     auto propagate_one_(const VecZ &gen_vec,
                         std::optional<size_t> only_rotate_len_k,

--- a/cpp/monoprop/algebra/Algebra.h
+++ b/cpp/monoprop/algebra/Algebra.h
@@ -18,6 +18,7 @@
 // fold, a term's rotation sign and emitted sine phase, the coefficient codec, and the diagonal
 // initial-state score. The arithmetic behind each answer lives in MajoranaAlgebra.h / PauliAlgebra.h.
 
+#include <cassert>
 #include <complex>
 #include <concepts>
 #include <cstddef>
@@ -59,6 +60,23 @@ struct MajoranaAlgebra {
         return rotation_sign * hermitian_phase(mono_pop, gen_pop, overlap);
     }
 
+    //! Whether rotation_sign_positions() is available for this generator. Always, for this algebra.
+    static auto sign_from_positions_ok(const GenContext & /*ctx*/) -> bool { return true; }
+    /*! @brief rotation_sign() from M's ascending positions instead of its bitset.
+     *
+     *  parity_and(W) is the parity of |M n W|, i.e. the XOR of W's bits AT those positions, so a packed
+     *  row is signed without being expanded.
+     */
+    template <typename PosT>
+    [[gnu::always_inline]] static auto rotation_sign_positions(const GenContext &ctx, const PosT *pos, size_t count)
+        -> int {
+        bool parity = false;
+        for (size_t j = 0; j < count; ++j) {
+            parity ^= ctx.interleave_mask.test(static_cast<size_t>(pos[j]));
+        }
+        return parity ? -1 : 1;
+    }
+
     // Anticommutation fold columns = G itself; odd |G| needs the per-row parity(|M|) correction.
     static auto fold_generator(const Monomial<NumModes> &gen) -> Monomial<NumModes> { return gen; }
     static auto fold_needs_odd_correction(const Monomial<NumModes> &gen) -> bool { return gen.count() % 2 != 0; }
@@ -72,6 +90,18 @@ struct MajoranaAlgebra {
     }
     static auto state_phase(const Monomial<NumModes> &mono, const Monomial<NumModes> &state_mask) -> double {
         return monoprop::majorana_state_phase<NumModes>(mono, state_mask);
+    }
+    /*! @brief state_phase() from the term's ascending positions: (-1)^(|M n mask| + |M|/2).
+     *
+     *  Meaningful only for a fully paired M, exactly as state_phase() is.
+     */
+    template <typename PosT>
+    static auto state_phase_positions(const PosT *pos, size_t count, const Monomial<NumModes> &state_mask) -> double {
+        size_t in_mask = 0;
+        for (size_t j = 0; j < count; ++j) {
+            in_mask += static_cast<size_t>(state_mask.test(static_cast<size_t>(pos[j])));
+        }
+        return POWERS_OF_MINUS_ONE[(in_mask + count / 2) % 2];
     }
 };
 
@@ -99,6 +129,27 @@ struct PauliAlgebra {
         return rotation_sign;
     }
 
+    //! Whether rotation_sign_positions() is available: false when G acts on more than 32 qubits.
+    static auto sign_from_positions_ok(const GenContext &ctx) -> bool { return ctx.pauli_ctx.compact_ok; }
+    /*! @brief rotation_sign() from M's positions, through the per-gate compact word.
+     *
+     *  @pre sign_from_positions_ok(ctx). Only the qubits G acts on can change the sign, so the term's
+     *  bits at those qubits are gathered into the compact word and the kernel runs there.
+     */
+    template <typename PosT>
+    [[gnu::always_inline]] static auto rotation_sign_positions(const GenContext &ctx, const PosT *pos, size_t count)
+        -> int {
+        assert(ctx.pauli_ctx.compact_ok);
+        constexpr uint8_t kNone = PauliGenContext<NumModes>::kNotInGen;
+        uint64_t m_compact = 0;
+        for (size_t j = 0; j < count; ++j) {
+            const uint8_t cs = ctx.pauli_ctx.compact_slot[static_cast<size_t>(pos[j])];
+            // cs == kNone contributes nothing: shift by a masked amount and AND with the predicate.
+            m_compact |= (uint64_t{cs != kNone}) << (cs & 63U);
+        }
+        return pauli_rotation_sign_compact<NumModes>(ctx.pauli_ctx, m_compact);
+    }
+
     // Anticommutation fold columns = J(G) = pair_swap(G); Pauli needs no odd-|G| row-parity correction.
     static auto fold_generator(const Monomial<NumModes> &gen) -> Monomial<NumModes> { return pair_swap<NumModes>(gen); }
     static auto fold_needs_odd_correction(const Monomial<NumModes> & /*gen*/) -> bool { return false; }
@@ -112,6 +163,15 @@ struct PauliAlgebra {
     }
     static auto state_phase(const Monomial<NumModes> &mono, const Monomial<NumModes> &state_mask) -> double {
         return pauli_state_phase<NumModes>(mono, state_mask);
+    }
+    //! state_phase() from the term's ascending positions: (-1)^|Z n occupied|, the mask count alone.
+    template <typename PosT>
+    static auto state_phase_positions(const PosT *pos, size_t count, const Monomial<NumModes> &state_mask) -> double {
+        size_t in_mask = 0;
+        for (size_t j = 0; j < count; ++j) {
+            in_mask += static_cast<size_t>(state_mask.test(static_cast<size_t>(pos[j])));
+        }
+        return (in_mask & 1U) != 0U ? -1.0 : 1.0;
     }
 };
 

--- a/cpp/monoprop/algebra/AlgebraCommon.h
+++ b/cpp/monoprop/algebra/AlgebraCommon.h
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <bit>
+#include <cassert>
 #include <cstdint>
 #include <format>
 #include <optional>
@@ -181,6 +182,23 @@ auto support_cutoff(const Monomial<NumModes> &mono, unsigned int cutoff) -> bool
     return support_cutoff<NumModes>(mono, cutoff, NumModes);
 }
 
+/*! @brief The (k, d) digest forms of the two structural cutoffs above.
+ *
+ *  k = |M| and d = the modes of M carrying both of their positions. Then xor_sum = k - 2d,
+ *  popcount_sum = k and or_sum = k - d, so nothing here reads a bitset. Same precondition as
+ *  cutoff_sums with no active mask: every set position of a well-formed monomial lies at or above
+ *  2 * (NumModes - logical_num_modes), which the constructor's bounds check guarantees for stored rows.
+ */
+[[nodiscard]] inline constexpr auto digest_is_paired(size_t k, size_t d) noexcept -> bool {
+    return k == 2 * d;
+}
+[[nodiscard]] inline constexpr auto length_keeps(size_t k, size_t d, unsigned int cutoff) noexcept -> bool {
+    return digest_is_paired(k, d) || k <= cutoff;
+}
+[[nodiscard]] inline constexpr auto support_keeps(size_t k, size_t d, unsigned int cutoff) noexcept -> bool {
+    return digest_is_paired(k, d) || (k - d) <= cutoff;
+}
+
 namespace detail {
 
 template <size_t NumModes>
@@ -231,6 +249,24 @@ public:
             return (*support_cutoff_)(mono);
         }
         return cutoff_fn_(mono);
+    }
+
+    /*! @brief Whether the cutoff is one of the two structural forms, i.e. passes_from_digest answers it.
+     *
+     *  An opaque cutoff_fn_ (a basis change) has no digest, and the emit site must materialise the
+     *  partner's bitset for it.
+     */
+    [[nodiscard]] auto has_digest_form() const -> bool {
+        return length_cutoff_ != nullptr || support_cutoff_ != nullptr;
+    }
+
+    //! The decision from the (k, d) digest alone (see length_keeps). @pre has_digest_form().
+    [[nodiscard]] auto passes_from_digest(size_t k, size_t d) const -> bool {
+        if (length_cutoff_ != nullptr) {
+            return length_keeps(k, d, length_cutoff_->cutoff);
+        }
+        assert(support_cutoff_ != nullptr && "passes_from_digest on an opaque cutoff");
+        return support_keeps(k, d, support_cutoff_->cutoff);
     }
 
     // Fast path when popcount(mono) is known: the predicate is `xor_sum==0 || (popcount/or_sum)<=cutoff`,

--- a/cpp/monoprop/algebra/PauliAlgebra.h
+++ b/cpp/monoprop/algebra/PauliAlgebra.h
@@ -25,6 +25,7 @@
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <stdexcept>
 
 #include "monoprop/Bitset.h"
@@ -97,7 +98,40 @@ struct PauliGenContext final {
     size_t g_y = 0;
     std::array<size_t, Monomial<NumModes>::num_words()> nz_words{};
     size_t nz_count = 0;
+
+    /*! @brief The compacted form for signing a term from its positions alone.
+     *
+     *  Only the qubits G acts on can change the sign (elsewhere mono == new_mono and x_gen == 0), so
+     *  their 2 bits each are packed into ONE 64-bit word preserving the (even, odd) lane structure:
+     *  compact_slot[p] is the compact bit of physical position p, kNotInGen for every other position.
+     *  compact_ok is false when G acts on more than 32 qubits, and the dense kernel must be used.
+     */
+    static constexpr uint8_t kNotInGen = std::numeric_limits<uint8_t>::max();
+    std::array<uint8_t, 2 * NumModes> compact_slot{};
+    uint64_t g_compact = 0;
+    bool compact_ok = false;
 };
+
+/*! @brief pauli_rotation_sign() over the compacted word (see PauliGenContext::compact_slot).
+ *
+ *  The same exponent pauli_rotation_sign folds over the whole bitset, restricted to the qubits that can
+ *  contribute, so the two agree bit for bit. `m_compact` gathers the source term's bits at the compact
+ *  slots; the partner is m_compact ^ g_compact.
+ */
+template <size_t NumModes>
+[[gnu::always_inline]] inline auto pauli_rotation_sign_compact(const PauliGenContext<NumModes> &ctx, uint64_t m_compact)
+    -> int {
+    constexpr uint64_t e = 0x5555'5555'5555'5555ULL;
+    const uint64_t n_compact = m_compact ^ ctx.g_compact;
+    const auto [v_m, u_m] = detail::pauli_uv(m_compact, e);
+    const auto [v_n, u_n] = detail::pauli_uv(n_compact, e);
+    const auto [v_g, u_g] = detail::pauli_uv(ctx.g_compact, e);
+    long delta = static_cast<long>(ctx.g_y);
+    delta += std::popcount(v_m & ~u_m);
+    delta -= std::popcount(v_n & ~u_n);
+    const long cross = std::popcount(v_m & (u_g ^ v_g));
+    return detail::mod4(delta + 2 * cross) == 1 ? -1 : 1;
+}
 
 // Call once per layer, not per term.
 template <size_t NumModes>
@@ -110,6 +144,23 @@ template <size_t NumModes>
             ctx.nz_words[ctx.nz_count++] = w;
         }
     }
+    ctx.compact_slot.fill(PauliGenContext<NumModes>::kNotInGen);
+    size_t qubits = 0;
+    for (size_t q = 0; q < NumModes; ++q) {
+        const bool even = gen.test(2 * q);
+        const bool odd = gen.test((2 * q) + 1);
+        if (!even && !odd) {
+            continue;
+        }
+        if (qubits < 32) {
+            ctx.compact_slot[2 * q] = static_cast<uint8_t>(2 * qubits);
+            ctx.compact_slot[(2 * q) + 1] = static_cast<uint8_t>((2 * qubits) + 1);
+            ctx.g_compact |=
+                (static_cast<uint64_t>(even) << (2 * qubits)) | (static_cast<uint64_t>(odd) << ((2 * qubits) + 1));
+        }
+        ++qubits;
+    }
+    ctx.compact_ok = qubits <= 32;
     return ctx;
 }
 

--- a/cpp/monoprop/detail/evolution/LayerBuilder.h
+++ b/cpp/monoprop/detail/evolution/LayerBuilder.h
@@ -15,9 +15,7 @@
 #pragma once
 
 // Umbrella header for build_layer<NumModes>(); the implementation lives in the sibling layer_build/ headers.
-// Pivot split: M and its partner M⊕G differ in every column of G including the pivot (G's lowest set
-// column), so exactly one of the pair carries it — leader (pivot clear) vs follower (pivot set). Visiting
-// leaders then the still-unmatched followers touches each pair once, no sort and no dedup.
+// Engine.h states the one-round symmetric gate exchange; Scan.h emits its records, Resolve.h joins them.
 
 #include "monoprop/detail/evolution/layer_build/Common.h"
 #include "monoprop/detail/evolution/layer_build/Engine.h"

--- a/cpp/monoprop/detail/evolution/layer_build/CMakeLists.txt
+++ b/cpp/monoprop/detail/evolution/layer_build/CMakeLists.txt
@@ -7,8 +7,11 @@ target_sources(
         "Common.h"
         "Engine.h"
         "FusedApply.h"
+        "GateScratch.h"
+        "GateSinks.h"
         "PartnerMerge.h"
         "QueryWire.h"
         "Resolve.h"
         "Scan.h"
+        "TableJoin.h"
 )

--- a/cpp/monoprop/detail/evolution/layer_build/Common.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Common.h
@@ -32,76 +32,87 @@ namespace monoprop::detail {
 // OperatorIndex::kNotFound, so one `>= size` bound check covers a miss and an unresolved slot alike.
 inline constexpr size_t kMissingIndex = std::numeric_limits<size_t>::max();
 
-// Marks matched followers without a per-gate O(n) memset: one counter bump clears every mark. Reused
-// across gates.
-struct MatchedEpochSet {
-    // One 2-byte stamp per term: the counter is never serialised, never exchanged, only compared to cur_.
-    using Stamp = uint16_t;
+// One nonzero-overlap word of the anticommutation fold, produced by the scan's pass 1 and read again by
+// the emit pass and the per-gate mark clear. `overlap` bit t set <=> term (base+t) anticommutes with G;
+// `foll` = overlap & pivot column = the followers (leaders are `overlap ^ foll`). `base` is a multiple
+// of 64: it is word wi's first row, so base/64 indexes a row-bitset word directly.
+struct EvenParityNzWord {
+    size_t base;
+    uint64_t overlap;
+    uint64_t foll;
+};
 
-    std::vector<Stamp> epoch_;
-    Stamp cur_ = 0;
+// One record this slot sent for a gate, in stream order (ascending source row): the source row and the
+// emit phase of that source. The absence pass walks these, so the row is carried rather than looked
+// up -- there are no per-gate ordinals to index a phase array by.
+struct SentRecord {
+    TermIndex row;
+    int8_t phase; // ternary, as A::emit_phase returns it
+};
 
-    // Wraps once per 65535 gates; without the fill a stale stamp on a row reused after a truncation aliases.
-    auto begin_gate(size_t n) -> void {
-        if (cur_ == std::numeric_limits<Stamp>::max()) {
-            std::fill(epoch_.begin(), epoch_.end(), Stamp{0});
-            cur_ = 0;
-        }
-        ++cur_;
-        if (epoch_.size() < n) {
-            epoch_.resize(n, Stamp{0});
-        }
-    }
-    auto mark(size_t i) -> void { epoch_[i] = cur_; }
-    [[nodiscard]] auto is_marked(size_t i) const -> bool { return epoch_[i] == cur_; }
-    [[nodiscard]] auto memory_bytes() const -> size_t { return epoch_.capacity() * sizeof(Stamp); }
+// Round 2 of the gate protocol (Engine.h): the answer a slot owes a record that hit one of its silent
+// rows is two words, `{sent_idx, value}`. `sent_idx` is that record's position in the sender's own
+// stream to this slot, which is what lets the answer name a row without carrying one -- the sender maps
+// it back through its `sent` list. Two words, so the response round reuses the records' transport verb
+// and buffer type.
+inline constexpr size_t kResponseWords = 2;
+
+// COMMPROF's tallies (MonomialPropagator::report_comm_profile_ prints them): the wire volume of one
+// call's gates, as this slot SENT it. Accumulated across the gates of a call, not reset per gate.
+struct ExchangeCounters {
+    size_t gates = 0;     // gates that exchanged, i.e. excluding the identity ones
+    size_t records = 0;   // round-1 records pushed, self-staged included
+    size_t responses = 0; // round-2 responses staged, the self slot's immediate ones included
 };
 
 // A trivial aggregate on purpose — not std::pair — so DefaultInitVector can skip the zero-fill and lower
 // the gather to memmove.
 struct PhasedEntry {
-    size_t idx; // local target index for in_entries, local source index for out_entries
+    size_t idx; // local target index for the in lists, local source index for the out lists
     int phase;
 };
 
-// Uniform per-rank rotation accumulator, drained into the LayerCore's sin_send/sin_recv lists by
-// GraphSink::finalize. Self slot: in:=(tgt,φ), out:=(src,φ); cross-rank: in=resolver, out=querier side.
+// One peer slot's rotation endpoints as the graph sink collects them (GateSinks.h has the rules),
+// drained into the LayerCore's sin_send/sin_recv lists by GraphSink::finalize as
+// in = [in_pairs, in_mints] and out = [out_pairs, out_unanswered]. Replay pairs my out[j] with the
+// peer's in[j] positionally, which the four lists' orders guarantee: in_pairs/in_mints are in the
+// peer's stream order (ascending peer row), out_pairs/out_unanswered in ascending own row.
 struct PartnerAcc {
-    // Default-init storage: every resize-then-overwrite path must fully overwrite [base, base+n) before reading.
-    DefaultInitVector<PhasedEntry> in_entries;
-    DefaultInitVector<PhasedEntry> out_entries;
+    std::vector<PhasedEntry> in_pairs;       // my follower endpoints of pairs with a tracked partner
+    std::vector<PhasedEntry> in_mints;       // partners this slot minted from a peer's E-record
+    std::vector<PhasedEntry> out_pairs;      // my leader endpoints of pairs with a tracked partner
+    std::vector<PhasedEntry> out_unanswered; // my E-records whose key missed at the peer (it minted)
+
+    [[nodiscard]] auto in_count() const -> size_t { return in_pairs.size() + in_mints.size(); }
+    [[nodiscard]] auto out_count() const -> size_t { return out_pairs.size() + out_unanswered.size(); }
 };
 
-// Fused contraction (ContractImmediately — the default forward path at all rank counts): one rotation
-// (source S, target T, phase φ) applied directly to op_coeffs, bypassing the LayerCore, after cos-scaling S and T:
-//   op[S] += -sin·φ·op_pre[T]      op[T] += +sin·φ·op_pre[S]
-struct RotationRec {
-    size_t src = 0;
-    size_t tgt = 0;
-    double v_src = 0.0; // op_pre[src] — signed coeff captured at scan emit
-    double v_tgt = 0.0; // op_pre[tgt] — resolve-time (hits) / post-extension (inserts) coeff
-    int32_t phase = 0;  // ±1 rotation phase (A::emit_phase)
-};
-
-// One cross-rank half-rotation (R>1): each rank applies only the add to the slot it owns. The resolver
-// owns target T: {T, v_src, +φ}; the querier owns source S: {S, v_tgt, −φ}. Applied like the self-rank
-// sin_recv apply: op[local_idx] += sin·phase_signed·v_partner (v_partner off the wire, pre-cos).
+// One half-rotation (Engine.h has the protocol): the add this slot owns of a rotation between a term and
+// its partner, applied as op[local_idx] += sin*phase_signed*v_partner with v_partner the partner's
+// pre-cos coefficient off the wire. Each slot is touched by exactly one add per gate (a term has one
+// partner), so the order of the records is irrelevant to the result.
+// Two words rather than three: the index is a row, so it is TermIndex-wide like every other row in the
+// engine, and the phase is ternary. One gate's halves are pushed and then drained as one sequential
+// stream over a buffer the join sizes exactly, so a third off the record is a third off the memory
+// traffic of both passes.
 struct HalfRotationRec {
-    size_t local_idx = 0;     // slot this rank owns: T (resolver) or S (querier)
-    double v_partner = 0.0;   // partner's pre-cos coeff: v_src (resolver) / v_tgt (querier)
-    int32_t phase_signed = 0; // +φ (resolver) / −φ (querier), pre-signed so the apply never negates
-    // Resolver miss halves write a slot inserted this gate (after the fused cos sweep), so the apply folds
-    // the gate's cos in (c = cos·c + sin) instead of a plain add. False for hit/querier halves: pre-gate terms.
+    TermIndex local_idx = 0; // the slot this rank owns
+    int8_t phase_signed = 0; // +phi_rec for a hit or mint, -phi_own for an absent partner: pre-signed so
+                             // the apply never negates
+    // A mint writes a slot inserted this gate (after the fused cos sweep), so the apply folds the gate's
+    // cos in (c = cos*c + sin*phi*v) instead of a plain add. False for every pre-gate term.
     bool is_insert = false;
+    double v_partner = 0.0; // partner's pre-cos coefficient: v_rec for a hit or mint, the answering
+                            // row's own coefficient for a response, c0 for an absence
 };
+// Only the default 32-bit TermIndex can hold the layout.
+static_assert(sizeof(TermIndex) != sizeof(uint32_t) || sizeof(HalfRotationRec) == 16,
+              "the apply streams these, so the packing is the point");
 
-// Sink threaded through build_layer's fused branch; a non-null FusedContract* selects the fused path.
-// Self-routed rotations (both endpoints local) are full RotationRecs, split into hit and insert lists so
-// the apply can fill insert v_tgt (readable only after extend_coeffs) without scanning for a sentinel.
+// Sink threaded through build_layer's fused branch (ContractImmediately); a non-null FusedContract*
+// selects the fused path. Drained by apply_fused_contract.
 struct FusedContract {
-    std::vector<RotationRec> hits;
-    std::vector<RotationRec> inserts;
-    std::vector<HalfRotationRec> cross_half; // R>1: one half per cross-rank query (resolver +φ, querier −φ)
+    std::vector<HalfRotationRec> halves;
 };
 
 // bit_cast, not a conversion, so v_src arrives over the wire bit-identical.
@@ -111,6 +122,12 @@ inline auto encode_value(double v) -> size_t {
 }
 inline auto decode_value(size_t word) -> double {
     return std::bit_cast<double>(word);
+}
+
+//! Appends one round-2 response, `kResponseWords` words wide.
+inline auto push_response(VecZ &buf, size_t sent_idx, double v) -> void {
+    buf.push_back(sent_idx);
+    buf.push_back(encode_value(v));
 }
 
 } // namespace monoprop::detail

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -15,11 +15,10 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <span>
@@ -30,317 +29,50 @@
 #include "monoprop/algebra/Algebra.h"
 #include "monoprop/detail/evolution/CutoffContext.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
+#include "monoprop/detail/evolution/layer_build/GateScratch.h"
+#include "monoprop/detail/evolution/layer_build/GateSinks.h"
 #include "monoprop/detail/evolution/layer_build/PartnerMerge.h"
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
 #include "monoprop/detail/evolution/layer_build/Resolve.h"
 #include "monoprop/detail/evolution/layer_build/Scan.h"
-#include "monoprop/detail/graph_encoding/MPGraphEncodingStorage.h"
+#include "monoprop/detail/evolution/layer_build/TableJoin.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
 #include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
-#include "monoprop/detail/operator/RowAccess.h"
 
 namespace monoprop::detail {
 
-// Every rotation target must be in cos so the gradient reverse-sweep can un-do this layer's cosine
-// scaling; only freshly inserted half-terms can be absent (see tests/test_infinite_cutoff.py), and those
-// sit in [combined_size, op.size()). Scan cos bits and inserted endpoint bits are disjoint, so only the
-// seam word can carry both — bitwise-or that one, append the rest, keeping blocks ascending/disjoint.
-template <size_t NumModes>
-inline auto append_inserted_endpoints(CosMask &cos_all, size_t combined_size, const MPOperator<NumModes> &op) -> void {
-    const size_t cos_lo = combined_size;
-    const size_t cos_hi = op.store->size();
-    CosineWordBuilder end_b;
-    for (size_t idx = cos_lo; idx < cos_hi; ++idx) {
-        end_b.push_index(idx);
-    }
-    CosMask end_words = end_b.finish();
-    cos_all.total_count += end_words.total_count;
-    if (!cos_all.blocks.empty() && !end_words.blocks.empty()
-        && end_words.blocks.front().first == cos_all.blocks.back().first) {
-        cos_all.blocks.back().second |= end_words.blocks.front().second;
-        cos_all.blocks.insert(cos_all.blocks.end(), end_words.blocks.begin() + 1, end_words.blocks.end());
-    }
-    else {
-        cos_all.blocks.insert(cos_all.blocks.end(), end_words.blocks.begin(), end_words.blocks.end());
-    }
-}
-
-// A sink owns the divergent state and supplies the emission surfaces — self-resolve, cross-rank
-// resolve/process, deferred self-insert — plus finalize. Each monomorphizes: no run-time fused/graph branch.
-
-// Graph-build sink: accumulates the per-rank PartnerAcc endpoints and assembles a LayerCore at finalize.
-// wants_values=false — the scan captures no coeffs and every rotation records only (index, phase).
-template <size_t NumModes>
-struct GraphSink {
-    static constexpr bool wants_values = false;
-    [[nodiscard]] auto incoming_form() const -> QueryForm { return QueryForm::Plain; }
-    [[nodiscard]] auto querier_form() const -> QueryForm { return QueryForm::Plain; }
-    using Response = TermIndex;
-    static auto init_response() -> Response { return std::numeric_limits<TermIndex>::max(); }
-
-    size_t R;
-    size_t my_rank;
-    std::vector<PartnerAcc> acc;
-    size_t def_in_base_ = 0; // deferred self-miss bases into acc[my_rank]
-    size_t def_out_base_ = 0;
-    std::vector<size_t> in_base_; // cross-rank per-rank base into acc[s].in_entries (set in prepare)
-
-    GraphSink(size_t R_, size_t my_rank_) : R(R_), my_rank(my_rank_), acc(R_) {}
-
-    auto self_hit(size_t src, size_t found, int phase, double /*v_src*/) -> void {
-        acc[my_rank].in_entries.push_back({found, phase});
-        acc[my_rank].out_entries.push_back({src, phase});
-    }
-    auto prepare_deferred(size_t n_miss) -> void {
-        def_in_base_ = acc[my_rank].in_entries.size();
-        def_out_base_ = acc[my_rank].out_entries.size();
-        acc[my_rank].in_entries.resize(def_in_base_ + n_miss);
-        acc[my_rank].out_entries.resize(def_out_base_ + n_miss);
-    }
-    auto emit_deferred(size_t k, size_t idx, size_t src, int phase, double /*v_src*/) -> void {
-        acc[my_rank].in_entries[def_in_base_ + k] = {idx, phase};
-        acc[my_rank].out_entries[def_out_base_ + k] = {src, phase};
-    }
-
-    // Cross-rank (R>1). Send buffer = the plain query stream (no value fusion). The exchange is positional:
-    // responses[s][q] must answer incoming[s][q], one resolution per query.
-    auto send_buffer(std::vector<VecZ> &queries,
-                     std::vector<std::vector<double>> & /*vals*/,
-                     std::vector<VecZ> & /*scratch*/) -> std::vector<VecZ> & {
-        return queries;
-    }
-    auto prepare(const IncomingProbe<NumModes> & /*pr*/,
-                 size_t rank_count,
-                 MPOperator<NumModes> & /*op*/,
-                 const std::vector<std::vector<Response>> &responses) -> void {
-        in_base_.assign(rank_count, 0);
-        for (size_t s = 0; s < rank_count; ++s) {
-            in_base_[s] = acc[s].in_entries.size();
-            acc[s].in_entries.resize(in_base_[s] + responses[s].size());
-        }
-    }
-    auto on_resolved(size_t g,
-                     size_t s,
-                     size_t q,
-                     size_t ip,
-                     const IncomingProbe<NumModes> &pr,
-                     const std::vector<VecZ> & /*incoming*/) -> Response {
-        acc[s].in_entries[in_base_[s] + q] = {ip, pr.phase_of[g]};
-        return static_cast<TermIndex>(ip);
-    }
-    auto process_reserve(const std::vector<std::vector<Response>> & /*inc_r*/,
-                         size_t /*rank_count*/,
-                         size_t /*my_rank*/) -> void {}
-    auto on_response_block(size_t r,
-                           const std::vector<Response> &resp,
-                           const std::vector<size_t> &srcs,
-                           const VecZ &qbuf) -> void {
-        auto &out = acc[r].out_entries;
-        const size_t base = out.size();
-        const size_t nq = resp.size();
-        const QueryForm form = querier_form();
-        out.resize(base + nq);
-        size_t off = 0;
-        for (size_t q = 0; q < nq; ++q) {
-            assert(resp[q] != std::numeric_limits<TermIndex>::max() && "resolver must insert absent cross-rank terms");
-            out[base + q] = {srcs[q], QueryWire<NumModes>::phase_at(qbuf, off)};
-            off = QueryWire<NumModes>::next_off(qbuf, form, off);
-        }
-    }
-
-    // Drains the per-rank accumulators into the LayerCore's sin_send/sin_recv lists (layout derivation:
-    // see cross_rank_sin_recv_index). cos covers all anticommuting indices, endpoints included, since the
-    // sin_recv apply only adds the sine term.
-    auto finalize(CosMask &&cos_all, CosMask *out_cos, size_t combined_size, MPOperator<NumModes> &op)
-        -> std::shared_ptr<LayerCore> {
-        std::vector<CrossRankPartnerData> partners(R);
-        for (size_t r = 0; r < R; ++r) {
-            const auto &a = acc[r];
-            auto &p = partners[r];
-            const size_t P = a.in_entries.size();
-            const size_t Q = a.out_entries.size();
-            if (P + Q == 0) {
-                continue;
-            }
-            p.in_count = P; // boundary for deriving the sin_recv index list from sin_send (not stored)
-            p.sin_send_indices.resize(P + Q);
-            p.sin_recv_entries.resize(P + Q);
-            for (size_t k = 0; k < P + Q; ++k) {
-                if (k < P) {
-                    const auto &e = a.in_entries[k];
-                    p.sin_send_indices[k] = e.idx;
-                    p.sin_recv_entries[Q + k] = {e.idx, e.phase};
-                }
-                else {
-                    const size_t j = k - P;
-                    const auto &e = a.out_entries[j];
-                    p.sin_send_indices[k] = e.idx;
-                    p.sin_recv_entries[j] = {e.idx, -e.phase};
-                }
-            }
-        }
-        if (out_cos != nullptr) {
-            append_inserted_endpoints<NumModes>(cos_all, combined_size, op);
-            *out_cos = std::move(cos_all);
-        }
-        return build_layer_storage_unified(partners, my_rank);
-    }
-};
-
-// Fused ContractImmediately sink: applies each resolved rotation directly to op_coeffs via the
-// FusedContract record streams (no LayerCore — finalize returns nullptr). wants_values=true: the scan
-// captures the signed pre-cos v_src, and resolve reads v_tgt from op_coeffs (·inv_cos under the cos sweep).
-template <size_t NumModes>
-struct ContractSink {
-    static constexpr bool wants_values = true;
-    // This rank receives fused records, but on_response_block is handed its own plain queries_r;
-    // reading the wrong form there decodes a neighbouring record's phase, i.e. a coefficient sign flip.
-    [[nodiscard]] auto incoming_form() const -> QueryForm { return QueryForm::Fused; }
-    [[nodiscard]] auto querier_form() const -> QueryForm { return QueryForm::Plain; }
-    using Response = double;
-    static auto init_response() -> Response { return 0.0; }
-
-    size_t R;
-    size_t my_rank;
-    FusedContract &fc;
-    const VecD &op_coeffs; // the very array the scan read, not a copy
-    bool fused_scale;      // fused cos sweep active: hit v_tgt recovered as stored·inv_cos
-    double inv_cos;
-    bool schrodinger;                 // fresh cross-rank miss coeff: 0 (Heisenberg) vs state-scored (Schrödinger)
-    Basis basis;                      // Pauli vs Majorana state scoring of fresh cross-rank Schrödinger misses
-    size_t def_base_ = 0;             // deferred self-insert base into fc.inserts
-    size_t cross_base_ = 0;           // cross-rank resolver-half base into fc.cross_half
-    Monomial<NumModes> state_mask_{}; // Schrödinger fresh-insert scoring mask (empty in Heisenberg)
-
-    // No constructor on purpose: as an aggregate the call site names each field, so the two adjacent
-    // bools cannot be swapped silently. GraphSink keeps its ctor because it sizes `acc` from R.
-
-    // Self-resolve hit: both endpoints are local.
-    [[gnu::always_inline]] auto self_hit(size_t src, size_t found, int phase, double v_src) -> void {
-        const double v_tgt = fused_scale ? op_coeffs[found] * inv_cos : op_coeffs[found];
-        fc.hits.push_back(RotationRec{src, found, v_src, v_tgt, static_cast<int32_t>(phase)});
-    }
-    // Deferred self-miss insert: v_tgt filled later (after op_coeffs is extended by the apply).
-    auto prepare_deferred(size_t n_miss) -> void {
-        def_base_ = fc.inserts.size();
-        fc.inserts.resize(def_base_ + n_miss);
-    }
-    [[gnu::always_inline]] auto emit_deferred(size_t k, size_t idx, size_t src, int phase, double v_src) -> void {
-        fc.inserts[def_base_ + k] = RotationRec{src, idx, v_src, /*v_tgt=*/0.0, static_cast<int32_t>(phase)};
-    }
-
-    // Cross-rank (R>1). Send buffer = queries interleaved with their v_src stream into `scratch`
-    // (combined_qv_), so one alltoallv carries query + value.
-    auto send_buffer(std::vector<VecZ> &queries, std::vector<std::vector<double>> &vals, std::vector<VecZ> &scratch)
-        -> std::vector<VecZ> & {
-        scratch.resize(queries.size());
-        for (size_t r = 0; r < queries.size(); ++r) {
-            QueryWire<NumModes>::build_fused(queries[r], vals[r], scratch[r]);
-        }
-        return scratch;
-    }
-    auto prepare(const IncomingProbe<NumModes> &pr,
-                 size_t /*rank_count*/,
-                 MPOperator<NumModes> &op,
-                 const std::vector<std::vector<Response>> & /*responses*/) -> void {
-        state_mask_ = schrodinger ? initial_state_mask<NumModes>(op.initial_state) : Monomial<NumModes>{};
-        cross_base_ = fc.cross_half.size();
-        fc.cross_half.resize(cross_base_ + pr.nq_total);
-    }
-    auto on_resolved(size_t g,
-                     size_t s,
-                     size_t /*q*/,
-                     size_t ip,
-                     const IncomingProbe<NumModes> &pr,
-                     const std::vector<VecZ> &incoming) -> Response {
-        double v_tgt;
-        if (ip < pr.base) {
-            v_tgt = fused_scale ? op_coeffs[ip] * inv_cos : op_coeffs[ip];
-        }
-        else if (schrodinger) {
-            v_tgt = pr.is_paired_at(g) ? algebra_state_phase<NumModes>(basis, pr.mono_at(g), state_mask_) : 0.0;
-        }
-        else {
-            v_tgt = 0.0; // Heisenberg fresh insert
-        }
-        fc.cross_half[cross_base_ + g] = HalfRotationRec{ip,
-                                                         QueryWire<NumModes>::value_at(incoming[s], pr.off_of[g]),
-                                                         static_cast<int32_t>(pr.phase_of[g]),
-                                                         /*is_insert=*/ip >= pr.base};
-        return v_tgt;
-    }
-    auto process_reserve(const std::vector<std::vector<Response>> &inc_r, size_t rank_count, size_t my_rank_) -> void {
-        size_t incoming = 0;
-        for (size_t r = 0; r < rank_count; ++r) {
-            if (r != my_rank_) {
-                incoming += inc_r[r].size();
-            }
-        }
-        fc.cross_half.reserve(fc.cross_half.size() + incoming);
-    }
-    // A querier half always writes a pre-gate term the cos sweep already covered ⇒ is_insert=false.
-    auto on_response_block(size_t /*r*/,
-                           const std::vector<Response> &rval,
-                           const std::vector<size_t> &srcs,
-                           const VecZ &qbuf) -> void {
-        const size_t nq = rval.size();
-        const QueryForm form = querier_form();
-        size_t off = 0;
-        for (size_t q = 0; q < nq; ++q) {
-            const auto nphase = static_cast<int32_t>(-QueryWire<NumModes>::phase_at(qbuf, off));
-            fc.cross_half.push_back(HalfRotationRec{srcs[q], rval[q], nphase, /*is_insert=*/false});
-            off = QueryWire<NumModes>::next_off(qbuf, form, off);
-        }
-    }
-
-    // No LayerCore in the fused path → nullptr. Two-pass fused (k>0 / cos==0 fallback) appends inserted
-    // endpoints so the immediate cos scale covers them; the fused cos sweep covers them in-place instead.
-    auto finalize(CosMask &&cos_all, CosMask *out_cos, size_t combined_size, MPOperator<NumModes> &op)
-        -> std::shared_ptr<LayerCore> {
-        if (out_cos != nullptr && !fused_scale) {
-            append_inserted_endpoints<NumModes>(cos_all, combined_size, op);
-            *out_cos = std::move(cos_all);
-        }
-        return nullptr;
-    }
-};
-
-// Owns build_layer's machinery over a compile-time Sink policy. combined_size = the pre-layer operator size.
+/*! @brief The gate exchange, over a compile-time Sink policy (GateSinks.h).
+ *
+ *  For a gate G, a tracked term v anticommuting with G has partner u = v ^ G owned by one flat slot, and
+ *  the pair rotates iff E(v) or E(u), both adds using the PRE-cos values and phi_v = -phi_u.
+ *
+ *  One and a half rounds. Only an EMITTING v sends a record (key u, phi_v, rot = E(v), [val_v]) to
+ *  owner(u), so round 1 is O(|emitted|), not O(|Anti(G)|). Each slot probes what it received against its
+ *  persistent term table once per record: a hit applies +phi_rec*val_rec onto u iff rot_rec or E(u), and
+ *  if u is SILENT (it sent nothing) stages a response carrying u's pre-gate coefficient; a miss mints u.
+ *  Round 2 delivers the responses, and the absence pass over the records v sent finds the partners nobody
+ *  could answer for. Per pair that is the same two adds with the same values whichever branch supplies
+ *  them, so the three outcomes are exact, not an approximation of the symmetric protocol. The narrative
+ *  argument is in docs/content/docs/features/parallelism.mdx.
+ *
+ *  Graph mode has no coefficients, so no term is silent and no response can be needed: it keeps the
+ *  symmetric one-round predicate its positional replay is proved on. `Sink::wants_responses` switches.
+ */
 template <size_t NumModes, typename Sink>
 struct LayerBuildEngine {
     using RowPosT = typename OperatorIndex<NumModes>::PosT;
 
-    // A miss keeps the decoded positions it will become a row from (pos_at indexes deferred_pos_flat_).
-    struct DeferredSelfMiss {
-        size_t pos_at;
-        uint32_t k;
-        size_t src;
-        int phase;
-        double v_src = 0.0; // ContractSink only: op_pre[src] captured at scan emit; 0 for GraphSink
-    };
     MPOperator<NumModes> &local_op; // scanned, looked up, and grown by the inserts
     mpi::Comm comm;
     size_t R;
     size_t my_rank;
-    // Follower-matched set over [0, combined_size), caller-owned (see MatchedEpochSet). Distinct leaders
-    // → distinct found, so each slot is marked once.
-    MatchedEpochSet &matched;
-    size_t combined_size;
-    std::vector<VecZ> queries_r;
-    std::vector<std::vector<size_t>> src_idx_r;
-    std::vector<DeferredSelfMiss> deferred_self_misses;
-    // Deferred-miss positions, concatenated in miss order; parallel to deferred_self_misses.
-    std::vector<RowPosT> deferred_pos_flat_;
-    // This pass's self-owned queries as positions, straight from the scan: never encoded, so the resolve
-    // below has nothing to decode. Parallel to src_idx_r[my_rank].
-    SelfQueryStage<NumModes> self_stage_;
-    // Scan-captured v_src per query (ContractSink only via Sink::wants_values; empty for GraphSink).
-    std::vector<std::vector<double>> src_val_r;
-    // Fused query+value send scratch (ContractSink, R>1): shared by a gate's two exchange passes.
-    std::vector<VecZ> combined_qv_;
-    // Which destination ranks this gate's queries can reach. Dense unless the router is GF(2)-linear;
-    // see mpi::PeerPlan. Derived once per layer in build_layer, never per query.
+    // This gate's join and the other per-gate scratch, propagator-owned so capacity survives the gate;
+    // the protocol's per-row state is in scratch.marks (GateScratch.h).
+    GateScratch<NumModes> &scratch;
+    size_t combined_size; // the pre-layer operator size
+    // Which destination ranks this gate's records can reach. Dense unless the router is GF(2)-linear;
+    // see mpi::PeerPlan. Derived once per layer in build_layer, never per record.
     mpi::PeerPlan plan;
     Sink sink;
 
@@ -348,7 +80,7 @@ struct LayerBuildEngine {
                      mpi::Comm comm_,
                      size_t R_,
                      size_t my_rank_,
-                     MatchedEpochSet &matched_scratch,
+                     GateScratch<NumModes> &scratch_,
                      size_t combined_size_,
                      Sink &&sink_,
                      mpi::PeerPlan plan_ = {}) // dense by default: the tests build the engine directly
@@ -356,207 +88,169 @@ struct LayerBuildEngine {
           comm(comm_),
           R(R_),
           my_rank(my_rank_),
-          matched(matched_scratch),
+          scratch(scratch_),
           combined_size(combined_size_),
-          queries_r(R_),
-          src_idx_r(R_),
           plan(plan_),
-          sink(std::move(sink_)) {
-        matched.begin_gate(combined_size);
-    }
+          sink(std::move(sink_)) {}
 
-    // Resolve this rank's own query stream inline, then clear it so the alltoallv never sends to self.
-    auto resolve_self_queries(bool is_leader_pass) -> void {
-        std::vector<size_t> &ls = src_idx_r[my_rank];
-        std::vector<double> *lv = nullptr;
-        if constexpr (Sink::wants_values) {
-            lv = &src_val_r[my_rank];
-        }
-        // The scan routes a self-owned partner to the stage, never to the wire buffer.
-        resolve_range_(ls, lv, is_leader_pass);
-        self_stage_.clear();
-        ls.clear();
-        if constexpr (Sink::wants_values) {
-            src_val_r[my_rank].clear();
-        }
-    }
+    /*! @brief The round and a half.
+     *
+     *  Exchange the scan's records, probe every record against this slot's term table in ONE batched
+     *  pass, apply the receiver rule to the self stage and then the incoming records in that fixed order,
+     *  exchange the responses the silent hits staged, insert the misses while that is in flight, apply
+     *  the responses, walk the sent records. Taking the scan result by value is what makes the sequence
+     *  unmissable -- nothing else can read the records once they are here.
+     */
+    auto exchange_and_join(FusedScanResult<NumModes> &&scan) -> void {
+        RowMarks &marks = scratch.marks;
+        TableJoin<NumModes> &join = scratch.join;
+        MissStage<NumModes> &misses = scratch.misses;
+        IncomingRecords<NumModes> &pr = scratch.incoming_records;
+        const size_t base = local_op.store->size();
+        misses.clear();
+        pr.nq_total = 0;
+        pr.goff.assign(R + 1, 0);
+        assert(scan.queries[my_rank].empty() && "self-owned records are staged, never encoded");
 
-    // One partner-resolution pass over the given query streams, which it takes ownership of. Round 1
-    // carries the queries (the sink may fuse the v_src stream into them) and the resolver inserts absent
-    // partners in that same round; round 2 returns the answers. Taking the streams here rather than having
-    // the caller assign the members first is what makes the two-pass protocol unmissable — the follower
-    // pass must also drop the queries a leader already matched, and that only holds once the leader pass
-    // has run.
-    auto run_exchange(bool is_leader_pass,
-                      std::vector<VecZ> &&queries,
-                      std::vector<std::vector<size_t>> &&src_idx,
-                      std::vector<std::vector<double>> &&src_val,
-                      SelfQueryStage<NumModes> &&self_stage) -> void {
-        queries_r = std::move(queries);
-        src_idx_r = std::move(src_idx);
-        self_stage_ = std::move(self_stage);
-        // src_val is empty unless Sink::wants_values, so the move is a no-op under GraphSink.
-        src_val_r = std::move(src_val);
-        if (!is_leader_pass && R > 1) {
-            drop_matched_cross_rank_followers();
+        std::optional<mpi::PendingAlltoallv<size_t>> pending;
+        // Round 1 opens here and closes past the decode: the post, the wait and the decode are one stage
+        // because no gate can overlap them with work of its own -- the join's row side needs every record.
+        if (R > 1) {
+            pending.emplace(
+                mpi::begin_alltoallv(scan.queries, comm, /*skip_self=*/false, /*known_recv_counts=*/nullptr, plan));
         }
-        resolve_self_queries(is_leader_pass);
-        if (R <= 1) {
-            return;
+        std::vector<std::span<const size_t>> views;
+        if (pending.has_value()) {
+            scratch.reuse_incoming_wire(R);
+            pending->wait_into(scratch.incoming_wire);
+            decode_incoming_records<NumModes>(slot_streams(scratch.incoming_wire, views), sink.incoming_form(), pr);
         }
-        std::vector<VecZ> &send = sink.send_buffer(queries_r, src_val_r, combined_qv_);
-        std::vector<std::vector<size_t>> inc_q;
-        mpi::begin_alltoallv(send, comm, /*skip_self=*/false, /*known_recv_counts=*/nullptr, plan).wait_into(inc_q);
-        auto resp = resolve_incoming<NumModes>(inc_q, local_op, R, is_leader_pass, matched, combined_size, sink);
-        std::vector<int> resp_recv = response_recv_counts();
-        std::vector<std::vector<typename Sink::Response>> inc_r;
-        // The answers retrace the queries, and the pairing is an XOR involution, so the same plan holds.
-        mpi::begin_alltoallv(resp, comm, /*skip_self=*/false, &resp_recv, plan).wait_into(inc_r);
-        process_responses<NumModes>(inc_r, src_idx_r, queries_r, R, my_rank, sink);
-    }
 
-    // Followers a leader already matched must not be re-resolved over the wire, so compact them out.
-    auto drop_matched_cross_rank_followers() -> void {
-        using QW = QueryWire<NumModes>;
-        const QueryForm form = sink.querier_form();
-        for (size_t r = 0; r < R; ++r) {
-            if (r == my_rank) {
-                continue;
-            }
-            VecZ &q = queries_r[r];
-            std::vector<size_t> &s = src_idx_r[r];
-            // Fused: the v_src stream is parallel to the query/source streams, so compact it in lockstep.
-            std::vector<double> *v = nullptr;
-            if constexpr (Sink::wants_values) {
-                v = &src_val_r[r];
-            }
-            const size_t nq = s.size();
-            size_t kept = 0;
-            // Two cursors, since a dropped query has no fixed width; order is the accumulation order.
-            size_t src_off = 0;
-            size_t dst_off = 0;
-            for (size_t k = 0; k < nq; ++k) {
-                const size_t next = QW::next_off(q, form, src_off);
-                if (!matched.is_marked(s[k])) {
-                    dst_off += QW::move_query(q, form, src_off, dst_off);
-                    s[kept] = s[k];
-                    if (v != nullptr) {
-                        (*v)[kept] = (*v)[k];
-                    }
-                    ++kept;
-                }
-                src_off = next;
-            }
-            q.resize(dst_off);
-            s.resize(kept);
-            if (v != nullptr) {
-                v->resize(kept);
-            }
-        }
-    }
+        // Query order IS mint order: the self stage first, then the incoming sources in ascending slot
+        // order, each in its sender's stream order.
+        const size_t n_self = scan.self.size();
+        const std::span<const SentRecord> sent_self(scan.sent[my_rank]);
+        assert(sent_self.size() == n_self && "one sent record per self query");
+        join.begin_queries(n_self + pr.nq_total);
+        // One batched probe of the term table over the whole query space, in resolve order. The table
+        // covers every row of the store (the previous gate's mints were appended by reindex_after_growth),
+        // and a record's partner, if tracked anywhere on this slot, is one of them.
+        join.run(
+            local_op.term_table(),
+            *local_op.store,
+            [&](size_t q) -> uint32_t { return (q < n_self) ? scan.self.tag_of[q] : pr.tag_of[q - n_self]; },
+            [&](size_t q) -> std::span<const RowPosT> {
+                return (q < n_self) ? scan.self.positions_at(q) : pr.positions_at(q - n_self);
+            },
+            [&](size_t /*q*/, size_t row) { marks.set_matched(row); });
 
-    // Sub-step of finish() — call only after both resolve passes complete, or the base+k assignment and
-    // per-miss distinctness break. Misses are pairwise-distinct (mono = source⊕G, ⊕G injective), so miss
-    // k gets base+k in leader-then-follower order.
-    auto insert_deferred_self_misses() -> void {
-        const size_t n_miss = deferred_self_misses.size();
-        if (n_miss == 0) {
-            return;
+        // Both output buffers of the resolve phase are sized here, before the first push, because the
+        // join has just settled the two counts they depend on. Every sink call is keyed on either a
+        // distinct query -- a hit pushes at most one half, a miss mints at most one -- or a distinct
+        // record this slot sent, since a record is answered (round 2, or a self silent hit) or absent but
+        // never both, and a row sends exactly one record because it has exactly one partner. So
+        // |Q| + |sent| bounds the gate's halves, and |Q| - |hits| bounds its mints exactly.
+        size_t n_sent = 0;
+        for (const auto &records : scan.sent) {
+            n_sent += records.size();
         }
-        sink.prepare_deferred(n_miss);
-        // Grow the rows, write each miss's positions, insert; same base+k ordering as insert_absent_terms.
-        // Kept as the dense reference sparse_resolve_tests.cpp differentially tests this path against.
-        const size_t base = local_op.store->grow_rows_geometric(n_miss);
-        for (size_t k = 0; k < n_miss; ++k) {
-            const auto &m = deferred_self_misses[k];
-            local_op.store->set_positions(base + k,
-                                          std::span<const RowPosT>(deferred_pos_flat_).subspan(m.pos_at, m.k));
-            sink.emit_deferred(k, base + k, m.src, m.phase, m.v_src);
+        sink.reserve_halves(join.queries() + n_sent);
+        misses.reserve(join.queries() - join.hits());
+
+        // Round 2's send buffer. A sink that answers nothing keeps an empty local rather than naming the
+        // shared one, so nothing charges it what an earlier fused call left there.
+        std::vector<VecZ> responses;
+        if constexpr (Sink::wants_responses) {
+            responses.assign(R, VecZ{});
         }
-        local_op.reindex_after_growth(base, n_miss);
+        size_t answered = 0;
+        if (n_self != 0) {
+            answered =
+                join_self<NumModes>(scan.self, join, /*q_base=*/0, marks, my_rank, base, misses, sink, sent_self);
+        }
+        answered += join_incoming<NumModes>(pr, join, /*q_base=*/n_self, marks, base, misses, sink, responses);
+
+        // Round 1 at its widest: the scan's arrays, the delivered records and the staged responses.
+        stamp_gate_buffers_(scan, scratch.incoming_wire, responses, /*extra=*/0);
+        run_round_two_(scan, responses, views, base);
+        absence_pass<NumModes>(marks, scan.sent, scan.sent_c0, sink);
+
+        scratch.counters.gates += 1;
+        scratch.counters.records += n_sent;
+        if constexpr (Sink::wants_responses) {
+            scratch.counters.responses += answered;
+        }
     }
 
     auto finish(CosMask &&cos_all, CosMask *out_cos = nullptr) -> std::shared_ptr<LayerCore> {
-        insert_deferred_self_misses();
         return sink.finalize(std::move(cos_all), out_cos, combined_size, local_op);
     }
 
 private:
-    // Response counts are the transpose of the query counts (one answer per query), so passing them as
-    // known_recv_counts skips the response count-Alltoall round.
-    auto response_recv_counts() const -> std::vector<int> {
-        std::vector<int> counts(R);
-        for (size_t r = 0; r < R; ++r) {
-            // One response per query, and src_idx_r[r] holds one source per query: no walk, no division.
-            counts[r] = static_cast<int>(src_idx_r[r].size());
+    /*! @brief Round 2: the responses out, the misses inserted under them, the answers applied.
+     *
+     *  The same verb with the response counts, posted before the inserts so the store's growth overlaps
+     *  the peers' answers. Its slot set is round 1's: the rank shift is an involution, so a slot a record
+     *  came from is a slot this one can send to. The inserts' order against apply_responses is what the
+     *  result depends on, and that is what fixes their place here (mint indices were assigned against
+     *  `base` before this call).
+     */
+    auto run_round_two_(const FusedScanResult<NumModes> &scan,
+                        std::vector<VecZ> &responses,
+                        std::vector<std::span<const size_t>> &views,
+                        size_t base) -> void {
+        std::optional<mpi::PendingAlltoallv<size_t>> answering;
+        if constexpr (Sink::wants_responses) {
+            if (R > 1) {
+                answering.emplace(
+                    mpi::begin_alltoallv(responses, comm, /*skip_self=*/false, /*known_recv_counts=*/nullptr, plan));
+            }
         }
-        return counts;
+        insert_misses<NumModes>(local_op, scratch.misses, base);
+        if constexpr (Sink::wants_responses) {
+            if (answering.has_value()) {
+                std::vector<VecZ> answers;
+                answering->wait_into(answers);
+                // Round 2 at its widest: round 1's buffers are all still in scope under the answers.
+                stamp_gate_buffers_(scan, scratch.incoming_wire, responses, wire_bytes_(answers));
+                apply_responses<NumModes>(scratch.marks, scan.sent, slot_streams(answers, views), sink);
+            }
+        }
     }
 
-    // Batched self-resolve over the term table's group-prefetch find_batch; hits/misses go to the sink
-    // in query order. `lv` is the per-query v_src array parallel to `ls` (read only when Sink::wants_values).
-    static constexpr size_t kResolveBatch = 64;
-    auto resolve_range_(std::vector<size_t> &ls, [[maybe_unused]] std::vector<double> *lv, bool is_leader_pass)
-        -> void {
-        const size_t op_size = local_op.store->size();
-        // Gathered per batch because a matched follower is skipped; offsets stay absolute into pos_flat.
-        std::array<size_t, kResolveBatch> pos_off;
-        std::array<uint32_t, kResolveBatch> k_of;
-        std::array<uint32_t, kResolveBatch> keys;
-        std::array<int, kResolveBatch> phases;
-        std::array<size_t, kResolveBatch> srcs;
-        std::array<double, kResolveBatch> vals;
-        std::array<size_t, kResolveBatch> found;
-        const size_t hi = self_stage_.size();
-        size_t q = 0;
-        while (q < hi) {
-            size_t m = 0;
-            for (; q < hi && m < kResolveBatch; ++q) {
-                const size_t src = ls[q];
-                if (!is_leader_pass && matched.is_marked(src)) {
-                    continue; // follower already matched by a leader → not an independent rotation
-                }
-                pos_off[m] = self_stage_.pos_off[q];
-                k_of[m] = self_stage_.k_of[q];
-                keys[m] = key_of_positions<2 * NumModes>(self_stage_.pos_flat.data() + pos_off[m], k_of[m]);
-                phases[m] = self_stage_.phase_of[q];
-                srcs[m] = src;
-                if constexpr (Sink::wants_values) {
-                    vals[m] = (*lv)[q];
-                }
-                ++m;
-            }
-            if (m == 0) {
-                break;
-            }
-            local_op.term_table().find_batch(
-                *local_op.store,
-                m,
-                [&keys](size_t j) { return keys[j]; },
-                [&](size_t j) { return std::span<const RowPosT>(self_stage_.pos_flat).subspan(pos_off[j], k_of[j]); },
-                std::span<size_t>(found).first(m));
-            for (size_t j = 0; j < m; ++j) {
-                double v_src = 0.0;
-                if constexpr (Sink::wants_values) {
-                    v_src = vals[j];
-                }
-                // kNotFound == kMissingIndex == size_t max, so one bound check covers both.
-                if (found[j] < op_size) {
-                    // Freshly inserted partners (found >= combined_size) skip the mark: combined_size bounds it.
-                    if (is_leader_pass && found[j] < combined_size) {
-                        matched.mark(found[j]);
-                    }
-                    sink.self_hit(srcs[j], found[j], phases[j], v_src);
-                }
-                else {
-                    // The stage dies with this pass and the misses are flushed after both, so copy now.
-                    const size_t at = deferred_pos_flat_.size();
-                    const auto *const first = self_stage_.pos_flat.data() + pos_off[j];
-                    deferred_pos_flat_.insert(deferred_pos_flat_.end(), first, first + k_of[j]);
-                    deferred_self_misses.push_back({at, k_of[j], srcs[j], phases[j], v_src});
-                }
-            }
+    static auto wire_bytes_(const std::vector<VecZ> &wire) -> size_t {
+        size_t bytes = wire.capacity() * sizeof(VecZ);
+        for (const VecZ &slot : wire) {
+            bytes += slot.capacity() * sizeof(size_t);
         }
+        return bytes;
+    }
+
+    /*! @brief Stamps the gate's per-gate buffers at one instant into the call's high-water mark.
+     *
+     *  @param extra Round 2's answers, which are live only at the second sample.
+     *
+     *  None of what it counts can be read back once the gate is over, which is the whole reason the
+     *  field exists; it overlaps the buffers the scratch owns for their capacity, so it is a `d_`
+     *  diagnostic beside the ledger and never a term in it.
+     */
+    auto stamp_gate_buffers_(const FusedScanResult<NumModes> &scan,
+                             const std::vector<VecZ> &incoming,
+                             const std::vector<VecZ> &responses,
+                             size_t extra) -> void {
+        size_t bytes = extra + wire_bytes_(scan.queries) + wire_bytes_(incoming) + wire_bytes_(responses)
+                       + scratch.misses.memory_bytes() + scratch.incoming_records.memory_bytes()
+                       + (scan.self.pos_flat.capacity() * sizeof(RowPosT))
+                       + (scan.self.pos_off.capacity() * sizeof(size_t)) + (scan.self.k_of.capacity() * 2)
+                       + (scan.self.phase_of.capacity()) + (scan.self.rot_of.capacity())
+                       + (scan.self.val_of.capacity() * sizeof(double)) + (scan.self.tag_of.capacity() * 4);
+        for (const auto &records : scan.sent) {
+            bytes += records.capacity() * sizeof(SentRecord);
+        }
+        for (const auto &c0 : scan.sent_c0) {
+            bytes += c0.capacity() * sizeof(double);
+        }
+        scratch.buffers_hwm_bytes = std::max(scratch.buffers_hwm_bytes, bytes);
     }
 };
 
@@ -565,7 +259,13 @@ static inline auto empty_coeffs() -> const VecD & {
     return coeffs;
 }
 
-// Primary-path layer builder: one fused scan, then two resolve passes into the chosen sink. See LayerBuilder.h.
+/*! @brief Primary-path layer builder: one fused scan, one exchange, one join into the chosen sink.
+ *
+ *  See LayerBuilder.h. `over_cutoff_possible` is the caller's per-call flag
+ *  (MonomialPropagator::run_gate_loop_): true when a tracked term may fail the structural cutoff, which
+ *  widens the scan's send predicate to every anticommuting term. It must be agreed across the comm, or
+ *  one side drops records the other expects.
+ */
 template <size_t NumModes>
 auto build_layer(MPOperator<NumModes> &local_op,
                  const Monomial<NumModes> &gen,
@@ -575,7 +275,8 @@ auto build_layer(MPOperator<NumModes> &local_op,
                  const std::optional<double> &upper_atol,
                  const std::optional<double> &param,
                  std::optional<size_t> only_rotate_len_k,
-                 MatchedEpochSet &matched_scratch,
+                 bool over_cutoff_possible,
+                 GateScratch<NumModes> &scratch,
                  mpi::Comm comm,
                  CosMask *out_cos = nullptr,
                  FusedContract *fused_contract = nullptr,
@@ -590,16 +291,19 @@ auto build_layer(MPOperator<NumModes> &local_op,
     // Hoisted here because mpi::geometry can reach the communicator, so it must never run per term.
     const routing::Router router = router_for<NumModes>(comm);
     assert(router.flat_world() == R);
+    // Under linear routing every record for THIS generator lands on the rank this rank's own index XOR
+    // rank_shift(gen), so the exchange knows its peer before it starts. Dense otherwise.
+    const auto plan =
+        mpi::PeerPlan{.sparse = router.is_linear(), .shift = static_cast<int>(router.rank_shift<NumModes>(gen))};
     // Fused contraction runs at all rank counts (R>1 via the cross-rank half-rotation exchange).
     const bool use_fused = (fused_contract != nullptr);
     const auto cut_st = build_majorana_evolution_cutoff_state(atol, local_coeffs, upper_atol, param);
     const auto &coeffs = local_coeffs.value_or(empty_coeffs()).get();
     const CutoffEvaluator<NumModes> cut_eval{cutoff_fn};
 
-    // Fused cos sweep: fold the per-gate cosine scale into the scan's own coefficient pass. No length cap only (a
-    // popcount>k hit is outside the per-index cos set, so 1/cos recovery would be wrong) and cos!=0 (else
-    // recovery is impossible; two-pass fallback). cos is even, so the sweep's cos(2·build_angle) matches
-    // the apply's cos(2·apply_angle) bit-for-bit.
+    // Fused cos sweep: fold the per-gate cosine into the scan's own coefficient pass. No length cap only
+    // (a popcount>k term is outside the per-index cos set) and cos!=0. cos is even, so the sweep's
+    // cos(2*build_angle) matches the apply's cos(2*apply_angle) bit-for-bit.
     const double cos_build = (use_fused && param.has_value()) ? std::cos(2.0 * param.value()) : 1.0;
     const bool fused_scale = use_fused && !only_rotate_len_k.has_value() && fused_scale_coeffs != nullptr
                              && param.has_value() && cos_build != 0.0;
@@ -609,38 +313,43 @@ auto build_layer(MPOperator<NumModes> &local_op,
     }
     assert(fused_scale_coeffs == nullptr || (local_coeffs && &local_coeffs->get() == fused_scale_coeffs));
 
-    // An identity generator anticommutes with nothing: the scan returns on its empty fold-column set
-    // with no query, no cosine block and no coefficient swept, and run_exchange's three collectives per
-    // pass would carry no payload. The generator list is replicated, so skipping needs no agreement.
-    // (These are the identity monomials a gate whose every term fell below its atol expands to; a zero
-    // chemical potential alone contributes 60 of the 60-site Hubbard's 476 generators per Trotter
-    // layer.) No gate is merged: a no-op gate is simply not exchanged for, and the layer is still built.
+    // An identity generator anticommutes with nothing, so there is nothing to scan or exchange. The
+    // generator list is replicated, so skipping it needs no agreement.
     const bool identity_gen = !gen.any();
-    // Under linear routing every query for THIS generator lands on the rank whose index is this rank's
-    // own XOR rank_shift(gen), so the exchange knows its peer before it starts. Dense otherwise, which
-    // is today's collective.
-    const auto plan =
-        mpi::PeerPlan{.sparse = router.is_linear(), .shift = static_cast<int>(router.rank_shift<NumModes>(gen))};
 
     FusedScanResult<NumModes> fused;
     CosMask cos_all;
+    // An identity generator skips the scan, so the fold's words it would have produced are emptied here.
+    scratch.nz.clear();
     if (!identity_gen) {
         double *const sweep_ptr = fused_scale ? fused_scale_coeffs->data() : nullptr;
+        // The fresh partner's pre-gate coefficient is state-scored only in the Schrödinger picture, and
+        // only the fused path needs it on the sender side (graph replay reads it off the extended vector).
+        std::optional<Monomial<NumModes>> state_mask;
+        if (use_fused && schrodinger) {
+            state_mask = initial_state_mask<NumModes>(local_op.initial_state);
+        }
         fused = with_algebra<NumModes>(basis, [&]<typename A>() {
-            return fused_find_and_collect<NumModes, A>(local_op,
-                                                       gen,
-                                                       cut_eval,
-                                                       cut_st,
-                                                       coeffs,
-                                                       only_rotate_len_k,
-                                                       router,
-                                                       my_rank,
-                                                       /*capture_values=*/use_fused,
-                                                       sweep_ptr,
-                                                       cos_build);
+            // capture_values selects the fused sink downstream, so it is a compile-time property of the
+            // whole scan rather than a flag each record re-tests.
+            auto run_scan = [&]<bool CaptureValues>() {
+                return fused_find_and_collect<NumModes, A, CaptureValues>(local_op,
+                                                                          gen,
+                                                                          cut_eval,
+                                                                          cut_st,
+                                                                          coeffs,
+                                                                          only_rotate_len_k,
+                                                                          over_cutoff_possible,
+                                                                          my_rank,
+                                                                          router,
+                                                                          scratch,
+                                                                          sweep_ptr,
+                                                                          cos_build,
+                                                                          state_mask ? &*state_mask : nullptr);
+            };
+            return use_fused ? run_scan.template operator()<true>() : run_scan.template operator()<false>();
         });
         if (fused.cos_blocks.size() == 1) {
-            // The serial scan produces a single cosine block set — take it wholesale.
             cos_all = std::move(fused.cos_blocks[0]);
         }
         else {
@@ -658,48 +367,32 @@ auto build_layer(MPOperator<NumModes> &local_op,
                                              comm,
                                              R,
                                              my_rank,
-                                             matched_scratch,
+                                             scratch,
                                              /*combined_size=*/local_op.store->size(),
                                              std::move(sink),
                                              plan);
-        // LayerBuildEngine construction stays outside the test: its ctor sizes the caller-owned matched
-        // scratch, which is reported as matched_scratch_bytes, so skipping it would move that telemetry
-        // when a propagator's first gate is identity. The ctor is O(R).
         if (!identity_gen) {
-            eng.run_exchange(/*is_leader_pass=*/true,
-                             std::move(fused.leader_queries),
-                             std::move(fused.leader_src),
-                             std::move(fused.leader_val),
-                             std::move(fused.leader_self));
-            eng.run_exchange(/*is_leader_pass=*/false,
-                             std::move(fused.follower_queries),
-                             std::move(fused.follower_src),
-                             std::move(fused.follower_val),
-                             std::move(fused.follower_self));
+            eng.exchange_and_join(std::move(fused));
         }
-
         return eng.finish(std::move(cos_all), out_cos);
     };
 
     std::shared_ptr<LayerCore> storage;
     if (use_fused) {
-        const double inv_cos = fused_scale ? 1.0 / cos_build : 1.0; // pre-cos recovery factor for hit v_tgt
-        storage = run(ContractSink<NumModes>{.R = R,
-                                             .my_rank = my_rank,
-                                             .fc = *fused_contract,
-                                             .op_coeffs = coeffs,
+        // fl(1/cos_build), once per gate, which is exactly where the two-pass protocol computed it.
+        const double inv_cos = fused_scale ? 1.0 / cos_build : 1.0;
+        storage = run(ContractSink<NumModes>{.fc = *fused_contract,
                                              .fused_scale = fused_scale,
-                                             .inv_cos = inv_cos,
-                                             .schrodinger = schrodinger,
-                                             .basis = basis});
+                                             .op_coeffs = coeffs,
+                                             .cos_build = cos_build,
+                                             .inv_cos = inv_cos});
     }
     else {
         storage = run(GraphSink<NumModes>{R, my_rank});
     }
-
     // Recompute metadata rides with the layer so it survives every graph transform. scaled_count is the
     // post-insert operator size: the fold truncated to it reproduces the "all anticommuting" cos
-    // bit-for-bit with no stored bitmap. Fused mode has no LayerCore to stamp.
+    // bit-for-bit with no stored bitmap.
     if (storage != nullptr) {
         storage->generator_words.assign(gen.data(), gen.data() + mpi_detail::kWords<NumModes>);
         storage->scaled_count = static_cast<uint64_t>(local_op.store->size());

--- a/cpp/monoprop/detail/evolution/layer_build/FusedApply.h
+++ b/cpp/monoprop/detail/evolution/layer_build/FusedApply.h
@@ -22,62 +22,36 @@
 
 namespace monoprop::detail {
 
-// The drain paired with build_layer's fused emission: complete each rotation by adding its sine term
-// directly to op_coeffs (the ContractImmediately forward path at all rank counts). The gate's cosine
-// scale reaches the coefficients two ways:
-//   • fused_scale (no length cap, default): the scan already scaled every anticommuting coeff, so no cos pass runs
-//     here; slots born after that sweep (fresh inserts) fold cos in via their apply arm below.
-//   • two-pass (length cap / cos==0 fallback): scale_cos_mask runs here, then every arm is a plain add.
-// At R>1 each rank applies only the add to the slot it owns (half rotations in fc.cross_half).
-inline auto apply_fused_contract(FusedContract &fc,
-                                 VecD &op_coeffs,
-                                 const CosMask &cos,
-                                 double param,
-                                 bool schrodinger,
-                                 bool fused_scale) -> void {
-    // (1) insert records: v_tgt is the freshly-inserted term's pre-cos coeff, readable only now op_coeffs
-    // is extended. Needed only in Schrödinger — a Heisenberg fresh insert has coeff 0, so skip the gather.
-    if (schrodinger) {
-        for (size_t k = 0; k < fc.inserts.size(); ++k) {
-            fc.inserts[k].v_tgt = op_coeffs[fc.inserts[k].tgt];
-        }
-    }
-
-    // (2) Two-pass mode only: cos scale over all anticommuting endpoints (inserts included).
+// The drain paired with build_layer's fused emission: complete each rotation by adding its half to
+// op_coeffs (the ContractImmediately forward path at all rank counts). The gate's cosine scale reaches
+// the coefficients two ways:
+//   • fused_scale (no length cap, default): the scan already scaled every anticommuting coeff, so no cos
+//     pass runs here; slots born after that sweep (mints) fold cos in via their insert arm below.
+//   • two-pass (length cap / cos==0 fallback): scale_cos_mask runs here, then every half is a plain add.
+inline auto apply_fused_contract(FusedContract &fc, VecD &op_coeffs, const CosMask &cos, double param, bool fused_scale)
+    -> void {
     const double cos_val = std::cos(2 * param);
     const double sin_val = std::sin(2 * param);
     double *const c = op_coeffs.data();
     if (!fused_scale) {
         scale_cos_mask(c, cos, cos_val);
     }
-
-    // (3) One pass over hits ++ inserts ++ cross_half. Each op slot is touched by exactly one add (pivot
-    // split + ⊕G-injective targets + drop_matched_cross_rank_followers), which is what makes the plain +=
-    // safe. In fused_scale mode a slot born after the sweep (insert targets, resolver miss halves) folds
-    // the gate's cos in here (c = cos·c + sin).
-    const size_t n_hit = fc.hits.size();
-    const size_t n_full = n_hit + fc.inserts.size();
-    const size_t n_cross = fc.cross_half.size();
-    for (size_t k = 0; k < n_full + n_cross; ++k) {
-        if (k < n_full) {
-            const bool is_insert = k >= n_hit;
-            const RotationRec &r = is_insert ? fc.inserts[k - n_hit] : fc.hits[k];
-            c[r.src] += sin_val * static_cast<double>(-r.phase) * r.v_tgt;
-            if (fused_scale && is_insert) {
-                c[r.tgt] = cos_val * c[r.tgt] + sin_val * static_cast<double>(r.phase) * r.v_src;
-            }
-            else {
-                c[r.tgt] += sin_val * static_cast<double>(r.phase) * r.v_src;
-            }
+    // Each op slot is touched by exactly one half (one partner per term, ^G-injective mints), which is
+    // what makes the add safe in any order.
+    //
+    // Both arms name their rounding with std::fma rather than leave it to -ffp-contract. Written as
+    // `c += sin*phi*v` the plain arm is not free of the branch it shares with the insert arm: GCC hoists
+    // the common sin*phi*v product above the is_insert test and the plain arm is left with a bare add, so
+    // it rounds TWICE where the same expression in an unmerged loop contracts to one vfmadd. One rounding
+    // is both the more accurate form and the one the pre-merge apply emitted, and the two shapes differ
+    // by 1 ULP on real data -- so the form is pinned here rather than left to codegen.
+    for (const HalfRotationRec &h : fc.halves) {
+        const double sin_phase = sin_val * static_cast<double>(h.phase_signed);
+        if (fused_scale && h.is_insert) {
+            c[h.local_idx] = std::fma(cos_val, c[h.local_idx], sin_phase * h.v_partner);
         }
         else {
-            const HalfRotationRec &h = fc.cross_half[k - n_full];
-            if (fused_scale && h.is_insert) {
-                c[h.local_idx] = cos_val * c[h.local_idx] + sin_val * static_cast<double>(h.phase_signed) * h.v_partner;
-            }
-            else {
-                c[h.local_idx] += sin_val * static_cast<double>(h.phase_signed) * h.v_partner;
-            }
+            c[h.local_idx] = std::fma(sin_phase, h.v_partner, c[h.local_idx]);
         }
     }
 }

--- a/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
+++ b/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
@@ -1,0 +1,280 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Per-partition scratch the layer build reuses from gate to gate. Nothing here carries state between
+// gates -- every member is re-initialised by the gate that uses it -- so it is owned by the propagator
+// only to keep its capacity, and a copied propagator starts with an empty one. `counters` is the one
+// exception: it accumulates over a call, and its owner resets it (MonomialPropagator::run_gate_loop_).
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "monoprop/TypeAliases.h"
+#include "monoprop/detail/evolution/layer_build/Common.h"
+#include "monoprop/detail/evolution/layer_build/TableJoin.h"
+#include "monoprop/detail/operator/OperatorIndex.h"
+
+namespace monoprop::detail {
+
+/*! @brief The protocol's per-row state for one gate (Engine.h has the rules), as six bitsets over rows.
+ *
+ *  The scan sets `rot` (the term's own emission predicate) and `foll` (the pivot bit: which endpoint of
+ *  a pair the row is); the probe sets `matched` the moment a record confirms the row; the resolve sets
+ *  `received` (the partner's record arrived, i.e. the partner is tracked) and `partner_rot` (that
+ *  record's rot bit); round 2 sets `answered` (the partner is tracked but silent, and sent its
+ *  coefficient back instead of a record).
+ *
+ *  Only rows of Anti(G) are ever set or read, and Anti(G) is exactly the set bits of the gate's `nz`
+ *  words, so a gate clears its state by zeroing one word per nz word rather than the whole operator's
+ *  worth of bits. Rows inserted by the gate's own mints are past the pre-gate size and carry no state.
+ */
+class RowMarks {
+public:
+    /*! @brief Sizes the bitsets to `n_rows`, rebinds the six bases, and clears the words `nz` names.
+     *
+     *  Must run after the fold's pass 1 (which produces `nz`) and before the emit pass sets a bit -- and
+     *  it is the only place the vectors can move, which is what makes the bases good for the whole gate.
+     */
+    auto begin(size_t n_rows, std::span<const EvenParityNzWord> nz) -> void {
+        const size_t words = (n_rows + 63) / 64;
+        for (auto *bits : arrays_()) {
+            if (bits->size() < words) {
+                bits->resize(words, 0);
+            }
+        }
+        bind_();
+        // The six bases in registers for the whole clear: `arrays_()` would otherwise rebuild its
+        // pointer array once per anticommuting word.
+        uint64_t *const rot = rot_;
+        uint64_t *const foll = foll_;
+        uint64_t *const matched = matched_;
+        uint64_t *const received = received_;
+        uint64_t *const partner_rot = partner_rot_;
+        uint64_t *const answered = answered_;
+        for (const auto &w : nz) {
+            const size_t wi = w.base / 64;
+            rot[wi] = 0;
+            foll[wi] = 0;
+            matched[wi] = 0;
+            received[wi] = 0;
+            partner_rot[wi] = 0;
+            answered[wi] = 0;
+        }
+    }
+
+    auto set_rot(size_t row) -> void { set_(rot_, row); }
+    auto set_foll(size_t row) -> void { set_(foll_, row); }
+    //! The whole pivot word at once: `nz` already carries word `word`'s followers, and begin() has just
+    //! zeroed it, so the scan sets them in one store instead of one per anticommuting row.
+    auto set_foll_word(size_t word, uint64_t bits) -> void { foll_[word] = bits; }
+    auto set_matched(size_t row) -> void { set_(matched_, row); }
+    auto set_received(size_t row) -> void { set_(received_, row); }
+    auto set_partner_rot(size_t row) -> void { set_(partner_rot_, row); }
+    auto set_answered(size_t row) -> void { set_(answered_, row); }
+    [[nodiscard]] auto rot(size_t row) const -> bool { return get_(rot_, row); }
+    [[nodiscard]] auto foll(size_t row) const -> bool { return get_(foll_, row); }
+    [[nodiscard]] auto matched(size_t row) const -> bool { return get_(matched_, row); }
+    [[nodiscard]] auto received(size_t row) const -> bool { return get_(received_, row); }
+    [[nodiscard]] auto partner_rot(size_t row) const -> bool { return get_(partner_rot_, row); }
+    [[nodiscard]] auto answered(size_t row) const -> bool { return get_(answered_, row); }
+
+    [[nodiscard]] auto memory_bytes() const -> size_t {
+        size_t bytes = 0;
+        for (const auto *bits : arrays_()) {
+            bytes += bits->capacity() * sizeof(uint64_t);
+        }
+        return bytes;
+    }
+
+private:
+    static auto set_(uint64_t *bits, size_t row) -> void { bits[row >> 6U] |= uint64_t{1} << (row & 63U); }
+    static auto get_(const uint64_t *bits, size_t row) -> bool { return ((bits[row >> 6U] >> (row & 63U)) & 1U) != 0; }
+    auto bind_() -> void {
+        rot_ = rot_words_.data();
+        foll_ = foll_words_.data();
+        matched_ = matched_words_.data();
+        received_ = received_words_.data();
+        partner_rot_ = partner_rot_words_.data();
+        answered_ = answered_words_.data();
+    }
+    auto arrays_() -> std::array<std::vector<uint64_t> *, 6> {
+        return {&rot_words_, &foll_words_, &matched_words_, &received_words_, &partner_rot_words_, &answered_words_};
+    }
+    auto arrays_() const -> std::array<const std::vector<uint64_t> *, 6> {
+        return {&rot_words_, &foll_words_, &matched_words_, &received_words_, &partner_rot_words_, &answered_words_};
+    }
+
+    std::vector<uint64_t> rot_words_;
+    std::vector<uint64_t> foll_words_;
+    std::vector<uint64_t> matched_words_;
+    std::vector<uint64_t> received_words_;
+    std::vector<uint64_t> partner_rot_words_;
+    std::vector<uint64_t> answered_words_;
+    // The bitsets' bases, rebound by begin() and valid for the gate it opened: a single load off `this`
+    // instead of a load of the owning vector's data pointer, on every mark this gate sets or reads.
+    // Null until the first begin(), which every path that touches a mark runs first. A copy of a
+    // GateScratch would carry the source's bases, so the propagator's copy constructor default-builds
+    // its scratch rather than copying it (MonomialPropagator.inl).
+    uint64_t *rot_ = nullptr;
+    uint64_t *foll_ = nullptr;
+    uint64_t *matched_ = nullptr;
+    uint64_t *received_ = nullptr;
+    uint64_t *partner_rot_ = nullptr;
+    uint64_t *answered_ = nullptr;
+};
+
+/*! @brief The keys that missed, in join order: miss j becomes row base + j.
+ *
+ *  Keys are source^G over globally distinct sources and ^G is injective, so the keys of one gate are
+ *  pairwise distinct and every miss is a distinct absent monomial, whichever slot or record it came from.
+ */
+template <size_t NumModes>
+struct MissStage {
+    using PosT = typename OperatorIndex<NumModes>::PosT;
+
+    DefaultInitVector<PosT> pos_flat;
+    std::vector<size_t> pos_off;
+    std::vector<uint16_t> k_of;
+
+    [[nodiscard]] auto size() const -> size_t { return k_of.size(); }
+    //! Sizes the per-miss arrays to the join's exact mint upper bound, so push() never reallocates them.
+    auto reserve(size_t n) -> void {
+        pos_off.reserve(n);
+        k_of.reserve(n);
+    }
+    auto clear() -> void {
+        pos_flat.clear();
+        pos_off.clear();
+        k_of.clear();
+    }
+    auto push(std::span<const PosT> pos) -> void {
+        pos_off.push_back(pos_flat.size());
+        k_of.push_back(static_cast<uint16_t>(pos.size()));
+        pos_flat.insert(pos_flat.end(), pos.begin(), pos.end());
+    }
+    [[nodiscard]] auto positions_at(size_t j) const -> std::span<const PosT> {
+        return std::span<const PosT>(pos_flat).subspan(pos_off[j], k_of[j]);
+    }
+    [[nodiscard]] auto memory_bytes() const -> size_t {
+        return (pos_flat.capacity() * sizeof(PosT)) + (pos_off.capacity() * sizeof(size_t))
+               + (k_of.capacity() * sizeof(uint16_t));
+    }
+};
+
+/*! @brief The records one exchange delivered, decoded (Resolve.h decode_incoming_records fills it).
+ *
+ *  Record g belongs to the sender at slot s iff goff[s] <= g < goff[s+1]; within a sender they are in
+ *  the sender's stream order.
+ */
+template <size_t NumModes>
+struct IncomingRecords {
+    // The operator store's position width, not the wire's: these positions exist to become rows.
+    using PosT = typename OperatorIndex<NumModes>::PosT;
+
+    std::vector<size_t> goff;           // slots+1 flat offsets: g = goff[s] + q
+    DefaultInitVector<int8_t> phase_of; // g -> record phase
+    DefaultInitVector<uint8_t> rot_of;  // g -> record rot bit
+    DefaultInitVector<double> val_of;   // g -> record value; sized only for the Fused form
+    size_t nq_total = 0;
+
+    // The keys as they arrived, flat: record g owns pos_flat[pos_off[g] .. pos_off[g] + k_of[g]).
+    DefaultInitVector<PosT> pos_flat;
+    DefaultInitVector<size_t> pos_off;
+    // g -> positions in the key. A popcount of a 2*NumModes bitset, which QueryWire already requires to
+    // fit a uint16_t (its kBits static_assert), so this is the wire's own width.
+    DefaultInitVector<uint16_t> k_of;
+    // g -> the key's join tag, folded off the decoded positions: the join's key for this record. The
+    // 32-bit tag rather than the 64-bit fingerprint it projects, because the join wants nothing else and
+    // the wire is unchanged either way (RowKey.h join_tag).
+    DefaultInitVector<uint32_t> tag_of;
+
+    //! Record g's ascending positions, as a view into pos_flat.
+    [[nodiscard]] auto positions_at(size_t g) const -> std::span<const PosT> {
+        return std::span<const PosT>(pos_flat).subspan(pos_off[g], k_of[g]);
+    }
+    [[nodiscard]] auto value_at(size_t g) const -> double { return val_of.empty() ? 0.0 : val_of[g]; }
+    [[nodiscard]] auto memory_bytes() const -> size_t {
+        return (goff.capacity() * sizeof(size_t)) + (phase_of.capacity() * sizeof(int8_t))
+               + (rot_of.capacity() * sizeof(uint8_t)) + (val_of.capacity() * sizeof(double))
+               + (pos_flat.capacity() * sizeof(PosT)) + (pos_off.capacity() * sizeof(size_t))
+               + (k_of.capacity() * sizeof(uint16_t)) + (tag_of.capacity() * sizeof(uint32_t));
+    }
+};
+
+/*! @brief Gives a per-gate buffer back when it has run far past what it last held.
+ *
+ *  The engine's release rule, one definition: a buffer whose capacity has run past 4x its content
+ *  gives the storage back and re-earns it, so one very wide gate cannot pin the partition's footprint
+ *  for the rest of the call. `kFloor` keeps the tiny buffers alone.
+ */
+template <typename Vector>
+inline auto release_if_oversized(Vector &v, size_t held) -> void {
+    constexpr size_t kFloor = 64;
+    if (v.capacity() > 4 * std::max(held, kFloor)) {
+        v = Vector{};
+    }
+}
+
+template <size_t NumModes>
+struct GateScratch {
+    using PosT = typename OperatorIndex<NumModes>::PosT;
+
+    TableJoin<NumModes> join;         // this gate's records probed against the operator's term table
+    RowMarks marks;                   // the protocol's per-row bits for this gate's anticommuting rows
+    std::vector<EvenParityNzWord> nz; // the fold's nonzero words: Anti(G), read by the emit pass and the join
+    std::vector<PosT> partner;        // one partner's positions; sized 2*NumModes, the partner's upper bound
+    std::vector<uint16_t> gen;        // the generator's ascending positions, the merge's second input
+    // The gate's mints, in join order, and the records the exchange delivered. Both die with the gate,
+    // and both are here rather than on the engine so that their storage does not: a gate would otherwise
+    // pay ~12 allocations and log2(mints) reallocations for buffers the previous gate had already sized.
+    MissStage<NumModes> misses;
+    IncomingRecords<NumModes> incoming_records;
+    std::vector<VecZ> incoming_wire; // the collective's receive buffer, one slot per flat slot
+    // How many records the previous gate of this partition staged for itself: what the next gate's
+    // self-slot reserve is sized from (Scan.h). A hint only -- wrong in either direction it costs at most
+    // a few pushes their geometric grow -- which is why it may cross gates although nothing else here does.
+    size_t self_records_hint = 0;
+    ExchangeCounters counters; // COMMPROF's per-call wire volume; reset by the caller, not per gate
+    // Widest instant of the gate's per-gate buffers over the call, in bytes. Those buffers die with the
+    // gate or are resized under it, so no resting field can name their peak; reset by the caller
+    // alongside `counters`.
+    size_t buffers_hwm_bytes{0uz};
+
+    //! Re-windows the collective receive buffer for a world of `slots`, under the release rule.
+    auto reuse_incoming_wire(size_t slots) -> void {
+        for (VecZ &slot : incoming_wire) {
+            release_if_oversized(slot, slot.size());
+            slot.clear();
+        }
+        incoming_wire.resize(slots);
+    }
+
+    [[nodiscard]] auto memory_bytes() const -> size_t {
+        size_t wire = incoming_wire.capacity() * sizeof(VecZ);
+        for (const VecZ &slot : incoming_wire) {
+            wire += slot.capacity() * sizeof(size_t);
+        }
+        return join.memory_bytes() + marks.memory_bytes() + (nz.capacity() * sizeof(EvenParityNzWord))
+               + (partner.capacity() * sizeof(PosT)) + (gen.capacity() * sizeof(uint16_t))
+               + misses.memory_bytes() + incoming_records.memory_bytes() + wire;
+    }
+};
+
+} // namespace monoprop::detail

--- a/cpp/monoprop/detail/evolution/layer_build/GateSinks.h
+++ b/cpp/monoprop/detail/evolution/layer_build/GateSinks.h
@@ -1,0 +1,240 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#pragma once
+
+// The two sinks the gate exchange resolves into. A sink owns the divergent state and supplies the
+// surfaces Resolve.h lists plus finalize; each monomorphizes, so there is no run-time fused/graph branch.
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "monoprop/TypeAliases.h"
+#include "monoprop/detail/evolution/layer_build/Common.h"
+#include "monoprop/detail/evolution/layer_build/GateScratch.h"
+#include "monoprop/detail/evolution/layer_build/QueryWire.h"
+#include "monoprop/detail/graph_encoding/MPGraphEncodingStorage.h"
+#include "monoprop/detail/operator/MPOperator.h"
+
+namespace monoprop::detail {
+
+// Every rotation target must be in cos so the gradient reverse-sweep can un-do this layer's cosine
+// scaling; only freshly inserted half-terms can be absent (see tests/test_infinite_cutoff.py), and those
+// sit in [combined_size, op.size()). Scan cos bits and inserted endpoint bits are disjoint, so only the
+// seam word can carry both — bitwise-or that one, append the rest, keeping blocks ascending/disjoint.
+template <size_t NumModes>
+inline auto append_inserted_endpoints(CosMask &cos_all, size_t combined_size, const MPOperator<NumModes> &op) -> void {
+    const size_t cos_lo = combined_size;
+    const size_t cos_hi = op.store->size();
+    CosineWordBuilder end_b;
+    for (size_t idx = cos_lo; idx < cos_hi; ++idx) {
+        end_b.push_index(idx);
+    }
+    CosMask end_words = end_b.finish();
+    cos_all.total_count += end_words.total_count;
+    if (!cos_all.blocks.empty() && !end_words.blocks.empty()
+        && end_words.blocks.front().first == cos_all.blocks.back().first) {
+        cos_all.blocks.back().second |= end_words.blocks.front().second;
+        cos_all.blocks.insert(cos_all.blocks.end(), end_words.blocks.begin() + 1, end_words.blocks.end());
+    }
+    else {
+        cos_all.blocks.insert(cos_all.blocks.end(), end_words.blocks.begin(), end_words.blocks.end());
+    }
+}
+
+/*! @brief Graph-build sink: collects the per-slot PartnerAcc endpoints and assembles a LayerCore.
+ *
+ *  wants_values=false -- the scan captures no coefficients and every rotation records only
+ *  (index, phase), so no term is silent and no response can be needed: the symmetric send predicate and
+ *  the four ordered lists its positional replay is proved on both stand.
+ *
+ *  Roles in a pair are decided by the pivot bit (`RowMarks::foll`): a term and its partner differ exactly
+ *  on G's bits and the pivot is one of them, so exactly one endpoint of a tracked pair carries it. Per
+ *  peer slot q, with the join's arrival order = q's stream order = ascending row at q:
+ *    in_pairs        hits on my follower rows whose pair rotates    (arrival order) (row(partner), phi_rec)
+ *    in_mints        rot=1 misses                                   (arrival order) (base+j, phi_rec)
+ *    out_pairs       my leaders with received and (rot or partner_rot)  (ascending row) (row, phi_own)
+ *    out_unanswered  my rot and not received                        (ascending row) (row, phi_own)
+ *  Replay's positional pairing needs my out[j] and q's in[j] to be the same pair: my out_pairs are q's
+ *  in_pairs (q's followers whose leader is at p), both in ascending-leader order; my out_unanswered are
+ *  q's in_mints (my E-records that missed at q), both in my stream order. The in-pair takes the leader's
+ *  phase, the out-pair its own, so sin_recv's (out, -phi) / (in, +phi) split reproduces the two adds.
+ */
+template <size_t NumModes>
+struct GraphSink {
+    static constexpr bool wants_values = false;
+    static constexpr bool wants_responses = false;
+    [[nodiscard]] auto incoming_form() const -> QueryForm { return QueryForm::Plain; }
+
+    size_t R;
+    size_t my_rank;
+    std::vector<PartnerAcc> acc; // flat [R]: finalize hands it to build_layer_storage_unified
+
+    GraphSink(size_t R_, size_t my_rank_) : R(R_), my_rank(my_rank_), acc(R_) {}
+
+    auto hit(size_t slot, size_t row, double /*v*/, int phase, bool foll, bool /*own_rot*/) -> void {
+        if (foll) {
+            acc[slot].in_pairs.push_back({row, phase});
+        }
+    }
+    auto mint(size_t slot, size_t idx, double /*v*/, int phase) -> void { acc[slot].in_mints.push_back({idx, phase}); }
+    auto out_pair(size_t slot, size_t row, int phase) -> void { acc[slot].out_pairs.push_back({row, phase}); }
+    auto out_unanswered(size_t slot, size_t row, double /*c0*/, int phase) -> void {
+        acc[slot].out_unanswered.push_back({row, phase});
+    }
+    // Nothing to size: the four lists are per peer slot, and a bound over the whole gate says nothing
+    // about how the halves split between the slots.
+    auto reserve_halves(size_t /*upper_bound*/) -> void {}
+
+    /*! @brief Drains the per-slot accumulators into the LayerCore's sin_send/sin_recv lists.
+     *
+     *  Layout derivation: see cross_rank_sin_recv_index. sin_send = [in..., out...],
+     *  sin_recv = [(out, -phi)..., (in, +phi)...]. cos covers all anticommuting indices, endpoints
+     *  included, since the sin_recv apply only adds the sine term.
+     */
+    auto finalize(CosMask &&cos_all, CosMask *out_cos, size_t combined_size, MPOperator<NumModes> &op)
+        -> std::shared_ptr<LayerCore> {
+        std::vector<CrossRankPartnerData> partners(R);
+        for (size_t r = 0; r < R; ++r) {
+            const auto &a = acc[r];
+            auto &p = partners[r];
+            const size_t P = a.in_count();
+            const size_t Q = a.out_count();
+            if (P + Q == 0) {
+                continue;
+            }
+            p.in_count = P; // boundary for deriving the sin_recv index list from sin_send (not stored)
+            p.sin_send_indices.resize(P + Q);
+            p.sin_recv_entries.resize(P + Q);
+            size_t k = 0;
+            for (const auto *list : {&a.in_pairs, &a.in_mints}) {
+                for (const auto &e : *list) {
+                    p.sin_send_indices[k] = e.idx;
+                    p.sin_recv_entries[Q + k] = {e.idx, e.phase};
+                    ++k;
+                }
+            }
+            size_t j = 0;
+            for (const auto *list : {&a.out_pairs, &a.out_unanswered}) {
+                for (const auto &e : *list) {
+                    p.sin_send_indices[P + j] = e.idx;
+                    p.sin_recv_entries[j] = {e.idx, -e.phase};
+                    ++j;
+                }
+            }
+        }
+        if (out_cos != nullptr) {
+            append_inserted_endpoints<NumModes>(cos_all, combined_size, op);
+            *out_cos = std::move(cos_all);
+        }
+        return build_layer_storage_unified(partners, my_rank);
+    }
+};
+
+/*! @brief Fused ContractImmediately sink: every half-rotation this slot owns goes straight into the
+ *  FusedContract (no LayerCore -- finalize returns nullptr), applied to op_coeffs by
+ *  apply_fused_contract.
+ *
+ *  wants_values=true: records carry the sender's pre-cos coefficient, which is the whole value the apply
+ *  needs.
+ */
+template <size_t NumModes>
+struct ContractSink {
+    static constexpr bool wants_values = true;
+    static constexpr bool wants_responses = true;
+    [[nodiscard]] auto incoming_form() const -> QueryForm { return QueryForm::Fused; }
+
+    FusedContract &fc;
+    bool fused_scale;      // the fused cos sweep ran: inserted endpoints fold cos in at the apply, not here
+    const VecD &op_coeffs;  // the very array the scan read, not a copy: under the sweep every
+                            // anticommuting slot in it already holds fl(c * cos)
+    double cos_build = 1.0; // cos(2*theta), the factor the sweep applied
+    double inv_cos = 1.0;   // fl(1/cos_build) under the sweep, 1.0 without it
+
+    /*! @brief One rotation half onto tracked row `row`, from the record that found it.
+     *
+     *  ONE endpoint of a rotating pair reads a partner value RECOVERED from its swept slot,
+     *  stored*(1/cos); the other reads the exact pre-cos double the record carries. Which is which is
+     *  not a free choice: the two-pass protocol built one rotation record per pair from the leader's
+     *  query, applying c[leader] from the follower's stored*(1/cos) while c[follower] took the leader's
+     *  value straight out of the scan's register. Reproducing that here means recovering exactly when
+     *  the half lands on a leader that EMITTED. `foll` is complementary across a pair (mu = nu ^ G flips
+     *  it), so the row's own pivot bit names the sender's side too and nothing extra crosses the wire.
+     */
+    auto hit(size_t /*slot*/, size_t row, double v, int phase, bool foll, bool own_rot) -> void {
+        const double v_partner = (fused_scale && own_rot && !foll) ? recovered_(v) : v;
+        push_half_(HalfRotationRec{row_of_(row), static_cast<int8_t>(phase), /*is_insert=*/false, v_partner});
+    }
+    //! A silent row is always the endpoint the sender's query FOUND, so its value is always recovered --
+    //! and here it is read straight off its own swept slot, the expression's original form.
+    [[nodiscard]] auto silent_value(size_t row) const -> double {
+        return fused_scale ? op_coeffs[row] * inv_cos : op_coeffs[row];
+    }
+    // The sender's half of an asymmetric pair, from the response its partner sent (or, on the self slot,
+    // from the silent hit directly): -phi * v, the same add the symmetric case gets off the partner's
+    // own record.
+    auto answer(size_t /*slot*/, size_t row, double v, int phase) -> void {
+        push_half_(HalfRotationRec{row_of_(row), static_cast<int8_t>(-phase), /*is_insert=*/false, v});
+    }
+    auto mint(size_t /*slot*/, size_t idx, double v, int phase) -> void {
+        push_half_(HalfRotationRec{row_of_(idx), static_cast<int8_t>(phase), /*is_insert=*/true, v});
+    }
+    auto out_pair(size_t /*slot*/, size_t /*row*/, int /*phase*/) -> void {}
+    // Pushed in Heisenberg too, where c0 is exactly 0.0: the signed-zero add is what a fresh Heisenberg
+    // partner's source received before, and skipping it would leave a coefficient sitting at -0.0 where
+    // the add turns it into +0.0.
+    auto out_unanswered(size_t /*slot*/, size_t row, double c0, int phase) -> void {
+        push_half_(HalfRotationRec{row_of_(row), static_cast<int8_t>(-phase), /*is_insert=*/false, c0});
+    }
+    // One allocation per gate instead of a doubling chain: `fc` is built fresh for each gate, so every
+    // half used to move once per reallocation. The bound is the caller's (Engine.h exchange_and_join).
+    auto reserve_halves(size_t upper_bound) -> void { fc.halves.reserve(upper_bound); }
+
+    // No LayerCore in the fused path -> nullptr. Two-pass fused (k>0 / cos==0 fallback) appends inserted
+    // endpoints so the immediate cos scale covers them; the fused cos sweep covers them in-place instead.
+    auto finalize(CosMask &&cos_all, CosMask *out_cos, size_t combined_size, MPOperator<NumModes> &op)
+        -> std::shared_ptr<LayerCore> {
+        if (out_cos != nullptr && !fused_scale) {
+            append_inserted_endpoints<NumModes>(cos_all, combined_size, op);
+            *out_cos = std::move(cos_all);
+        }
+        return nullptr;
+    }
+
+private:
+    // fl(fl(v * cos) * fl(1/cos)): the double the partner's own swept slot holds, reached from the
+    // record's pre-cos value because that partner's row is not on this rank. The sweep stored fl(v * cos)
+    // there exactly, so this is the same pair of roundings a load and a multiply of that slot would give.
+    [[nodiscard]] auto recovered_(double v) const -> double { return (v * cos_build) * inv_cos; }
+
+    // Every slot a half names is a row of this rank's own operator, and those are TermIndex-wide
+    // throughout the engine (the join's own entries carry them as uint32 too).
+    static auto row_of_(size_t row) -> TermIndex {
+        assert(row <= std::numeric_limits<TermIndex>::max() && "a half named a slot past the TermIndex ceiling");
+        return static_cast<TermIndex>(row);
+    }
+    // Holds the reserve honest: a bound that ever came out short would silently reintroduce the doubling
+    // chain rather than fail, so it is asserted at the only place that can notice.
+    auto push_half_(HalfRotationRec rec) -> void {
+        assert(fc.halves.size() < fc.halves.capacity() && "more halves than reserve_halves() was sized for");
+        fc.halves.push_back(rec);
+    }
+};
+
+} // namespace monoprop::detail

--- a/cpp/monoprop/detail/evolution/layer_build/PartnerMerge.h
+++ b/cpp/monoprop/detail/evolution/layer_build/PartnerMerge.h
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <ranges>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -30,16 +31,21 @@
 
 namespace monoprop::detail {
 
-/*! @brief The symmetric difference's length together with the count of cancelled positions. */
+/*! @brief The symmetric difference's length, the count of cancelled positions, and its paired modes. */
 struct MergedPartner {
     size_t count;   //!< positions written to out
     size_t overlap; //!< positions present in both inputs, which therefore cancelled
+    size_t paired;  //!< modes carrying BOTH of their positions in the output: the `d` of the (k, d) digest
 };
 
 /*! @brief Writes the symmetric difference of `a` and `b` to `out`.
  *
- *  Both inputs must be ascending, or the result is silently wrong; `out` needs room for
- *  `a.size() + b.size()`. One pass yields the positions and the overlap together.
+ *  Both inputs must be strictly ascending, or the result is silently wrong; `out` needs room for
+ *  `a.size() + b.size()`. One pass yields the positions, the overlap and the paired-mode count together,
+ *  so the structural cutoff (length_keeps / support_keeps) never reads a bitset. Mode m owns positions
+ *  (2m, 2m+1), so in ascending output a paired mode is an even position immediately followed by its
+ *  successor. Written out three times rather than through a lambda: on an earlier port GCC declined to
+ *  inline a five-capture closure into three call sites and the calls alone cost a third of the kernel.
  */
 template <std::ranges::contiguous_range Row, std::ranges::contiguous_range Gen, std::ranges::contiguous_range Out>
 [[gnu::always_inline]] inline auto merge_partner_positions(const Row &a, const Gen &b, Out &&out) noexcept
@@ -51,6 +57,10 @@ template <std::ranges::contiguous_range Row, std::ranges::contiguous_range Gen, 
     size_t j = 0;
     size_t n = 0;
     size_t overlap = 0;
+    size_t paired = 0;
+    // Seeded ODD so the (prev even && p == prev + 1) test cannot fire on the first emit: 1 is not a
+    // reachable prev + 1 either, since prev would have to be 0 and even.
+    size_t prev = 1;
     while (i < ka && j < kb) {
         const size_t pa = static_cast<size_t>(a[i]);
         const size_t pb = static_cast<size_t>(b[j]);
@@ -63,52 +73,101 @@ template <std::ranges::contiguous_range Row, std::ranges::contiguous_range Gen, 
         const size_t p = pa < pb ? pa : pb;
         i += static_cast<size_t>(pa < pb);
         j += static_cast<size_t>(pb < pa);
+        paired += static_cast<size_t>((prev % 2 == 0) && p == prev + 1);
         out[n++] = static_cast<PosT>(p);
+        prev = p;
     }
     for (; i < ka; ++i) {
-        out[n++] = static_cast<PosT>(a[i]);
+        const size_t p = static_cast<size_t>(a[i]);
+        paired += static_cast<size_t>((prev % 2 == 0) && p == prev + 1);
+        out[n++] = static_cast<PosT>(p);
+        prev = p;
     }
     for (; j < kb; ++j) {
-        out[n++] = static_cast<PosT>(b[j]);
+        const size_t p = static_cast<size_t>(b[j]);
+        paired += static_cast<size_t>((prev % 2 == 0) && p == prev + 1);
+        out[n++] = static_cast<PosT>(p);
+        prev = p;
     }
-    return {n, overlap};
+    return {n, overlap, paired};
 }
 
-/*! @brief Stages self-owned query positions for direct use by OperatorIndex's
- *  find_batch_positions and set_positions, with no encoding step.
+/*! @brief The paired modes of an ascending position list: an even position immediately followed by its
+ *  successor. The `d` of the (k, d) digest for a list the merge did not produce.
+ */
+template <typename PosT>
+[[nodiscard]] inline auto count_paired_positions(const PosT *pos, size_t k) noexcept -> size_t {
+    size_t d = 0;
+    for (size_t j = 0; j + 1 < k; ++j) {
+        const auto p = static_cast<size_t>(pos[j]);
+        if (p % 2 == 0 && static_cast<size_t>(pos[j + 1]) == p + 1) {
+            ++d;
+            ++j;
+        }
+    }
+    return d;
+}
+
+/*! @brief Stages the records addressed to this slot itself as positions, for direct use by the join and
+ *  OperatorIndex::set_positions, with no encoding step.
+ *
+ *  Carries exactly the fields a wire record does (QueryWire.h): key positions, phase, rot and, for the
+ *  fused form, the sender's value. `keeps_values` says whether the value column exists at all: the graph
+ *  sink captures none, and sizing it would cost 8 B per staged record for a column nothing reads. It
+ *  must be set before the first push and not changed after one.
  */
 template <size_t NumModes>
 struct SelfQueryStage {
     using PosT = typename OperatorIndex<NumModes>::PosT;
 
     //! Sized to capacity, not filled: the logical length is size()/positions(), not the vectors' own size().
-    DefaultInitVector<PosT> pos_flat;   //!< ascending positions, concatenated in push order
-    DefaultInitVector<size_t> pos_off;  //!< query -> absolute offset into pos_flat
-    DefaultInitVector<uint32_t> k_of;   //!< positions per query
+    DefaultInitVector<PosT> pos_flat;  //!< ascending positions, concatenated in push order
+    DefaultInitVector<size_t> pos_off; //!< query -> absolute offset into pos_flat
+    //! Positions per query. A record's key is a popcount of a 2*NumModes bitset, which QueryWire
+    //! already requires to fit a uint16_t (its kBits static_assert), so this is the wire's own width.
+    DefaultInitVector<uint16_t> k_of;
     DefaultInitVector<int8_t> phase_of; //!< emit_phase is ternary, so a byte is the whole range
+    DefaultInitVector<uint8_t> rot_of;  //!< the sender's rotation bit
+    DefaultInitVector<double> val_of;   //!< the sender's pre-cos coefficient; empty unless keeps_values
+    //! The query's join tag, key(M) ^ key(G) -- the whole of what the join needs of its identity, so
+    //! the 8-byte fingerprint it is a linear projection of is never staged (RowKey.h join_tag).
+    DefaultInitVector<uint32_t> tag_of;
+    bool keeps_values = false;
 
     [[nodiscard]] auto size() const -> size_t { return n_; }
     [[nodiscard]] auto positions() const -> size_t { return pos_n_; }
+    [[nodiscard]] auto positions_at(size_t q) const -> std::span<const PosT> {
+        return std::span<const PosT>(pos_flat).subspan(pos_off[q], k_of[q]);
+    }
+    //! The staged value of query `q`, or 0.0 when this stage keeps none.
+    [[nodiscard]] auto value_at(size_t q) const -> double { return keeps_values ? val_of[q] : 0.0; }
 
     auto clear() -> void {
         n_ = 0;
         pos_n_ = 0;
     }
 
+    //! Sizes the arrays for `n_queries` records of `positions_per_query` positions each. Capacity only:
+    //! size() is unchanged, so a reserve that turns out short only costs the pushes that outrun it a grow_.
     auto reserve(size_t n_queries, size_t positions_per_query) -> void {
         if (pos_off.size() < n_queries) {
             pos_off.resize(n_queries);
             k_of.resize(n_queries);
             phase_of.resize(n_queries);
+            rot_of.resize(n_queries);
+            tag_of.resize(n_queries);
+            if (keeps_values) {
+                val_of.resize(n_queries);
+            }
         }
         if (pos_flat.size() < n_queries * positions_per_query) {
             pos_flat.resize(n_queries * positions_per_query);
         }
     }
 
-    //! Appends one query's positions and its (offset, k, phase) record; grows only when capacity runs out.
+    //! Appends one record; grows only when capacity runs out.
     template <std::ranges::contiguous_range Pos>
-    auto push(const Pos &pos, int phase) -> void {
+    auto push(const Pos &pos, int phase, uint32_t tag, bool rot = false, double val = 0.0) -> void {
         assert(phase >= -1 && phase <= 1 && "emit_phase is ternary: rotation_sign, or REAL_PARTS entry");
         const size_t k = std::ranges::size(pos);
         const size_t n = n_;
@@ -121,8 +180,13 @@ struct SelfQueryStage {
         for (size_t j = 0; j < k; ++j) {
             dst[j] = pos[j];
         }
-        k_of[n] = static_cast<uint32_t>(k);
+        k_of[n] = static_cast<uint16_t>(k);
         phase_of[n] = static_cast<int8_t>(phase);
+        rot_of[n] = static_cast<uint8_t>(rot);
+        tag_of[n] = tag;
+        if (keeps_values) {
+            val_of[n] = val;
+        }
         n_ = n + 1;
         pos_n_ = at + k;
     }
@@ -138,6 +202,11 @@ private:
             pos_off.resize(want);
             k_of.resize(want);
             phase_of.resize(want);
+            rot_of.resize(want);
+            tag_of.resize(want);
+            if (keeps_values) {
+                val_of.resize(want);
+            }
         }
         if (pos_n_ + k > pos_flat.size()) {
             pos_flat.resize(std::max((pos_flat.size() * 2) + 256, pos_n_ + k));

--- a/cpp/monoprop/detail/evolution/layer_build/QueryWire.h
+++ b/cpp/monoprop/detail/evolution/layer_build/QueryWire.h
@@ -32,30 +32,36 @@ namespace monoprop::detail {
 /*! @brief `Fused` records carry a trailing value word after the positions; `Plain` ones do not. */
 enum class QueryForm { Plain, Fused };
 
-/*! @brief One term's wire record for a cross-rank query: its ascending set-bit positions,
- *  gap-coded, plus a phase.
+/*! @brief One term's wire record in the gate exchange: the partner's ascending set-bit positions,
+ *  gap-coded, plus the sender's emit phase and its rotation bit.
+ *
+ *  The record is what a term sends to the owner of its partner (Engine.h has the protocol): the key is
+ *  the partner's positions, `phase` is the sender's A::emit_phase, and `rot` is the sender's emission
+ *  predicate -- whether the sender alone would rotate the pair. A `Fused` record carries one trailing
+ *  word with the sender's pre-cos coefficient (`push_value`), bit-cast so it arrives exactly.
  *
  *  It replaces a fixed dense stride, which would spend one word per 64 modes however few bits a
- *  term actually sets. Fields pack LSB-first from word 0: a 2-bit phase biased to unsigned, a
- *  5-bit popcount @p k whose all-ones value escapes to a wider field, a 4-bit gap width @p gw,
- *  then the first position in `kPosBits` bits and the remaining k-1 positions as gaps of @p gw
- *  bits to their predecessor. Both k and gw are per-record, so a two-bit term and a full-support
- *  one each cost what they are.
+ *  term actually sets. Fields pack LSB-first from word 0: a 2-bit phase biased to unsigned, the
+ *  1-bit @p rot, a 5-bit popcount @p k whose all-ones value escapes to a wider field, a 4-bit gap
+ *  width @p gw, then the first position in `kPosBits` bits and the remaining k-1 positions as gaps
+ *  of @p gw bits to their predecessor. Both k and gw are per-record, so a two-bit term and a
+ *  full-support one each cost what they are.
  *
  *  At `NumModes = 128` (`kBits = 256`, so `kPosBits = 8`) a term at positions {3, 7, 8, 40} with
- *  phase +1 has k = 4 and gaps {3, 0, 31}, hence `gw = bit_width(31) = 5`:
+ *  phase +1 and rot set has k = 4 and gaps {3, 0, 31}, hence `gw = bit_width(31) = 5`:
  *
  *  @code
  *  bits  0..1   phase   2   +1, biased by 1
- *  bits  2..6   k       4   below kKEscape, so no wide-k field follows
- *  bits  7..10  gw      5
- *  bits 11..18  first   3
- *  bits 19..23  gap     3   7 - 3 - 1
- *  bits 24..28  gap     0   8 - 7 - 1
- *  bits 29..33  gap     31  40 - 8 - 1
+ *  bit   2      rot     1
+ *  bits  3..7   k       4   below kKEscape, so no wide-k field follows
+ *  bits  8..11  gw      5
+ *  bits 12..19  first   3
+ *  bits 20..24  gap     3   7 - 3 - 1
+ *  bits 25..29  gap     0   8 - 7 - 1
+ *  bits 30..34  gap     31  40 - 8 - 1
  *  @endcode
  *
- *  34 bits, so one word, against the four a 256-bit dense stride spends on the same term.
+ *  35 bits, so one word, against the four a 256-bit dense stride spends on the same term.
  */
 template <size_t NumModes>
 struct QueryWire {
@@ -69,12 +75,13 @@ struct QueryWire {
     static constexpr size_t kPosBits = static_cast<size_t>(std::bit_width(kBits - 1));
 
     static constexpr size_t kPhaseBits = 2;
+    static constexpr size_t kRotBits = 1;
     static constexpr size_t kKBits = 5;
     //! k is a popcount of a kBits bitset, so the escape field never needs more bits than this.
     static constexpr size_t kLongKBits = static_cast<size_t>(std::bit_width(kBits));
     static constexpr size_t kGwBits = 4;
     static constexpr size_t kKEscape = (1U << kKBits) - 1U;
-    static constexpr size_t kHeaderBits = kPhaseBits + kKBits + kGwBits;
+    static constexpr size_t kHeaderBits = kPhaseBits + kRotBits + kKBits + kGwBits;
     static_assert(kPosBits <= (1U << kGwBits) - 1U, "gw <= kPosBits must fit the header's gap-width field");
     static_assert(kHeaderBits + kLongKBits <= 64, "the widest header must be readable from word 0 alone");
 
@@ -87,6 +94,7 @@ struct QueryWire {
     struct Decoded {
         size_t next; //!< word offset just past what this call consumed
         int phase;   //!< the record's ternary phase
+        bool rot;    //!< the sender's rotation bit
     };
 
     /*! @brief Bit-packs variable-width fields into `buf`, one 64-bit word at a time. */
@@ -148,6 +156,7 @@ struct QueryWire {
     /*! @brief A record's decoded header fields. */
     struct Header {
         int phase = 0;
+        bool rot = false;
         size_t k = 0;
         size_t gw = 0;
         size_t bits = 0; //!< header width, i.e. where the payload begins
@@ -157,8 +166,9 @@ struct QueryWire {
         const auto w0 = static_cast<uint64_t>(buf[off]);
         Header h;
         h.phase = static_cast<int>(w0 & 0x3U) - 1;
-        h.k = static_cast<size_t>((w0 >> kPhaseBits) & kKEscape);
-        h.bits = kPhaseBits + kKBits;
+        h.rot = ((w0 >> kPhaseBits) & 1U) != 0;
+        h.k = static_cast<size_t>((w0 >> (kPhaseBits + kRotBits)) & kKEscape);
+        h.bits = kPhaseBits + kRotBits + kKBits;
         if (h.k == kKEscape) {
             h.k = static_cast<size_t>((w0 >> h.bits) & ((uint64_t{1} << kLongKBits) - 1U));
             h.bits += kLongKBits;
@@ -188,6 +198,7 @@ struct QueryWire {
 
     [[nodiscard]] static auto k_at(WireView buf, size_t off) noexcept -> size_t { return header_at(buf, off).k; }
     [[nodiscard]] static auto phase_at(WireView buf, size_t off) noexcept -> int { return header_at(buf, off).phase; }
+    [[nodiscard]] static auto rot_at(WireView buf, size_t off) noexcept -> bool { return header_at(buf, off).rot; }
 
     //! gw = bit_width(max gap), folded into push()'s own pass over the positions.
     template <std::ranges::contiguous_range Pos>
@@ -202,14 +213,14 @@ struct QueryWire {
         return g;
     }
 
-    /*! @brief Appends one record for `pos` and `phase`, and returns the words written.
+    /*! @brief Appends one record for `pos`, `phase` and `rot`, and returns the words written.
      *
      *  `pos` must be strictly ascending with every position below `kBits`; a violation encodes a
      *  different, still well-formed record rather than failing. The element type is deduced because
      *  the store's position width is narrower than the wire's below 129 modes.
      */
     template <std::ranges::contiguous_range Pos>
-    static auto push(VecZ &buf, const Pos &pos, int phase) -> size_t {
+    static auto push(VecZ &buf, const Pos &pos, int phase, bool rot = false) -> size_t {
         const size_t k = std::ranges::size(pos);
         assert(k <= kMaxPositions && "term has more positions than the record's width admits");
         assert(phase >= -1 && phase <= 1 && "emit_phase is ternary: rotation_sign, or REAL_PARTS entry");
@@ -217,6 +228,7 @@ struct QueryWire {
         const size_t gw = gap_width(pos);
         Writer w{buf};
         w.put(static_cast<uint64_t>(phase + 1), kPhaseBits);
+        w.put(static_cast<uint64_t>(rot), kRotBits);
         if (k >= kKEscape) {
             w.put(kKEscape, kKBits);
             w.put(static_cast<uint64_t>(k), kLongKBits);
@@ -242,8 +254,13 @@ struct QueryWire {
      */
     template <std::ranges::contiguous_range Out>
     static auto read_positions(WireView buf, size_t off, Out &&out) -> Decoded {
+        return read_positions(buf, off, header_at(buf, off), std::forward<Out>(out));
+    }
+
+    //! read_positions() for a caller that has already decoded the header, so word 0 is parsed once.
+    template <std::ranges::contiguous_range Out>
+    static auto read_positions(WireView buf, size_t off, const Header &h, Out &&out) -> Decoded {
         using OutT = std::ranges::range_value_t<Out>;
-        const Header h = header_at(buf, off);
         Reader r{buf, off, h.bits};
         if (h.k != 0) {
             auto prev = static_cast<size_t>(r.get(kPosBits));
@@ -253,25 +270,17 @@ struct QueryWire {
                 out[j] = static_cast<OutT>(prev);
             }
         }
-        return {off + words_of_header(h), h.phase};
-    }
-
-    //! d, recomputed rather than carried: in ascending order a pair is an even position then its successor.
-    template <std::ranges::contiguous_range Pos>
-    [[nodiscard]] static auto pair_count(const Pos &pos) noexcept -> size_t {
-        const size_t k = std::ranges::size(pos);
-        size_t d = 0;
-        for (size_t j = 0; j + 1 < k; ++j) {
-            if ((pos[j] % 2 == 0) && (pos[j + 1] == pos[j] + 1)) {
-                ++d;
-            }
-        }
-        return d;
+        return {off + words_of_header(h), h.phase, h.rot};
     }
 
     //! Offset of the next record in a stream; `off` always names the start of one.
     [[nodiscard]] static auto next_off(WireView buf, QueryForm form, size_t off) -> size_t {
-        return off + words_at(buf, off) + (form == QueryForm::Fused ? 1U : 0U);
+        return next_off(form, off, header_at(buf, off));
+    }
+
+    //! next_off() from an already-decoded header.
+    [[nodiscard]] static auto next_off(QueryForm form, size_t off, const Header &h) -> size_t {
+        return off + words_of_header(h) + (form == QueryForm::Fused ? 1U : 0U);
     }
 
     /*! @brief Decodes one record from a query stream, whose `form` says whether a value word
@@ -279,14 +288,25 @@ struct QueryWire {
      */
     template <std::ranges::contiguous_range Out>
     static auto read_query(WireView buf, QueryForm form, size_t off, Out &&out) -> Decoded {
-        Decoded d = read_positions(buf, off, std::forward<Out>(out));
+        return read_query(buf, form, off, header_at(buf, off), std::forward<Out>(out));
+    }
+
+    //! read_query() from an already-decoded header: the decode loop parses word 0 once per record.
+    template <std::ranges::contiguous_range Out>
+    static auto read_query(WireView buf, QueryForm form, size_t off, const Header &h, Out &&out) -> Decoded {
+        Decoded d = read_positions(buf, off, h, std::forward<Out>(out));
         d.next += (form == QueryForm::Fused ? 1U : 0U);
         return d;
     }
 
     //! The fused value word, a bit_cast that follows a record's positions.
     [[nodiscard]] static auto value_at(WireView buf, size_t off) -> double {
-        return decode_value(buf[off + words_at(buf, off)]);
+        return value_at(buf, off, header_at(buf, off));
+    }
+
+    //! value_at() from an already-decoded header.
+    [[nodiscard]] static auto value_at(WireView buf, size_t off, const Header &h) -> double {
+        return decode_value(buf[off + words_of_header(h)]);
     }
 
     static auto push_value(VecZ &buf, double v) -> void { buf.push_back(encode_value(v)); }
@@ -298,36 +318,6 @@ struct QueryWire {
         while (off < buf.size()) {
             off = next_off(buf, form, off);
             ++n;
-        }
-        return n;
-    }
-
-    //! Interleaves a plain query stream with its parallel value array into one fused stream.
-    static auto build_fused(WireView queries, std::span<const double> vals, VecZ &out) -> void {
-        out.clear();
-        out.reserve(queries.size() + vals.size());
-        size_t off = 0;
-        size_t i = 0;
-        while (off < queries.size()) {
-            const size_t n = words_at(queries, off);
-            out.insert(out.end(),
-                       queries.begin() + static_cast<std::ptrdiff_t>(off),
-                       queries.begin() + static_cast<std::ptrdiff_t>(off + n));
-            assert(i < vals.size() && "fused build needs exactly one value per query");
-            out.push_back(encode_value(vals[i]));
-            off += n;
-            ++i;
-        }
-    }
-
-    //! Copies the record at src_off (and its value word, if fused) to dst_off; returns the words moved.
-    static auto move_query(VecZ &buf, QueryForm form, size_t src_off, size_t dst_off) -> size_t {
-        const size_t n = words_at(buf, src_off) + (form == QueryForm::Fused ? 1U : 0U);
-        if (src_off != dst_off) {
-            assert(dst_off < src_off && "compaction only ever moves a query earlier");
-            std::copy(buf.begin() + static_cast<std::ptrdiff_t>(src_off),
-                      buf.begin() + static_cast<std::ptrdiff_t>(src_off + n),
-                      buf.begin() + static_cast<std::ptrdiff_t>(dst_off));
         }
         return n;
     }

--- a/cpp/monoprop/detail/evolution/layer_build/Resolve.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Resolve.h
@@ -14,224 +14,334 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
-#include <limits>
 #include <span>
 #include <vector>
 
 #include "monoprop/TypeAliases.h"
-#include "monoprop/algebra/Algebra.h"
-#include "monoprop/detail/evolution/CutoffContext.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
+#include "monoprop/detail/evolution/layer_build/GateScratch.h"
+#include "monoprop/detail/evolution/layer_build/PartnerMerge.h"
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
+#include "monoprop/detail/evolution/layer_build/TableJoin.h"
+#include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
-#include "monoprop/detail/operator/RowAccess.h"
+#include "monoprop/detail/operator/RowKey.h"
 
 namespace monoprop::detail {
 
-// Picture-independent probe/insert machinery shared by resolve_incoming and its callers. Each miss takes
-// the next index base+j in (sender,record) order, so the assignment (and multi-rank bit-exactness) cannot
-// drift between resolvers. Queries are source⊕G over globally-distinct sources, ⊕G injective ⇒ queries
-// pairwise distinct ⇒ misses distinct and absent.
+// The join side of the gate exchange (Engine.h states the protocol). Everything here is
+// picture-independent; what a hit, a mint, a response or an absence records is supplied by a
+// compile-time sink with these surfaces:
+//   hit(slot, row, v, phase, foll, own_rot)  a record hit tracked row `row` and the pair rotates.
+//                                       `foll` and `own_rot` are that row's own pivot bit and E(row):
+//                                       the value picture needs both to tell which endpoint of the pair
+//                                       this half is (GateSinks.h ContractSink::hit says why).
+//   mint(slot, idx, v, phase)           a rot=1 record missed: its key is inserted at `idx`
+//   out_pair(slot, row, phase)          a leader of this slot whose partner is tracked and rotates
+//   out_unanswered(slot, row, c0, phase) an E-record of this slot whose key missed at `slot`
+// and, iff `Sink::wants_responses`, the round-2 pair:
+//   silent_value(row) -> double         row's pre-gate value, the payload of a response
+//   answer(slot, row, v, phase)         a response arrived for this slot's row: its half is -phase*v
+// plus, once per gate before any of them:
+//   reserve_halves(n)                   at most n of the recording calls above will follow this gate
+// `slot` is always the flat slot of the peer the record came from / went to.
+//
+// How a partner is found is entirely TableJoin's business: the join reads `join.hit(q)` and nothing
+// else, so replacing the matching structure leaves the receiver rule, the mint order and the absence
+// pass untouched.
+
+// One read-only record stream per sender slot, ascending. Every producer of a gate's incoming records
+// reaches the decode through it: today the collective's receive buffer, whose slots are viewed in place.
+using WireStreams = std::span<const std::span<const size_t>>;
+
+//! Views of a per-slot wire buffer's slots, ascending, into caller-owned storage.
+inline auto slot_streams(const std::vector<VecZ> &wire, std::vector<std::span<const size_t>> &into) -> WireStreams {
+    into.resize(wire.size());
+    for (size_t s = 0; s < wire.size(); ++s) {
+        into[s] = std::span<const size_t>(wire[s]);
+    }
+    return {into};
+}
+
+/*! @brief Decodes every incoming record into @a pr: key positions, phase, rot bit, value, and the key's
+ *  join tag folded off those positions.
+ *
+ *  The tag is the same label XOR the sender's own key took, kept as the 32-bit tag, so the wire carries
+ *  neither and sender and receiver agree by using one map. Nothing is looked up here -- the keys go into
+ *  the gate's TableJoin, which probes them against the operator's term table.
+ *
+ *  Each record's header is decoded ONCE and reused for its width, its value word and its fields, and the
+ *  tag is folded inside the same loop, while the positions this record owns are still in cache.
+ */
 template <size_t NumModes>
-struct IncomingProbe {
-    // The operator store's position width, not the wire's: these positions exist to become rows.
-    using PosT = typename OperatorIndex<NumModes>::PosT;
-
-    std::vector<size_t> goff;              // rank_count+1 flat offsets: g = goff[s] + q
-    DefaultInitVector<uint32_t> sender_of; // g → sender rank
-    DefaultInitVector<int> phase_of;       // g → query phase
-    // g → word offset of that query inside incoming[sender_of[g]]; a query ordinal names no position.
-    DefaultInitVector<size_t> off_of;
-    DefaultInitVector<size_t> idx_of; // g → resolved index (hit: < base; miss: base+j)
-    std::vector<TermIndex> miss_g;    // j → the g that became miss j (Phase 4 reads the key of miss_g[j])
-    size_t base = 0;                  // op size before the miss inserts (the miss-index base)
-    size_t nq_total = 0;
-
-    // The queries as they arrived, flat: query g owns pos_flat[pos_off[g] .. pos_off[g] + k_of[g]).
-    DefaultInitVector<PosT> pos_flat;
-    DefaultInitVector<size_t> pos_off;
-    DefaultInitVector<uint32_t> k_of;
-    // g → the query's join key, folded off its positions as they are decoded.
-    DefaultInitVector<uint32_t> key_of;
-
-    //! Query g's ascending positions, as a view into pos_flat.
-    [[nodiscard]] auto positions_at(size_t g) const -> std::span<const PosT> {
-        return std::span<const PosT>(pos_flat).subspan(pos_off[g], k_of[g]);
-    }
-
-    //! Builds a dense bitset; only the fully paired minority of callers needs one.
-    [[nodiscard]] auto mono_at(size_t g) const -> Monomial<NumModes> {
-        Monomial<NumModes> m;
-        for (const PosT q : positions_at(g)) {
-            m.set(static_cast<size_t>(q));
-        }
-        return m;
-    }
-
-    //! Every mode of query g carries both Majoranas, read off the positions.
-    [[nodiscard]] auto is_paired_at(size_t g) const -> bool {
-        const auto pos = positions_at(g);
-        return pos.size() == 2 * QueryWire<NumModes>::pair_count(pos);
-    }
-};
-
-// Read-only phases 1-2 of the exchange: `form` says whether the incoming records are fused
-// (ContractSink) or plain (GraphSink). The caller runs phase 3, then insert_incoming_misses.
-template <size_t NumModes>
-auto probe_incoming_queries(const std::vector<VecZ> &incoming, // serialized, one VecZ per sender
-                            MPOperator<NumModes> &op,
-                            size_t rank_count,
-                            QueryForm form) -> IncomingProbe<NumModes> {
+auto decode_incoming_records(WireStreams incoming, QueryForm form, IncomingRecords<NumModes> &pr) -> void {
     using QW = QueryWire<NumModes>;
-    using PosT = typename IncomingProbe<NumModes>::PosT;
-    IncomingProbe<NumModes> pr;
+    using PosT = typename IncomingRecords<NumModes>::PosT;
+    const size_t senders = incoming.size();
 
-    pr.goff.assign(rank_count + 1, 0);
-    for (size_t s = 0; s < rank_count; ++s) {
-        const size_t nq = QW::count_queries(incoming[s], form);
-        pr.goff[s + 1] = pr.goff[s] + nq;
+    pr.goff.assign(senders + 1, 0);
+    for (size_t s = 0; s < senders; ++s) {
+        pr.goff[s + 1] = pr.goff[s] + QW::count_queries(incoming[s], form);
     }
-    pr.nq_total = pr.goff[rank_count];
+    pr.nq_total = pr.goff[senders];
     if (pr.nq_total == 0) {
-        return pr;
+        return;
     }
 
-    pr.sender_of.resize(pr.nq_total);
-    for (size_t s = 0; s < rank_count; ++s) {
-        std::fill(pr.sender_of.begin() + static_cast<std::ptrdiff_t>(pr.goff[s]),
-                  pr.sender_of.begin() + static_cast<std::ptrdiff_t>(pr.goff[s + 1]),
-                  static_cast<uint32_t>(s));
-    }
-
-    // Phase 1 (read-only): deserialize, then probe with the group-prefetch batch find. One walk per sender.
     pr.phase_of.resize(pr.nq_total);
-    pr.off_of.resize(pr.nq_total);
-    pr.idx_of.resize(pr.nq_total);
+    pr.rot_of.resize(pr.nq_total);
+    if (form == QueryForm::Fused) {
+        pr.val_of.resize(pr.nq_total);
+    }
     pr.pos_off.resize(pr.nq_total);
     pr.k_of.resize(pr.nq_total);
-    pr.key_of.resize(pr.nq_total);
+    pr.tag_of.resize(pr.nq_total);
     pr.pos_flat.clear();
     // A hint only, so this stays one allocation for the common case.
     pr.pos_flat.reserve(pr.nq_total * QW::kReservePositionsPerQuery);
-    for (size_t s = 0; s < rank_count; ++s) {
+    const uint64_t *const labels = routing::linear_basis<2 * NumModes>().data();
+    for (size_t s = 0; s < senders; ++s) {
+        const std::span<const size_t> buf = incoming[s];
         size_t off = 0;
         for (size_t g = pr.goff[s]; g < pr.goff[s + 1]; ++g) {
-            const size_t k = QW::k_at(incoming[s], off);
+            const auto h = QW::header_at(buf, off);
             const size_t at = pr.pos_flat.size();
-            pr.pos_flat.resize(at + k); // default-init grow: read_query writes every element
+            pr.pos_flat.resize(at + h.k); // default-init grow: read_query writes every element
             pr.pos_off[g] = at;
-            pr.k_of[g] = static_cast<uint32_t>(k);
-            pr.off_of[g] = off;
-            const auto d = QW::read_query(incoming[s], form, off, std::span<PosT>(pr.pos_flat).subspan(at, k));
-            // Folded here, while the positions this query owns are still in cache.
-            pr.key_of[g] = key_of_positions<2 * NumModes>(pr.pos_flat.data() + at, k);
-            pr.phase_of[g] = d.phase;
+            pr.k_of[g] = static_cast<uint16_t>(h.k);
+            if (form == QueryForm::Fused) {
+                pr.val_of[g] = QW::value_at(buf, off, h);
+            }
+            const auto d = QW::read_query(buf, form, off, h, std::span<PosT>(pr.pos_flat).subspan(at, h.k));
+            pr.phase_of[g] = static_cast<int8_t>(d.phase);
+            pr.rot_of[g] = static_cast<uint8_t>(d.rot);
+            pr.tag_of[g] = join_tag(routing::fingerprint_positions(labels, pr.pos_flat.data() + at, h.k));
             off = d.next;
         }
     }
-    {
-        const size_t op_size = op.store->size();
-        // The vectors are sized to capacity, not to nq_total, so the output span is trimmed explicitly.
-        op.term_table().find_batch(
-            *op.store,
-            pr.nq_total,
-            [&pr](size_t g) { return pr.key_of[g]; },
-            [&pr](size_t g) { return pr.positions_at(g); },
-            std::span<size_t>(pr.idx_of).first(pr.nq_total));
-        for (size_t g = 0; g < pr.nq_total; ++g) {
-            if (pr.idx_of[g] >= op_size) { // kNotFound is size_t max → also lands here
-                pr.idx_of[g] = kMissingIndex;
+}
+
+/*! @brief Bulk insert of the misses into rows [base, base + n).
+ *
+ *  insert_absent_terms' steps without its dense round-trip, on the same ordering contract. @a base must
+ *  be the size the join assigned indices against.
+ */
+template <size_t NumModes>
+auto insert_misses(MPOperator<NumModes> &op, const MissStage<NumModes> &misses, size_t base) -> void {
+    const size_t n = misses.size();
+    if (n == 0) {
+        return;
+    }
+    [[maybe_unused]] const size_t grown_at = op.store->grow_rows_geometric(n);
+    assert(grown_at == base && "misses were indexed against a size the store no longer has");
+    for (size_t j = 0; j < n; ++j) {
+        op.store->set_positions(base + j, misses.positions_at(j));
+    }
+    op.reindex_after_growth(base, n);
+}
+
+/*! @brief The receiver rule for one record (key = the partner, from the owner of its source at @a slot).
+ *
+ *  hit  -> the partner is tracked: mark received (and its rot); the pair rotates iff rot_rec or rot_own,
+ *          and then this slot's half is +phase_rec * v_rec onto the row.
+ *  miss -> the partner is absent everywhere; a rot=1 record mints it at base + j with the same half. A
+ *          rot=0 record that misses is dropped: neither side rotates, so there is nothing to mint.
+ *
+ *  @return Whether the sender still owes its own half a value, i.e. true iff the pair rotates on the
+ *  record's `rot` alone -- the partner is tracked but silent, which is the case round 2 answers
+ *  (Engine.h). Always false unless the sink asked for responses; graph mode's silent rows send records
+ *  of their own instead.
+ */
+template <size_t NumModes, typename Sink>
+[[gnu::always_inline]] inline auto join_record(RowMarks &marks,
+                                               size_t slot,
+                                               size_t row,
+                                               std::span<const typename OperatorIndex<NumModes>::PosT> pos,
+                                               int phase,
+                                               bool rot,
+                                               double v,
+                                               size_t base,
+                                               MissStage<NumModes> &misses,
+                                               Sink &sink) -> bool {
+    if (row != TableJoin<NumModes>::kMissing) {
+        marks.set_received(row);
+        if (rot) {
+            marks.set_partner_rot(row);
+        }
+        const bool own_rot = marks.rot(row);
+        if (rot || own_rot) {
+            sink.hit(slot, row, v, phase, marks.foll(row), own_rot);
+        }
+        return Sink::wants_responses && rot && !own_rot;
+    }
+    if (!rot) {
+        return false;
+    }
+    const size_t idx = base + misses.size();
+    misses.push(pos);
+    sink.mint(slot, idx, v, phase);
+    return false;
+}
+
+/*! @brief The records this slot addressed to itself, in stream order.
+ *
+ *  They occupy the join's query indices [q_base, q_base + stage.size()), which is the front of the query
+ *  space: the self stage is joined first, so its misses take the first mint indices.
+ *
+ *  `sent_self` is the parallel record of what those queries were sent for (the source row and its phase),
+ *  which is why a silent hit needs no response here: both halves are on this slot, so the sender's is
+ *  applied at once instead of travelling. `answered` is still marked, so the absence pass reads the pair
+ *  alike however the answer arrived.
+ *
+ *  @return How many self records were answered without the wire.
+ */
+template <size_t NumModes, typename Sink>
+auto join_self(const SelfQueryStage<NumModes> &stage,
+               const TableJoin<NumModes> &join,
+               size_t q_base,
+               RowMarks &marks,
+               size_t my_rank,
+               size_t base,
+               MissStage<NumModes> &misses,
+               Sink &sink,
+               std::span<const SentRecord> sent_self) -> size_t {
+    assert(!Sink::wants_responses || sent_self.size() == stage.size());
+    size_t answered = 0;
+    for (size_t q = 0; q < stage.size(); ++q) {
+        const size_t row = join.hit(q_base + q);
+        const bool answer = join_record<NumModes>(marks,
+                                                  my_rank,
+                                                  row,
+                                                  stage.positions_at(q),
+                                                  static_cast<int>(stage.phase_of[q]),
+                                                  stage.rot_of[q] != 0,
+                                                  stage.value_at(q),
+                                                  base,
+                                                  misses,
+                                                  sink);
+        if constexpr (Sink::wants_responses) {
+            if (answer) {
+                const SentRecord &s = sent_self[q];
+                marks.set_answered(s.row);
+                sink.answer(my_rank, s.row, sink.silent_value(row), static_cast<int>(s.phase));
+                ++answered;
             }
         }
     }
-
-    // Phase 2 ((sender,query) prefix order): each miss takes the next index base+j.
-    pr.base = op.store->size();
-    for (size_t g = 0; g < pr.nq_total; ++g) {
-        if (pr.idx_of[g] == kMissingIndex) {
-            pr.idx_of[g] = pr.base + pr.miss_g.size();
-            pr.miss_g.push_back(static_cast<TermIndex>(g));
-        }
-    }
-    return pr;
+    return answered;
 }
 
-// Phase 4 (bulk insert of the distinct absent terms) into op slots [base, base+n_miss). Call after the
-// caller's Phase-3 scatter, which reads pre-insert op_coeffs for hits and needs base == op.size().
-template <size_t NumModes>
-auto insert_incoming_misses(MPOperator<NumModes> &op, const IncomingProbe<NumModes> &pr) -> void {
-    const size_t n_miss = pr.miss_g.size();
-    if (n_miss == 0) {
-        return;
-    }
-    // insert_absent_terms' steps on the same ordering contract, which is what matters: slot j lands at
-    // base+j, in miss order = (sender, record) order. The indices then index the rows they have written.
-    const size_t base = op.store->grow_rows_geometric(n_miss);
-    for (size_t j = 0; j < n_miss; ++j) {
-        const size_t g = pr.miss_g[j];
-        op.store->set_positions(base + j, pr.positions_at(g));
-    }
-    op.reindex_after_growth(base, n_miss);
-}
-
-// resolve_incoming / process_responses are the picture-independent cross-rank exchange skeletons; what
-// each resolved query records and answers with is supplied by a compile-time sink. The two concrete sinks
-// (GraphSink / ContractSink) live in Engine.h, each also carrying the self-resolve + finalize policy.
-
-// Resolver rank (any cross-rank sink): for each query from sender s, look up M' locally; found → answer
-// with its index/value, absent → insert it in the same round (the resolver is the sole inserter of
-// cross-rank absent terms). Matched-follower marks stay here so both sinks mark byte-identically.
+/*! @brief The records the exchange delivered: sources in ascending slot order, each in its stream order.
+ *
+ *  That order is what pairs a peer's in-mints with this slot's out-unanswered positionally in graph mode.
+ *  A hit on a silent row stages a response to that record's sender, naming the record by its position in
+ *  the sender's own stream to this slot -- the one index both sides can compute without agreeing on
+ *  anything but the order they already agree on.
+ *
+ *  @return How many responses were staged, so COMMPROF needs no second pass over the buffers.
+ */
 template <size_t NumModes, typename Sink>
-auto resolve_incoming(const std::vector<VecZ> &incoming, // serialized, one VecZ per sender
-                      MPOperator<NumModes> &op,
-                      size_t rank_count,
-                      bool is_leader_pass,
-                      MatchedEpochSet &matched,
-                      size_t combined_size, // pre-layer op size: bounds the matched set
-                      Sink &sink) -> std::vector<std::vector<typename Sink::Response>> {
-    using Resp = typename Sink::Response;
-    const IncomingProbe<NumModes> pr = probe_incoming_queries<NumModes>(incoming, op, rank_count, sink.incoming_form());
-    std::vector<std::vector<Resp>> responses(rank_count);
-    for (size_t s = 0; s < rank_count; ++s) {
-        responses[s].assign(pr.goff[s + 1] - pr.goff[s], Sink::init_response());
-    }
-    if (pr.nq_total == 0) {
-        return responses;
-    }
-
-    // Phase 3 (scatter): responses + sink records + matched-follower marks. Freshly inserted partners
-    // (ip ≥ combined_size) skip the mark.
-    sink.prepare(pr, rank_count, op, responses);
-    for (size_t g = 0; g < pr.nq_total; ++g) {
-        const size_t s = pr.sender_of[g];
-        const size_t q = g - pr.goff[s];
-        const size_t ip = pr.idx_of[g];
-        responses[s][q] = sink.on_resolved(g, s, q, ip, pr, incoming);
-        if (is_leader_pass && ip < combined_size) {
-            matched.mark(ip);
+auto join_incoming(const IncomingRecords<NumModes> &pr,
+                   const TableJoin<NumModes> &join,
+                   size_t q_base,
+                   RowMarks &marks,
+                   size_t base,
+                   MissStage<NumModes> &misses,
+                   Sink &sink,
+                   std::vector<VecZ> &responses) -> size_t {
+    size_t staged = 0;
+    for (size_t s = 0; s + 1 < pr.goff.size(); ++s) {
+        for (size_t g = pr.goff[s]; g < pr.goff[s + 1]; ++g) {
+            const size_t row = join.hit(q_base + g);
+            // The value column exists only for the fused form, and that is a property of the sink, so
+            // the branch value_at() would cost per record is settled at compile time here.
+            double v = 0.0;
+            if constexpr (Sink::wants_values) {
+                v = pr.val_of[g];
+            }
+            const bool answer = join_record<NumModes>(marks,
+                                                      s,
+                                                      row,
+                                                      pr.positions_at(g),
+                                                      static_cast<int>(pr.phase_of[g]),
+                                                      pr.rot_of[g] != 0,
+                                                      v,
+                                                      base,
+                                                      misses,
+                                                      sink);
+            if constexpr (Sink::wants_responses) {
+                if (answer) {
+                    push_response(responses[s], g - pr.goff[s], sink.silent_value(row));
+                    ++staged;
+                }
+            }
         }
     }
-
-    insert_incoming_misses<NumModes>(op, pr);
-    return responses;
+    return staged;
 }
 
-// Querier rank (any cross-rank sink): fold each resolver response into a querier-side record. The self/
-// local rank was already resolved inline, so it is skipped here. inc_r[r][q] answers query q from rank r.
+/*! @brief Round 2's arrival: response j from slot s names one of the records THIS slot sent to s.
+ *
+ *  It names it by its position in that stream, and carries the answering row's pre-gate coefficient. The
+ *  sender's half is -phase * v, the phase being the one it kept in `sent` -- the record itself carried no
+ *  row, and none had to.
+ */
 template <size_t NumModes, typename Sink>
-auto process_responses(const std::vector<std::vector<typename Sink::Response>> &inc_r,
-                       const std::vector<std::vector<size_t>> &src_idx,
-                       const std::vector<VecZ> &queries, // serialized query buffers (for phase recovery)
-                       size_t rank_count,
-                       size_t my_rank,
-                       Sink &sink) -> void {
-    sink.process_reserve(inc_r, rank_count, my_rank);
-    for (size_t r = 0; r < rank_count; ++r) {
-        if (r == my_rank) {
-            continue;
+auto apply_responses(RowMarks &marks,
+                     const std::vector<std::vector<SentRecord>> &sent,
+                     WireStreams responses,
+                     Sink &sink) -> void {
+    assert(responses.size() == sent.size() && "one answer stream per slot");
+    for (size_t s = 0; s < responses.size(); ++s) {
+        const std::span<const size_t> buf = responses[s];
+        const std::vector<SentRecord> &records = sent[s];
+        for (size_t off = 0; off + kResponseWords <= buf.size(); off += kResponseWords) {
+            const size_t idx = buf[off];
+            assert(idx < records.size() && "a response named a record this slot never sent to that peer");
+            const SentRecord &r = records[idx];
+            marks.set_answered(r.row);
+            sink.answer(s, r.row, decode_value(buf[off + 1]), static_cast<int>(r.phase));
         }
-        sink.on_response_block(r, inc_r[r], src_idx[r], queries[r]);
+    }
+}
+
+/*! @brief The walk over this slot's own records after the join and after round 2, per destination slot in
+ *  stream order (ascending ordinal).
+ *
+ *  A record gets exactly one of three answers, and they are what distinguishes an absent partner from a
+ *  tracked one:
+ *   received  the partner sent a record of its own, so it is tracked and rotates; both halves are applied.
+ *   answered  the partner is tracked but silent, and sent its coefficient back; the sender's half came
+ *             from that.
+ *   neither   nobody could send this key but the partner's owner, and it does whenever the partner is
+ *             tracked, so the partner is absent -- minted by its owner from this very record -- and the
+ *             sender's own half (-phase * c0) is supplied here. That is the absence proper.
+ *
+ *  A leader whose partner is tracked and whose pair rotates is reported as the out-side of that pair; the
+ *  graph sink pairs it positionally with the peer's in-pair, the fused sink ignores it (its half arrived
+ *  with the partner's record).
+ */
+template <size_t NumModes, typename Sink>
+auto absence_pass(const RowMarks &marks,
+                  const std::vector<std::vector<SentRecord>> &sent,
+                  const std::vector<std::vector<double>> &sent_c0,
+                  Sink &sink) -> void {
+    const bool has_c0 = sent_c0.size() == sent.size();
+    for (size_t s = 0; s < sent.size(); ++s) {
+        const std::vector<SentRecord> &records = sent[s];
+        for (size_t j = 0; j < records.size(); ++j) {
+            const size_t row = static_cast<size_t>(records[j].row);
+            const int phase = static_cast<int>(records[j].phase);
+            const bool received = marks.received(row);
+            if (marks.rot(row) && !received && !marks.answered(row)) {
+                sink.out_unanswered(s, row, has_c0 ? sent_c0[s][j] : 0.0, phase);
+            }
+            else if (received && !marks.foll(row) && (marks.rot(row) || marks.partner_rot(row))) {
+                sink.out_pair(s, row, phase);
+            }
+        }
     }
 }
 

--- a/cpp/monoprop/detail/evolution/layer_build/Scan.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Scan.h
@@ -30,6 +30,7 @@
 #include "monoprop/core/Monomial.h"
 #include "monoprop/detail/evolution/CutoffContext.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
+#include "monoprop/detail/evolution/layer_build/GateScratch.h"
 #include "monoprop/detail/evolution/layer_build/PartnerMerge.h"
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
 #include "monoprop/detail/graph_encoding/MPGraphEncodingTypes.h"
@@ -37,8 +38,13 @@
 #include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/InvertedIndex.h"
 #include "monoprop/detail/operator/MPOperator.h"
+#include "monoprop/detail/operator/RowKey.h"
 
 namespace monoprop::detail {
+
+// Floor of the self-slot reserve, so a gate that follows a silent one still starts with room: below this
+// the estimate is not worth having and push()'s own first growth step is the same size.
+inline constexpr size_t kSelfReserveFloor = 64;
 
 inline auto build_majorana_evolution_cutoff_state(const std::optional<double> &atol,
                                                   std::optional<std::reference_wrapper<const VecD>> local_coeffs,
@@ -72,15 +78,7 @@ auto build_even_parity_generator_columns(const Monomial<NumModes> &gen_mono) -> 
     return columns;
 }
 
-// One nonzero-overlap word carried from scan pass 1 to emit pass 2. `overlap` bit t set ⟺ term (base+t)
-// anticommutes with G; `foll` = overlap & pivot column = the followers (leaders are `overlap ^ foll`).
-struct EvenParityNzWord {
-    size_t base;
-    uint64_t overlap;
-    uint64_t foll;
-};
-
-// Even-parity scan pass 1 over words [wlo,whi). n_anti/n_foll are tallied here so pass 2 reserves once.
+// Even-parity scan pass 1 over words [wlo,whi). n_anti is tallied here so pass 2 reserves once.
 // `pivot_col` is read separately from `gen_cols` so a caller can fold a transformed generator while
 // splitting on the untransformed one. `g_odd` XORs the per-row parity(|M|) correction (row_parity_ptr)
 // in before followers are derived.
@@ -95,11 +93,9 @@ inline auto even_parity_scan_pass1(const InvertedIndex<NumModes> &sc,
                                    bool g_odd,
                                    const uint64_t *row_parity_ptr,
                                    std::vector<EvenParityNzWord> &nz,
-                                   size_t &n_anti,
-                                   size_t &n_foll) -> void {
+                                   size_t &n_anti) -> void {
     nz.clear();
     n_anti = 0;
-    n_foll = 0;
     const bool pivot_dense = sc.column_is_dense(pivot_col);
     std::vector<uint64_t> &blk = column_block_scratch();
     // A dense pivot is read inline; a sparse pivot is scatter-expanded lazily (only for blocks with a
@@ -123,11 +119,7 @@ inline auto even_parity_scan_pass1(const InvertedIndex<NumModes> &sc,
                 continue;
             }
             n_anti += static_cast<size_t>(std::popcount(overlap));
-            uint64_t foll = 0;
-            if (pivot_dense) {
-                foll = overlap & pivot_dense_ptr[wi - bb];
-                n_foll += static_cast<size_t>(std::popcount(foll));
-            }
+            const uint64_t foll = pivot_dense ? (overlap & pivot_dense_ptr[wi - bb]) : uint64_t{0};
             nz.push_back(EvenParityNzWord{wi * 64, overlap, foll});
         }
         if (pivot_dense || nz.size() == nz_block_start) {
@@ -140,7 +132,6 @@ inline auto even_parity_scan_pass1(const InvertedIndex<NumModes> &sc,
             EvenParityNzWord &e = nz[k];
             const size_t wi = e.base / 64;
             e.foll = e.overlap & pw[wi - bb];
-            n_foll += static_cast<size_t>(std::popcount(e.foll));
         }
     };
     for (size_t bb = wlo; bb < whi; bb += kColumnBlockWords) {
@@ -149,115 +140,175 @@ inline auto even_parity_scan_pass1(const InvertedIndex<NumModes> &sc,
 }
 
 // The per-term rotation gate splits into a dynamic part (orbital pop cap, lower-atol sine cutoff) and a
-// static part (the structural cutoff on M'=M⊕G, applied in emit).
-inline auto rotation_dynamic_gate(std::optional<size_t> only_rotate_len_k,
-                                  size_t mono_pop,
-                                  const CutoffContext &ctx,
-                                  double abs_c) -> bool {
-    if (only_rotate_len_k && mono_pop > static_cast<size_t>(*only_rotate_len_k)) {
-        return false;
-    }
-    if (ctx.is_below_sin(abs_c)) {
-        return false;
-    }
-    return true;
+// static part (the structural cutoff on the partner, applied in emit). The dynamic part is two
+// independent tests, kept separate because only one of them needs the row: the value path reads the
+// coefficient half first and, when it fails, never reads the row at all (emit_row below).
+inline auto rotation_coeff_gate(const CutoffContext &ctx, double abs_c) -> bool {
+    return !ctx.is_below_sin(abs_c);
+}
+inline auto rotation_pop_gate(std::optional<size_t> only_rotate_len_k, size_t mono_pop) -> bool {
+    return !only_rotate_len_k.has_value() || mono_pop <= static_cast<size_t>(*only_rotate_len_k);
 }
 
-// The dense form is unavoidable: the owner hash folds every word and the basis sign reads the source
-// bitset, so it is built regardless, and the merge below runs beside it.
+/*! @brief One partner M^G as ascending positions plus what the emit reads off it.
+ *
+ *  The (k, d) digest the structural cutoff reads, the cancelled-slot count the Hermitian phase reads, and
+ *  the basis sign -- all from the source row's positions. The dense form is built only where something
+ *  still reads it: the splitmix router's hash, an opaque cutoff, or a sign kernel without a position form
+ *  (a Pauli generator on more than 32 qubits).
+ */
 template <size_t NumModes>
 struct PartnerProduct {
-    Monomial<NumModes> new_mono;
-    size_t k = 0;       // popcount(M⊕G)
+    size_t k = 0;       // popcount(M^G)
     size_t overlap = 0; // slots in both M and G, which cancel
+    size_t paired = 0;  // modes of M^G carrying both positions: the d of the (k, d) digest
     int phase_factor = 0;
+    bool sign_pending = false; // phase_factor not filled: the caller asked for the digest only
+    bool has_dense = false;
+    Monomial<NumModes> dense; // M^G; valid iff has_dense
 };
 
-// phase_factor is the basis-specific sign only: Majorana interleave_phase, still to be folded with
-// hermitian_phase at emit; Pauli pauli_rotation_sign, already rotation-ready. `out_pos` receives the
-// partner's ascending positions; a spilled source row has no position array, so that case walks the
-// dense partner to fill it instead.
+/*! @brief The partner product of row @a i, from the positions the caller has already read.
+ *
+ *  `phase_factor` is the basis-specific sign only: Majorana interleave_phase, still to be folded with
+ *  hermitian_phase at emit; Pauli pauli_rotation_sign, already rotation-ready. `src` is row i's positions
+ *  (a spilled row has none, and that case walks the dense form instead).
+ *
+ *  `need_sign` false returns the digest with `sign_pending` set and no sign computed, for a caller whose
+ *  send predicate reads the digest first and may drop the record: the sign is then taken from the same
+ *  positions once the record is known to go out. The paths that build the dense partner compute the sign
+ *  on the way there, so they honour the request only in the common inline case.
+ */
 template <size_t NumModes, Algebra A, typename PosT, typename GenT>
-[[gnu::always_inline]] inline auto emit_term_products(const OperatorIndex<NumModes> &ham,
-                                                      size_t i,
-                                                      const typename A::GenContext &ctx,
-                                                      std::span<const GenT> gen_pos,
-                                                      std::span<PosT> out_pos) -> PartnerProduct<NumModes> {
+[[gnu::always_inline]] inline auto emit_partner(const OperatorIndex<NumModes> &ham,
+                                                size_t i,
+                                                typename OperatorIndex<NumModes>::RowPositions src,
+                                                const typename A::GenContext &ctx,
+                                                std::span<const GenT> gen_pos,
+                                                std::span<PosT> out_pos,
+                                                bool need_dense,
+                                                bool need_sign = true) -> PartnerProduct<NumModes> {
     const Monomial<NumModes> &gen = A::generator(ctx);
     PartnerProduct<NumModes> out;
-    Monomial<NumModes> mono;
-    if (const auto src = ham.row_positions(i); src.inlined()) {
+    if (src.inlined()) {
         const auto merged = merge_partner_positions(src.pos, gen_pos, out_pos);
         out.k = merged.count;
         out.overlap = merged.overlap;
-        for (const PosT q : src.pos) {
-            mono.set(static_cast<size_t>(q));
+        out.paired = merged.paired;
+        if (A::sign_from_positions_ok(ctx)) {
+            if (need_sign) {
+                out.phase_factor = A::rotation_sign_positions(ctx, src.pos.data(), src.pos.size());
+            }
+            else {
+                out.sign_pending = true;
+            }
+            if (need_dense) {
+                for (size_t j = 0; j < out.k; ++j) {
+                    out.dense.set(static_cast<size_t>(out_pos[j]));
+                }
+                out.has_dense = true;
+            }
         }
-        out.new_mono = mono ^ gen;
-    }
-    else {
-        ham.for_each_position(i, [&](size_t pos) { mono.set(pos); });
-        out.new_mono = mono ^ gen;
-        out.overlap = mono.count_and(gen);
-        for (size_t b = out.new_mono.find_first(); b < out.new_mono.size(); b = out.new_mono.find_next(b)) {
-            out_pos[out.k++] = static_cast<PosT>(b);
+        else {
+            Monomial<NumModes> mono;
+            for (const PosT q : src.pos) {
+                mono.set(static_cast<size_t>(q));
+            }
+            out.dense = mono ^ gen;
+            out.has_dense = true;
+            out.phase_factor = A::rotation_sign(ctx, mono, out.dense);
         }
+        return out;
     }
-    out.phase_factor = A::rotation_sign(ctx, mono, out.new_mono);
+    Monomial<NumModes> mono;
+    ham.for_each_position(i, [&](size_t pos) { mono.set(pos); });
+    out.dense = mono ^ gen;
+    out.has_dense = true;
+    out.overlap = mono.count_and(gen);
+    for (size_t b = out.dense.find_first(); b < out.dense.size(); b = out.dense.find_next(b)) {
+        out_pos[out.k++] = static_cast<PosT>(b);
+    }
+    out.paired = count_paired_positions(out_pos.data(), out.k);
+    out.phase_factor = A::rotation_sign(ctx, mono, out.dense);
     return out;
 }
 
 template <size_t NumModes>
 struct FusedScanResult {
-    std::vector<CosMask> cos_blocks;               // ascending, disjoint, chunk order
-    std::vector<VecZ> leader_queries;              // size R: serialized leader queries per owner rank
-    std::vector<std::vector<size_t>> leader_src;   // size R: parallel to leader_queries (source op idx)
-    std::vector<VecZ> follower_queries;            // size R: serialized follower queries per owner rank
-    std::vector<std::vector<size_t>> follower_src; // size R: parallel to follower_queries
-    // Fused-contraction only (capture_values): signed pre-cos source coeff (v_src) parallel to
-    // leader_src / follower_src. Empty when capture_values is false.
-    std::vector<std::vector<double>> leader_val;
-    std::vector<std::vector<double>> follower_val;
-    // Self-owned queries, staged as positions instead of queued to the wire and resolved inline.
-    // Order must match leader_src[my_rank] / follower_src[my_rank], or resolution attributes the wrong source.
-    SelfQueryStage<NumModes> leader_self;
-    SelfQueryStage<NumModes> follower_self;
+    std::vector<CosMask> cos_blocks; // ascending, disjoint, chunk order
+    // The wire records (QueryWire.h) per destination slot, in stream order = ascending source row. Fused
+    // (value word after each record) iff capture_values.
+    std::vector<VecZ> queries;
+    // Per destination slot, the SOURCE row and emit phase of each record, parallel to the records of that
+    // slot (the self slot's parallel to `self`). Ascending in row, because the scan walks rows ascending:
+    // the absence pass and the graph sink's out lists rely on that order.
+    std::vector<std::vector<SentRecord>> sent;
+    // Parallel to `sent`: the pre-gate coefficient the partner would be minted with (Schrodinger: the
+    // state score of a fully paired partner, else 0). Only filled when a state mask is given, i.e. for
+    // the fused Schrodinger picture; read by the absence pass alone.
+    std::vector<std::vector<double>> sent_c0;
+    // Records addressed to this slot itself, staged as positions instead of encoded into the wire's self
+    // slot, and joined inline.
+    SelfQueryStage<NumModes> self;
 };
 
-// Classify, cut off and emit in one pass over the anticommuting terms. Queries go to the owner of
-// M'=M⊕G (routing::Router; self at R==1) in ascending source-index order, so resolve and index
-// assignment are deterministic. `fused_scale_coeffs` (no length cap only; must alias coeffs.data()) scales every
-// anticommuting coeff in place by `fused_scale_cos`=cos(2·build_angle), so no cosine set is built and a hit's stored
-// value is post-cos (resolve recovers it via 1/cos).
-template <size_t NumModes, Algebra A>
+/*! @brief Classify, cut off and emit in one pass over the anticommuting terms.
+ *
+ *  Every anticommuting row records its pivot bit (`foll`) in scratch.marks and then decides two things
+ *  about its partner M^G (Engine.h has the protocol):
+ *    E(M)    = coeff gate and pop gate and (struct_pass(partner) or is_above_upper(|c|))   its `rot` bit
+ *    send(M) = CaptureValues ? E(M) : struct_pass(partner) or over_cutoff_possible
+ *  The value path sends records for emitting terms ONLY: a silent term's contribution reaches its partner
+ *  as a round-2 response instead, so it needs neither the row, the merge nor the wire, and the coefficient
+ *  half of E is therefore tested first. Graph mode has no coefficients and so no silent terms to answer,
+ *  and keeps the symmetric predicate its positional in/out pairing is proved on.
+ *
+ *  Records go to the owner of the partner (routing::Router; self at R==1) in ascending source-index order,
+ *  so the join and the miss-index assignment are deterministic. The rows themselves are NOT indexed here:
+ *  the records probe the operator's persistent term table after the exchange (TableJoin.h), so the only
+ *  per-term row work the scan does is the partner merge every record needs anyway.
+ *
+ *  `fused_scale_coeffs` (no length cap only; must alias coeffs.data()) scales the anticommuting coeffs in
+ *  place by `fused_scale_cos` = cos(2*build_angle), so no cosine set is built; the value a record carries
+ *  is the PRE-cos coefficient, read before the store. EVERY anticommuting row is scaled here, in the one
+ *  pass that already has its value in a register; a silent row's pre-gate value, which the join owes a
+ *  partner that rotated it, is recovered from its swept slot as stored*(1/cos) (GateSinks.h ContractSink).
+ *
+ *  `state_mask` (Schrodinger fused picture only) switches on the c0 side channel in `sent_c0`.
+ */
+template <size_t NumModes, Algebra A, bool CaptureValues>
 auto fused_find_and_collect(const MPOperator<NumModes> &op,
                             const Monomial<NumModes> &gen,
                             const CutoffEvaluator<NumModes> &cutoff_eval,
                             const CutoffContext &cut_st,
                             const VecD &coeffs,
                             std::optional<size_t> only_rotate_len_k,
-                            const routing::Router &router,
+                            bool over_cutoff_possible,
                             size_t my_rank,
-                            bool capture_values = false,
+                            const routing::Router &router,
+                            GateScratch<NumModes> &scratch,
                             double *fused_scale_coeffs = nullptr,
-                            double fused_scale_cos = 1.0) -> FusedScanResult<NumModes> {
+                            double fused_scale_cos = 1.0,
+                            const Monomial<NumModes> *state_mask = nullptr) -> FusedScanResult<NumModes> {
     validate_only_rotate_len_k_(only_rotate_len_k, 2 * NumModes);
-    // The flat world the router indexes: R ranks x S partitions, which is what mpi::size reports.
-    const size_t rank_count = router.flat_world();
     const size_t gen_pop = gen.count();
+    const size_t rank_count = router.flat_world();
     const auto ectx = A::make_gen_context(gen);
 
+    // The value path is exactly the path that answers silent hits with a response (Engine.h,
+    // ContractSink::wants_responses), and so the path whose send predicate is E(M) alone.
+    constexpr bool kAnswerSilentHits = CaptureValues;
+
     FusedScanResult<NumModes> res;
-    res.leader_queries.assign(rank_count, VecZ{});
-    res.leader_src.assign(rank_count, std::vector<size_t>{});
-    res.follower_queries.assign(rank_count, VecZ{});
-    res.follower_src.assign(rank_count, std::vector<size_t>{});
-    // Sized to R even on the early-return paths below so the fused engine's per-rank src_val_r access
-    // is always in bounds (parallel to leader_src / follower_src).
-    if (capture_values) {
-        res.leader_val.assign(rank_count, std::vector<double>{});
-        res.follower_val.assign(rank_count, std::vector<double>{});
+    res.queries.assign(rank_count, VecZ{});
+    res.sent.assign(rank_count, std::vector<SentRecord>{});
+    res.self.keeps_values = CaptureValues;
+    // Sized on the early-return paths below too, so the engine's per-slot access is always in bounds.
+    if (state_mask != nullptr) {
+        res.sent_c0.assign(rank_count, std::vector<double>{});
     }
+    // No anticommuting words on an early return: nothing is sent, so the per-row marks stay untouched.
+    scratch.nz.clear();
 
     {
         // The anticommutation fold runs over G's inverted-index columns (Majorana: G; Pauli: J(G) =
@@ -278,8 +329,12 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
         const uint64_t *const row_parity_ptr = g_odd ? inverted_index.row_parity_words() : nullptr;
         const size_t n = op.store->size();
         // The fused sweep writes fused_scale_coeffs[i] for every anticommuting i < n, so it must be the
-        // very array the reads come from and cover the full operator — a violation corrupts 1/cos recovery.
+        // very array the reads come from and cover the full operator.
         assert(fused_scale_coeffs == nullptr || (fused_scale_coeffs == coeffs.data() && coeffs.size() >= n));
+        // The value path answers a silent hit out of `coeffs`, so it already requires one coefficient per
+        // pre-gate row. The hot arm below leans on that same contract to load a coefficient with no
+        // per-row bound; the other arms run where the picture may carry none.
+        assert((!CaptureValues || coeffs.size() >= n) && "the value path needs a coefficient per pre-gate row");
 
         const size_t last_word = word_count - 1;
         const uint64_t last_word_mask = (n % 64 == 0) ? ~uint64_t{0} : ((uint64_t{1} << (n % 64)) - 1);
@@ -301,78 +356,179 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
         // g_odd guard is load-bearing: an odd Majorana generator anticommutes with disjoint odd-weight terms.
         const bool skip_scan = !g_odd && fold_cols_empty;
 
-        auto &lq = res.leader_queries;
-        auto &ls = res.leader_src;
-        auto &lv = res.leader_val;
-        auto &fq = res.follower_queries;
-        auto &fs = res.follower_src;
-        auto &fv = res.follower_val;
-
         const OperatorIndex<NumModes> &ham = *op.store;
         using RowPosT = typename OperatorIndex<NumModes>::PosT;
+        using RowPositions = typename OperatorIndex<NumModes>::RowPositions;
+        RowMarks &marks = scratch.marks;
 
         // The generator's positions, once per gate: the merge's second input.
-        std::vector<uint16_t> gen_pos;
-        gen_pos.reserve(gen_pop);
+        std::vector<uint16_t> &gen_pos = scratch.gen;
+        gen_pos.clear();
         for (size_t b = gen.find_first(); b < gen.size(); b = gen.find_next(b)) {
             gen_pos.push_back(static_cast<uint16_t>(b));
         }
+        // Bound once per gate so the per-record fold never re-enters routing's static-init guard.
+        const uint64_t *const labels = routing::linear_basis<2 * NumModes>().data();
         // pbuf capacity is 2*NumModes: the partner's positions are distinct, so this always suffices.
-        std::vector<RowPosT> pbuf(2 * NumModes);
+        std::vector<RowPosT> &pbuf = scratch.partner;
+        if (pbuf.size() < 2 * NumModes) {
+            pbuf.resize(2 * NumModes);
+        }
+        // Every flag emit_row reads on every emitting row, by value rather than through the closure: a
+        // noinline lambda reloads a captured reference per call, which is most of what its frame costs.
+        const bool need_dense = (rank_count != 1 && !router.is_linear()) || !cutoff_eval.has_digest_form()
+                                || !A::sign_from_positions_ok(ectx);
+        const bool over_cutoff = over_cutoff_possible;
+        const bool multi_rank = rank_count != 1;
+        const Monomial<NumModes> *const mask = state_mask;
+        double *const sweep_on_emit = fused_scale_coeffs;
+        // And when the whole flat slot is linear, so is the destination: flat(M^G) = flat(M) ^
+        // flat_shift(G), and flat(M) is this slot. Present exactly when nothing has to fold the partner's
+        // fingerprint to route it (Routing.h is_flat_linear: splitmix, R == 1 and a non-power-of-two S
+        // are the exceptions, and those keep the fold).
+        const std::optional<size_t> gen_flat_shift = router.flat_shift<NumModes>(gen);
+        const size_t partner_slot = gen_flat_shift.has_value() ? (my_rank ^ *gen_flat_shift) : my_rank;
+        const bool shift_routes = gen_flat_shift.has_value();
+#ifndef NDEBUG
+        // Per gate, not per record: both identities are properties of the router and the key map, so one
+        // dense partner witnesses them for the whole gate.
+        bool routing_checked = false;
+#endif
 
-        auto push = [&](const Monomial<NumModes> &dense,
+        // `r_prime` is the partner's owning slot, decided by the caller (routing::Router is the only owner
+        // function; find_rank (MPIUtils.h) must stay in step with it or a term is placed and queried on
+        // different ranks, which duplicates a row silently), and `tag_partner` the partner's join tag.
+        auto push = [&](size_t r_prime,
+                        uint32_t tag_partner,
                         std::span<const RowPosT> pos,
                         int phase,
-                        size_t i,
+                        bool rot,
+                        size_t row,
                         double v_src,
-                        bool is_follower) {
-            // Single rank: every partner is self-owned, skip the O(W) map; multi-rank routes by owner.
-            // The Router is the single authority and find_rank calls the same dest(), or a term is
-            // placed and queried on different ranks, which duplicates a row silently;
-            // mpi_utils_tests.cpp asserts the two agree.
-            size_t r_prime = my_rank;
-            if (rank_count != 1) {
-                r_prime = router.dest<NumModes>(dense);
-            }
+                        double c0) {
             if (r_prime == my_rank) {
-                (is_follower ? res.follower_self : res.leader_self).push(pos, phase);
+                res.self.push(pos, phase, tag_partner, rot, v_src);
             }
             else {
-                QueryWire<NumModes>::push(is_follower ? fq[r_prime] : lq[r_prime], pos, phase);
+                VecZ &buf = res.queries[r_prime];
+                QueryWire<NumModes>::push(buf, pos, phase, rot);
+                if constexpr (CaptureValues) {
+                    QueryWire<NumModes>::push_value(buf, v_src);
+                }
             }
-            (is_follower ? fs[r_prime] : ls[r_prime]).push_back(i);
-            if (capture_values) {
-                (is_follower ? fv[r_prime] : lv[r_prime]).push_back(v_src);
+            res.sent[r_prime].push_back(SentRecord{static_cast<TermIndex>(row), static_cast<int8_t>(phase)});
+            if (mask != nullptr) {
+                res.sent_c0[r_prime].push_back(c0);
             }
         };
 
-        // The dynamic gate runs before emit_term_products, so a gate-rejected term computes no products.
-        // abs_c/v_src come from the caller's coeff read, not re-read.
-        auto emit = [&](size_t mono_pop, size_t i, double abs_c, double v_src, bool is_follower) {
-            if (!rotation_dynamic_gate(only_rotate_len_k, mono_pop, cut_st, abs_c)) {
-                return;
+        // Row i as the scan reads it: its positions (empty span for a spilled row) and popcount.
+        struct RowRead {
+            RowPositions src;
+            size_t pop;
+        };
+        // Read through the row store's chunk already resolved for i's 64-row window: every loop below
+        // walks an inverted-index word, so the chunk lookup is hoisted out of the row loop once and for
+        // all -- the emitting rows included.
+        using RowBlock = typename OperatorIndex<NumModes>::RowBlock;
+        auto read_row_in = [&](const RowBlock &block, size_t i) -> RowRead {
+            const RowPositions src = ham.positions_at(OperatorIndex<NumModes>::block_row(block, i));
+            if (src.inlined()) {
+                return {src, src.pos.size()};
             }
-            const auto p = emit_term_products<NumModes, A>(ham,
-                                                           i,
-                                                           ectx,
-                                                           std::span<const uint16_t>(gen_pos),
-                                                           std::span<RowPosT>(pbuf));
-            // Structural cutoff on the partner M⊕G, unless upper_atol rescues it (CutoffContext::is_above_upper).
-            const bool struct_pass = cutoff_eval.passes_with_popcount(p.new_mono, p.k);
-            if (!struct_pass && !cut_st.is_above_upper(abs_c)) {
-                return;
+            return {src, ham.popcount(i)};
+        };
+        /*! The emitting tail of one anticommuting row: the row read, the partner product, the structural
+         *  cutoff and the record. Deliberately NOT inlined: it runs only behind the coefficient gate --
+         *  about a fifth of Anti(G) on the value path -- so inlining it would put its frame, its spills
+         *  and its closure reloads on the silent path too, which is the cost the protocol exists to avoid.
+         *
+         *  `block` is row i's 64-row window, resolved once by the caller, so the row read below costs no
+         *  chunk lookup of its own. `pre` is the row when the caller has already read it (the orbital-gate
+         *  loop reads it for the cosine push), nullptr otherwise. Returns whether the row emitted, i.e.
+         *  whether `rot` was set: the caller owes a row that did not its share of the fused cos sweep.
+         */
+        auto emit_row = [&] [[gnu::noinline]] (const RowBlock &block,
+                                               size_t i,
+                                               const RowRead *pre,
+                                               double v_src,
+                                               double abs_c,
+                                               bool row_rot) -> bool {
+            const RowRead row = (pre != nullptr) ? *pre : read_row_in(block, i);
+            auto p = emit_partner<NumModes, A>(ham,
+                                               i,
+                                               row.src,
+                                               ectx,
+                                               std::span<const uint16_t>(gen_pos),
+                                               std::span<RowPosT>(pbuf),
+                                               need_dense,
+                                               /*need_sign=*/false);
+            // Structural cutoff on the partner, unless upper_atol rescues it (CutoffContext::is_above_upper).
+            const bool struct_pass = cutoff_eval.has_digest_form() ? cutoff_eval.passes_from_digest(p.k, p.paired)
+                                                                   : cutoff_eval.passes_with_popcount(p.dense, p.k);
+            if (!struct_pass && !over_cutoff) {
+                return false; // the partner cannot be tracked and would not be minted: nobody needs to hear
             }
-            const int phase = A::emit_phase(p.phase_factor, mono_pop, gen_pop, p.overlap);
-            push(p.new_mono, std::span<const RowPosT>(pbuf).first(p.k), phase, i, v_src, is_follower);
+            const bool rot = row_rot && (struct_pass || cut_st.is_above_upper(abs_c));
+            if (!rot && kAnswerSilentHits) {
+                return false; // silent on the partner's cutoff instead: answered the same way
+            }
+            if (rot) {
+                marks.set_rot(i);
+                // The fused cos sweep for an emitting row: the scale lands now, while v_src is still in a
+                // register. The record carries the pre-cos value, so nothing has to read this slot back.
+                // The caller scales the silent rows in the same pass.
+                if (sweep_on_emit != nullptr) {
+                    sweep_on_emit[i] = v_src * fused_scale_cos;
+                }
+            }
+            if (p.sign_pending) {
+                p.phase_factor = A::rotation_sign_positions(ectx, row.src.pos.data(), row.src.pos.size());
+            }
+            const int phase = A::emit_phase(p.phase_factor, row.pop, gen_pop, p.overlap);
+            double c0 = 0.0;
+            // Only an E-record can mint, so only it needs the fresh partner's pre-gate coefficient.
+            if (rot && mask != nullptr && digest_is_paired(p.k, p.paired)) {
+                c0 = A::state_phase_positions(pbuf.data(), p.k, *mask);
+            }
+            // The record's identity: the partner's own fingerprint, folded off the positions the merge has
+            // just written into pbuf -- one label XOR per position, and the row's key is not resident to
+            // XOR instead. Its top half is the join tag the table is keyed on, and a receiver folds the
+            // same number off the positions it decodes, so the two agree. k == 0 means the partner is the
+            // identity, i.e. the source is G itself, and the empty fold is 0 -- no special case.
+            const uint64_t fp_partner = routing::fingerprint_positions(labels, pbuf.data(), p.k);
+            const uint32_t tag_partner = join_tag(fp_partner);
+            // Where it goes. The XOR identity covers every flat-linear geometry; the two that are not (a
+            // non-power-of-two S under linear routing, and the splitmix router) still need a number of the
+            // partner's own -- the fingerprint just folded, or its dense form.
+            size_t r_prime = partner_slot;
+            if (multi_rank && !shift_routes) {
+                if (router.is_linear()) {
+                    r_prime = router.dest_from_fingerprint(fp_partner);
+                }
+                else {
+                    assert(p.has_dense);
+                    r_prime = router.dest<NumModes>(p.dense);
+                }
+            }
+#ifndef NDEBUG
+            if (p.has_dense && !routing_checked) {
+                routing_checked = true;
+                assert(r_prime == router.dest<NumModes>(p.dense)); // an identity
+                assert(tag_partner == key_of<NumModes>(p.dense));  // and so is this
+            }
+#endif
+            push(r_prime, tag_partner, std::span<const RowPosT>(pbuf).first(p.k), phase, rot, i, v_src, c0);
+            return rot;
         };
 
         // Pass 1 and pass 2 stay fused over `nz`: splitting them regressed measurably, as `nz` spills L1
-        // between them. `nz` is thread_local so each partition master reuses its capacity across gates.
-        thread_local std::vector<EvenParityNzWord> nz;
+        // between them. `nz` is scratch-owned, both to reuse its capacity across gates and because the
+        // join streams it again after the exchange (Engine.h).
+        std::vector<EvenParityNzWord> &nz = scratch.nz;
         size_t n_anti = 0;
-        size_t n_foll = 0;
         if (skip_scan) {
-            nz.clear(); // pass 1 clears it on entry; the skip must too (thread_local reuse)
+            nz.clear(); // pass 1 clears it on entry; the skip must too (the vector is reused)
         }
         else {
             even_parity_scan_pass1<NumModes>(inverted_index,
@@ -385,76 +541,112 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
                                              g_odd,
                                              row_parity_ptr,
                                              nz,
-                                             n_anti,
-                                             n_foll);
+                                             n_anti);
         }
+        // After pass 1, so the clear knows which words carry this gate's rows; before the emit pass, which
+        // is what sets them.
+        marks.begin(n, nz);
+        // The self-slot buffers are sized to what this gate will EMIT, not to the fold's tally. Reserving
+        // |Anti(G)| filled them to ~1.7 % of themselves in the lower_atol regime; dropping the reserve
+        // outright is not the answer either, the geometric growth it left behind costing 1.4 % of
+        // propagate. The previous gate's emitted count with a margin is a good enough estimate to leave
+        // one allocation, is capped by the fold's own bound, and when it falls short push() doubles as it
+        // always has.
         if (rank_count == 1) {
-            // A hint only; wider terms grow the buffer as needed.
-            const size_t pq = QueryWire<NumModes>::kReservePositionsPerQuery;
-            res.leader_self.reserve(n_anti - n_foll, pq);
-            ls[my_rank].reserve(n_anti - n_foll);
-            res.follower_self.reserve(n_foll, pq);
-            fs[my_rank].reserve(n_foll);
+            const size_t hint = scratch.self_records_hint;
+            const size_t want = std::min(n_anti, std::max(kSelfReserveFloor, hint + (hint / 4)));
+            res.self.reserve(want, QueryWire<NumModes>::kReservePositionsPerQuery);
+            res.sent[my_rank].reserve(want);
         }
-        auto derive_coeff = [&](size_t i) -> std::pair<double, double> {
-            if (capture_values) {
-                const double v_src = (i < coeffs.size()) ? coeffs[i] : 0.0;
-                return {v_src, cut_st.use_coeff_checks ? std::abs(v_src) : 0.0};
-            }
-            return {0.0, cut_st.abs_coeff_for(i, coeffs)};
-        };
+
+        // Everything the per-row loops read on every anticommuting row, hoisted out of them: through a
+        // closure these are reloaded per row, which is a third of the silent path's instructions.
+        const CutoffContext cut = cut_st;
+        const double *const coeff_ptr = coeffs.data();
+        const size_t coeff_n = coeffs.size();
+        // `use_coeff_checks` is fixed for the whole scan, so it rides the value as a mask rather than a
+        // per-row branch: clearing the sign bit is std::abs exactly, and a zero mask is the +0.0 the
+        // `false` arm produced. The branch cost three instructions on every anticommuting row.
+        const uint64_t abs_mask = cut.use_coeff_checks ? ~(uint64_t{1} << 63U) : uint64_t{0};
+        double *const sweep = fused_scale_coeffs;
+        const double sweep_cos = fused_scale_cos;
         const bool word_aligned_cos = !only_rotate_len_k.has_value();
+        // No orbital gate and no fused sweep: the whole word goes into the cosine set in one push.
+        const bool build_cos_words = word_aligned_cos && sweep == nullptr;
         CosineWordBuilder cos_b;
-        for (const auto &w : nz) {
-            if (word_aligned_cos && fused_scale_coeffs != nullptr) {
-                // Fused cos sweep: scaling in place here is what replaces building a cosine set.
-                for (uint64_t m = w.overlap; m; m &= m - 1) {
-                    const size_t tz = static_cast<size_t>(std::countr_zero(m));
-                    const size_t i = w.base + tz;
-                    const double v_src = fused_scale_coeffs[i];
-                    fused_scale_coeffs[i] = v_src * fused_scale_cos;
-                    const double abs_c = std::abs(v_src);
-                    if (cut_st.is_below_sin(abs_c)) {
-                        continue;
+
+        /*! One emit pass over the fold's words. `WordAlignedCos` (no orbital gate) decides whether the
+         *  cosine set is pushed per word or per passing index, and whether the row has to be read before
+         *  the coefficient gate; `CaptureValues` decides whether a silent row is skipped and swept or
+         *  still sends its rot=0 record. The four combinations are four instantiations of one body rather
+         *  than three hand-written loops.
+         */
+        auto emit_pass = [&]<bool WordAlignedCos>() {
+            for (const auto &w : nz) {
+                marks.set_foll_word(w.base / 64, w.foll);
+                // One chunk resolution per 64 rows; on the hot arm a silent row is never read at all.
+                const auto block = ham.row_block(w.base);
+                if constexpr (WordAlignedCos) {
+                    if (build_cos_words) {
+                        cos_b.push_word(w.base, w.overlap);
                     }
-                    const size_t mono_pop = op.store->popcount(i);
-                    const bool is_follower = (w.foll >> tz) & 1u;
-                    emit(mono_pop, i, abs_c, v_src, is_follower);
+                }
+                for (uint64_t m = w.overlap; m != 0U; m &= m - 1) {
+                    const size_t i = w.base + static_cast<size_t>(std::countr_zero(m));
+                    // The hot shape reads the coefficient with no bound: the value path guarantees one per
+                    // pre-gate row (asserted above). The other arms run where the picture may carry none.
+                    const double c =
+                        (WordAlignedCos && CaptureValues) ? coeff_ptr[i] : ((i < coeff_n) ? coeff_ptr[i] : 0.0);
+                    const double abs_c = std::bit_cast<double>(std::bit_cast<uint64_t>(c) & abs_mask);
+                    const double v_src = CaptureValues ? c : 0.0;
+                    if constexpr (WordAlignedCos) {
+                        if constexpr (CaptureValues) {
+                            // E(M) factorises: this half reads the coefficient alone, the other needs the
+                            // partner's digest. A record is silent iff this half already fails, so the
+                            // whole partner product -- the row read, the merge, the cutoff, the encoding --
+                            // is skipped for it. Exactness survives because a hit on this row is answered
+                            // with its value.
+                            if (rotation_coeff_gate(cut, abs_c)
+                                && emit_row(block, i, nullptr, v_src, abs_c, /*row_rot=*/true)) {
+                                continue;
+                            }
+                            if (sweep != nullptr) {
+                                sweep[i] = c * sweep_cos;
+                            }
+                        }
+                        else {
+                            // Graph mode: nothing is dropped for being silent -- a below-threshold term
+                            // still sends its rot=0 record, since its partner may rotate it.
+                            emit_row(block, i, nullptr, v_src, abs_c, rotation_coeff_gate(cut, abs_c));
+                        }
+                    }
+                    else {
+                        // Orbital gate active: the per-index cosine push covers only orbital-passing terms,
+                        // and the row it needs is the row the emit reads. A capped term still sends (with
+                        // rot=0) on the graph path, since its partner may rotate it.
+                        const RowRead row = read_row_in(block, i);
+                        if (row.pop <= static_cast<size_t>(*only_rotate_len_k)) {
+                            cos_b.push_index(i);
+                        }
+                        const bool row_rot =
+                            rotation_coeff_gate(cut, abs_c) && rotation_pop_gate(only_rotate_len_k, row.pop);
+                        if (row_rot || !CaptureValues) {
+                            emit_row(block, i, &row, v_src, abs_c, row_rot);
+                        }
+                    }
                 }
             }
-            else if (word_aligned_cos) {
-                // No orbital gate: record the whole word in the cosine set, then per bit apply the atol
-                // gate before the popcount row read — deferring popcount saves random packed-row loads.
-                cos_b.push_word(w.base, w.overlap);
-                for (uint64_t m = w.overlap; m; m &= m - 1) {
-                    const size_t tz = static_cast<size_t>(std::countr_zero(m));
-                    const size_t i = w.base + tz;
-                    const auto [v_src, abs_c] = derive_coeff(i);
-                    if (cut_st.is_below_sin(abs_c)) {
-                        continue;
-                    }
-                    const size_t mono_pop = op.store->popcount(i);
-                    const bool is_follower = (w.foll >> tz) & 1u;
-                    emit(mono_pop, i, abs_c, v_src, is_follower);
-                }
-            }
-            else {
-                // Orbital gate active: it needs mono_pop, and the per-index cosine push covers only
-                // orbital-passing terms, so the popcount row read must precede both.
-                for (uint64_t m = w.overlap; m; m &= m - 1) {
-                    const size_t tz = static_cast<size_t>(std::countr_zero(m));
-                    const size_t i = w.base + tz;
-                    const size_t mono_pop = op.store->popcount(i);
-                    if (mono_pop > static_cast<size_t>(*only_rotate_len_k)) {
-                        continue;
-                    }
-                    cos_b.push_index(i);
-                    const auto [v_src, abs_c] = derive_coeff(i);
-                    const bool is_follower = (w.foll >> tz) & 1u;
-                    emit(mono_pop, i, abs_c, v_src, is_follower);
-                }
-            }
+        };
+        if (word_aligned_cos) {
+            emit_pass.template operator()<true>();
         }
+        else {
+            // The fused sweep is off with an orbital gate by construction.
+            assert(sweep == nullptr && "the fused sweep does not run with an orbital gate");
+            emit_pass.template operator()<false>();
+        }
+        // After the emit pass, so it is the count this gate actually staged.
+        scratch.self_records_hint = res.self.size();
         res.cos_blocks.push_back(cos_b.finish());
     }
     return res;

--- a/cpp/monoprop/detail/evolution/layer_build/TableJoin.h
+++ b/cpp/monoprop/detail/evolution/layer_build/TableJoin.h
@@ -1,0 +1,102 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// The per-gate partner join as one batched probe of the operator's persistent term table.
+//
+// A record names its partner M^G by the partner's 4-byte join key (key(M) ^ key(G) at the sender, folded
+// off the decoded positions at a receiver) and its positions. The table (TermTable.h) maps that key to
+// the one row holding it, if any, so a gate's join is |Q| probes -- O(records) -- and never touches the
+// anticommuting rows no record names. At most one query can match a row: keys are M^G over globally
+// distinct sources and ^G is injective, so no two queries of one gate name the same monomial.
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "monoprop/TypeAliases.h"
+#include "monoprop/detail/operator/OperatorIndex.h"
+#include "monoprop/detail/operator/TermTable.h"
+
+namespace monoprop::detail {
+
+template <size_t NumModes>
+class TableJoin {
+public:
+    using PosT = typename OperatorIndex<NumModes>::PosT;
+
+    //! "No row matched this query". Valid rows are below the TermIndex ceiling, so the sentinel is free.
+    static constexpr size_t kMissing = static_cast<size_t>(std::numeric_limits<TermIndex>::max());
+    static constexpr TermIndex kMissingRow = std::numeric_limits<TermIndex>::max();
+
+    /*! @brief Sizes the hit slots, the join's only output, for a gate of `n_queries` records.
+     *
+     *  The order is the resolve's: the self-staged records first, then the delivered ones. A gate with a
+     *  very large record count must not pin its footprint, hence the 4x release rule.
+     */
+    auto begin_queries(size_t n_queries) -> void {
+        if (hit_.capacity() > 4 * std::max<size_t>(n_queries, kMinSlots)) {
+            hit_ = std::vector<TermIndex>{};
+        }
+        hit_.assign(n_queries, kMissingRow);
+        hits_ = 0;
+    }
+
+    /*! @brief Probes every query against @a table, filling hit().
+     *
+     *  `key_of(q)` / `pos_of(q)` are query q's join key and ascending positions; `on_hit(q, row)` is
+     *  TermTable::find_batch's, run at every confirm in query order within a group (the probe-phase mark).
+     *  @pre table.rows() == store.size(): the table covers every row a record could name.
+     */
+    template <typename KeyOf, typename PosOf, typename OnHit>
+    auto run(const TermTable &table,
+             const OperatorIndex<NumModes> &store,
+             KeyOf &&key_of,
+             PosOf &&pos_of,
+             OnHit &&on_hit) -> void {
+        assert(table.rows() == store.size() && "the term table must cover the whole store before a gate probes it");
+        hits_ = table.find_batch(store,
+                                 hit_.size(),
+                                 std::forward<KeyOf>(key_of),
+                                 std::forward<PosOf>(pos_of),
+                                 std::forward<OnHit>(on_hit),
+                                 std::span<TermIndex>(hit_),
+                                 kMissingRow);
+    }
+
+    //! The row query `q` matched, or kMissing: the partner is absent from this slot.
+    [[nodiscard]] auto hit(size_t q) const -> size_t {
+        const TermIndex row = hit_[q];
+        return (row == kMissingRow) ? kMissing : static_cast<size_t>(row);
+    }
+
+    [[nodiscard]] auto queries() const -> size_t { return hit_.size(); }
+    //! Queries that confirmed a row, so queries() - hits() is the gate's exact mint count.
+    [[nodiscard]] auto hits() const -> size_t { return hits_; }
+
+    [[nodiscard]] auto memory_bytes() const -> size_t { return hit_.capacity() * sizeof(TermIndex); }
+
+private:
+    static constexpr size_t kMinSlots = 16;
+
+    std::vector<TermIndex> hit_; // query -> matching row, kMissingRow for a miss
+    size_t hits_ = 0;            // rows confirmed this gate: what the resolve phase sizes by
+};
+
+} // namespace monoprop::detail

--- a/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
+++ b/cpp/monoprop/detail/monomial_propagator/MonomialPropagator.inl
@@ -248,7 +248,7 @@ MonomialPropagator<NumModes>::MonomialPropagator(const MonomialPropagator &other
       cutoff_fn_(other.cutoff_fn_),
       mp_op_(other.mp_op_),
       graph_(other.graph_),
-      matched_scratch_(other.matched_scratch_),
+      gate_scratch_(), // capacity only: nothing in it outlives a gate, and its bases would be stale
       cutoff_(other.cutoff_),
       lower_atol_(other.lower_atol_),
       upper_atol_(other.upper_atol_),
@@ -697,7 +697,7 @@ auto MonomialPropagator<NumModes>::evolve_mode_contract_immediately_(const std::
             bool fused_scale = false;
             build_evolve_result_(mono, rot_len, std::cref(*op_coeffs), build_angle, &cos, &fc, op_coeffs, &fused_scale);
             extend_coeffs_from_current_picture_if_needed_(*op_coeffs);
-            detail::apply_fused_contract(fc, *op_coeffs, cos, apply_angle, schrodinger_, fused_scale);
+            detail::apply_fused_contract(fc, *op_coeffs, cos, apply_angle, fused_scale);
         });
 }
 
@@ -840,11 +840,53 @@ auto MonomialPropagator<NumModes>::report_routing_coverage_(const std::vector<Ve
 }
 
 template <size_t NumModes>
+auto MonomialPropagator<NumModes>::any_local_term_fails_cutoff_() const -> bool {
+    const detail::CutoffEvaluator<NumModes> eval(cutoff_fn_);
+    // Both structural forms keep any term with popcount <= cutoff (or_sum <= popcount), so only the rows
+    // above it are materialised.
+    std::optional<size_t> quick;
+    if (const auto *lc = eval.length_cutoff(); lc != nullptr) {
+        quick = lc->cutoff;
+    }
+    else if (const auto *sc = eval.support_cutoff(); sc != nullptr) {
+        quick = sc->cutoff;
+    }
+    const auto &store = *mp_op_.store;
+    const bool digest_form = eval.has_digest_form();
+    for (size_t i = 0; i < store.size(); ++i) {
+        const size_t pop = store.popcount(i);
+        if (quick.has_value() && pop <= *quick) {
+            continue;
+        }
+        // Both structural cutoffs are functions of the (k, d) digest, which the row's own position list
+        // yields directly -- only an opaque cutoff or a spilled row (no position array) needs a bitset.
+        const auto src = store.row_positions(i);
+        if (digest_form && src.inlined()) {
+            if (!eval.passes_from_digest(pop, detail::count_paired_positions(src.pos.data(), pop))) {
+                return true;
+            }
+            continue;
+        }
+        if (!eval(store.row(i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template <size_t NumModes>
 template <typename EvolutionFunc>
 auto MonomialPropagator<NumModes>::run_gate_loop_(const std::vector<VecZ> &majoranas,
                                                   std::optional<size_t> only_rotate_len_k,
                                                   EvolutionFunc evolution_func) -> void {
     report_routing_coverage_(majoranas);
+    // Terms inserted during this call pass the cutoff unless upper_atol rescues them, so one agreement per
+    // call covers every gate. A sum of 0/1 flags is the OR; it is a collective, so every participant runs
+    // it whatever its local answer.
+    const size_t local_fails = any_local_term_fails_cutoff_() ? 1 : 0;
+    over_cutoff_possible_ = upper_atol_.has_value() || mpi::allreduce_sum<size_t>(local_fails, comm_) != 0;
+    gate_scratch_.counters = detail::ExchangeCounters{};
+    gate_scratch_.buffers_hwm_bytes = 0;
     mp_op_.reset_op_coeffs_slack_hwm();
     // Serial per partition; parallelism comes from partitioning the operator across cores.
     for (size_t i = 0; i < majoranas.size(); ++i) {
@@ -858,7 +900,30 @@ auto MonomialPropagator<NumModes>::run_gate_loop_(const std::vector<VecZ> &major
         }
     }
 
+    report_comm_profile_();
+
     initialize_operator_caches_();
+}
+
+template <size_t NumModes>
+auto MonomialPropagator<NumModes>::report_comm_profile_() const -> void {
+    if (!config::get().comm_profile) {
+        return;
+    }
+    // One greppable line per slot: what this slot SENT over the call's exchanging gates (graph mode never
+    // sends a response, so its responses column is 0).
+    const auto &c = gate_scratch_.counters;
+    const double gates = (c.gates == 0) ? 1.0 : static_cast<double>(c.gates);
+    const auto line = std::format("COMMPROF slot={} gates={} records={} responses={} records_per_gate={:.1f} "
+                                  "responses_per_gate={:.1f}\n",
+                                  static_cast<size_t>(mpi::rank(comm_)),
+                                  c.gates,
+                                  c.records,
+                                  c.responses,
+                                  static_cast<double>(c.records) / gates,
+                                  static_cast<double>(c.responses) / gates);
+    std::fputs(line.c_str(), stderr);
+    std::fflush(stderr);
 }
 
 template <size_t NumModes>
@@ -883,7 +948,8 @@ auto MonomialPropagator<NumModes>::build_evolve_result_(const VecZ &gen_vec,
                                          upper_atol_,
                                          param,
                                          only_rotate_len_k,
-                                         matched_scratch_,
+                                         over_cutoff_possible_,
+                                         gate_scratch_,
                                          comm_,
                                          out_cos,
                                          fused_contract,

--- a/cpp/monoprop/detail/operator/MPOperator.h
+++ b/cpp/monoprop/detail/operator/MPOperator.h
@@ -348,8 +348,9 @@ struct MPOperatorMemoryBreakdown final {
     size_t init_operator_bytes{0uz};
     size_t initial_state_bytes{0uz};
     size_t inverted_index_bytes{0uz};
-    // The MatchedEpochSet stamp array. Propagator-owned, so 0 unless MonomialPropagator fills it in.
-    size_t matched_scratch_bytes{0uz};
+    // The layer build's per-gate scratch (GateScratch), whose capacity survives from gate to gate.
+    // Propagator-owned, so 0 unless MonomialPropagator fills it in.
+    size_t gate_scratch_bytes{0uz};
 
     // Diagnostics: breakdowns of the fields above, deliberately excluded from total_bytes() so they can
     // never double-count.
@@ -376,6 +377,13 @@ struct MPOperatorMemoryBreakdown final {
      *  the comm's memory, not the operator's, and total_bytes() is an operator figure.
      */
     size_t wire_staging_bytes{0uz};
+    /*! @brief The widest instant of the gate exchange's per-gate buffers over the last call.
+     *
+     *  Those buffers die with their gate or are resized under the next one, so no resting figure can name
+     *  their peak. Not in total_bytes(): it is a high-water mark over a call, not a resident size, and it
+     *  overlaps the part of gate_scratch_bytes whose capacity the scratch keeps for reuse.
+     */
+    size_t gate_buffers_hwm_bytes{0uz};
     // of op_coeffs_bytes: the most capacity the coefficient array held beyond its live rows at any
     // point in the last propagate or build_graph call. A high-water mark, not a resting figure: the
     // array is shrunk to fit at the end of every call, so measured at quiescence the slack is always 0.
@@ -387,7 +395,7 @@ struct MPOperatorMemoryBreakdown final {
 
     auto total_bytes() const -> size_t {
         return operator_terms_bytes + op_coeffs_bytes + state_coeffs_bytes + indexing_bytes + init_operator_bytes
-               + initial_state_bytes + inverted_index_bytes + matched_scratch_bytes;
+               + initial_state_bytes + inverted_index_bytes + gate_scratch_bytes;
     }
 
     auto operator+=(const MPOperatorMemoryBreakdown &o) -> MPOperatorMemoryBreakdown & {
@@ -398,7 +406,7 @@ struct MPOperatorMemoryBreakdown final {
         init_operator_bytes += o.init_operator_bytes;
         initial_state_bytes += o.initial_state_bytes;
         inverted_index_bytes += o.inverted_index_bytes;
-        matched_scratch_bytes += o.matched_scratch_bytes;
+        gate_scratch_bytes += o.gate_scratch_bytes;
         inverted_index_dense_bytes += o.inverted_index_dense_bytes;
         inverted_index_sparse_bytes += o.inverted_index_sparse_bytes;
         inverted_index_dense_columns += o.inverted_index_dense_columns;
@@ -411,6 +419,9 @@ struct MPOperatorMemoryBreakdown final {
         pool_free_chunk_bytes += o.pool_free_chunk_bytes;
         // Summed although it is per-rank, because only one partition reports a nonzero: see the field.
         wire_staging_bytes += o.wire_staging_bytes;
+        // Summed, not maxed: the partitions run their gates concurrently, so the per-process transient
+        // peak is the sum of theirs. An upper bound, and it errs the safe way.
+        gate_buffers_hwm_bytes += o.gate_buffers_hwm_bytes;
         // Summed, not maxed, across partitions: the partitions grow together within a call, so the sum
         // is the figure a per-process footprint wants. An upper bound, and it errs the safe way.
         op_coeffs_slack_bytes += o.op_coeffs_slack_bytes;

--- a/cpp/monoprop/detail/operator/TermTable.h
+++ b/cpp/monoprop/detail/operator/TermTable.h
@@ -128,23 +128,30 @@ public:
         return find(store, key_of_positions<2 * NumModes>(pos.data(), k), std::span<const PosT>(pos.data(), k));
     }
 
-    /*! @brief Probes @a n queries in order: out[q] = the confirmed row of query q, or kNotFound.
+    /*! @brief Probes @a n queries in order, out[q] = the confirmed row of query q, or @a not_found.
      *
-     *  `key_of(q)` is query q's join key and `pos_of(q)` its ascending positions (the confirm). Same
-     *  result as n calls to find(), query by query; the group pipeline overlaps the three dependent
-     *  misses of a probe (slot line, chain walk, row) across kGroup queries, and a prefilter match the
+     *  `key_of(q)` is query q's join key and `pos_of(q)` its ascending positions (the confirm).
+     *  `on_hit(q, row)` runs at every confirm, in query order within a group.
+     *
+     *  Same result as n calls to find(), query by query. The group pipeline overlaps the three dependent
+     *  misses of a probe (slot line, chain walk, row) across kGroup queries; a prefilter match that the
      *  row refutes resumes the chain synchronously, which a 32-bit collision is rare enough to afford.
+     *
+     *  @return How many queries confirmed a row.
      */
-    template <size_t NumModes, typename KeyOf, typename PosOf>
+    template <size_t NumModes, typename KeyOf, typename PosOf, typename OnHit>
     auto find_batch(const OperatorIndex<NumModes> &store,
                     size_t n,
                     KeyOf &&key_of,
                     PosOf &&pos_of,
-                    std::span<size_t> out) const -> void {
+                    OnHit &&on_hit,
+                    std::span<TermIndex> out,
+                    TermIndex not_found) const -> size_t {
         assert(out.size() >= n && "one output slot per query");
+        size_t hits = 0;
         if (rows_ == 0) {
-            std::fill_n(out.begin(), n, kNotFound);
-            return;
+            std::fill_n(out.begin(), n, not_found);
+            return 0;
         }
         std::array<bool, kGroup> cand{};
         std::array<size_t, kGroup> at{};
@@ -174,16 +181,25 @@ public:
                 }
             }
             for (size_t j = 0; j < g; ++j) {
+                const size_t q = base + j;
                 if (!cand[j]) {
-                    out[base + j] = kNotFound;
+                    out[q] = not_found;
                     continue;
                 }
-                const auto pos = pos_of(base + j);
+                const auto pos = pos_of(q);
                 const size_t first = slots[at[j]] & mask_;
-                out[base + j] =
+                const size_t row =
                     store.row_eq_positions(first, pos) ? first : find_from_(store, (at[j] + 1) & mask_, pf[j], pos);
+                if (row == kNotFound) {
+                    out[q] = not_found;
+                    continue;
+                }
+                out[q] = static_cast<TermIndex>(row);
+                ++hits;
+                on_hit(q, row);
             }
         }
+        return hits;
     }
 
     /*! @brief The hash a key's slot and prefilter are cut from: splitmix64's finalizer over the key.

--- a/cpp/tests/README.md
+++ b/cpp/tests/README.md
@@ -94,6 +94,8 @@ name and cannot address suite-nested cases, tests use flat
   diagnostic, the non-power-of-two throw and the shipped default),
   `env_config_tests.cpp` (the environment parsers, which throw rather than
   default on a malformed routing knob),
+  `position_kernels_tests.cpp` (the position-only emit kernels -- both algebras'
+  rotation sign and the (k, d) digest cutoff -- against their dense oracles),
   `evolution_detail_tests.cpp` (MatchedEpochSet + CutoffContext),
   `row_accessor_tests.cpp` (dense vs OperatorIndex row accessors).
 - **Operator store**: `chunked_array_tests.cpp` (the pooled chunk allocator and

--- a/cpp/tests/README.md
+++ b/cpp/tests/README.md
@@ -88,7 +88,8 @@ name and cannot address suite-nested cases, tests use flat
   CutoffEvaluator, interleave phase, coeff encode/decode, cutoff_sums vs a
   bitwise reference), `validation_tests.cpp`
   (parameter validators), `mpi_utils_tests.cpp` (find_rank, word serialization,
-  scan routing agreement under both routers, the routing-agreement check),
+  scan routing agreement under both routers and the per-slot sent-ordinal lists,
+  the routing-agreement check),
   `routing_tests.cpp` (Router term -> flat-slot map: the splitmix equivalence
   with `hash % P`, the linear shift identity, the gf2_rank coverage
   diagnostic, the non-power-of-two throw and the shipped default),
@@ -96,7 +97,10 @@ name and cannot address suite-nested cases, tests use flat
   default on a malformed routing knob),
   `position_kernels_tests.cpp` (the position-only emit kernels -- both algebras'
   rotation sign and the (k, d) digest cutoff -- against their dense oracles),
-  `evolution_detail_tests.cpp` (MatchedEpochSet + CutoffContext),
+  `evolution_detail_tests.cpp` (the one-round gate exchange on a hand-built
+  scan: the receiver rule at the join, the absence pass, the fused and graph
+  sinks' outputs, the emit-phase antisymmetry it rests on, the receiver rule end
+  to end through propagate(), the Schrödinger c0 channel, and CutoffContext),
   `row_accessor_tests.cpp` (dense vs OperatorIndex row accessors).
 - **Operator store**: `chunked_array_tests.cpp` (the pooled chunk allocator and
   the chunked arrays on it: arena reuse, unmapping read from
@@ -118,10 +122,16 @@ name and cannot address suite-nested cases, tests use flat
   coefficient growth policy, memory estimate and its row-tier and pool fields,
   deep copy).
 - **Layer build / evolution**: `build_graph_tests.cpp`,
-  `pauli_build_layer_tests.cpp`, `fused_cos_sweep_tests.cpp`,
+  `pauli_build_layer_tests.cpp`, `fused_cos_sweep_tests.cpp` (the sweep against
+  the build_graph replay, and which endpoint of a pair reads a partner value
+  recovered from its swept slot),
   `sparse_query_tests.cpp` (the QueryWire wire record against the frozen dense
-  oracle, plus the fused value channel), `sparse_resolve_tests.cpp` (probe and
-  insert from wire positions vs the dense Monomial-keyed path),
+  oracle, plus the fused value channel and the rot bit's header shapes),
+  `sparse_resolve_tests.cpp` (the receiver side: decode, join and mint from wire
+  positions vs the dense Monomial-keyed path),
+  `graph_pair_order_tests.cpp` (an in-process ShmComm world: every (p, q)
+  out-part length equals q's in-part length, and the graph replay reproduces the
+  fused propagate to a few ULP),
   `combined_recompute_equivalence.cpp` (recompute equivalence +
   snapshot invariance), `exact_upper_atol_rescue.cpp`,
   `large_cosine_storage_tests.cpp`, `gate_boundaries.cpp`.
@@ -140,7 +150,7 @@ name and cannot address suite-nested cases, tests use flat
   path's transport gate: which arm `wire_bits` picks and what the ticket has to
   drain, never inferred from the layout), `partition_equivalence_tests.cpp`,
   `mpi_distributed_layer_equivalence.cpp`, `mpi_fresh_insert_equivalence.cpp`
-  (serial↔world equivalence of the Schrödinger fused-resolve fresh-insert arms,
+  (serial↔world equivalence of the Schrödinger one-round fresh-insert arms,
   Majorana + native Pauli; self-skips at world size 1).
 - **Simulator / operator lifecycle**: `simulator_copy_tests.cpp`,
   `update_initial_operator.cpp`, `ctor_validation_tests.cpp` (constructor guard

--- a/cpp/tests/evolution_detail_tests.cpp
+++ b/cpp/tests/evolution_detail_tests.cpp
@@ -12,169 +12,830 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// MatchedEpochSet, CutoffContext and the self-resolve mark guard driven directly, not through build_layer.
+// The gate exchange (Engine.h): the join, response and absence rules driven directly on a hand-built scan
+// result, the graph sink's endpoint layout, the phase antisymmetry the protocol's exactness rests on, and
+// the receiver rule end to end through propagate() on two-term operators. Plus the CutoffContext predicates.
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
+#include <random>
+#include <span>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "monoprop/MonomialPropagator.h"
 #include "monoprop/TypeAliases.h"
 #include "monoprop/algebra/Algebra.h"
 #include "monoprop/detail/evolution/CutoffContext.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
 #include "monoprop/detail/evolution/layer_build/Engine.h"
+#include "monoprop/detail/evolution/layer_build/GateSinks.h"
+#include "monoprop/detail/evolution/layer_build/Scan.h"
+#include "monoprop/detail/evolution/layer_build/TableJoin.h"
+#include "monoprop/detail/graph_encoding/MPGraphEncodingStorage.h"
+#include "monoprop/detail/mpi/MPICompat.h"
+#include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
 #include "monoprop/detail/operator/RowAccess.h"
 
 using namespace monoprop;
 using monoprop::detail::CutoffContext;
-using monoprop::detail::MatchedEpochSet;
 
 namespace {
 
-// resolve_range_ touches only wants_values and self_hit, so the engine drives without the cross-rank sink surface.
+// Records every sink surface in call order. wants_responses is false: this sink is the oracle for the
+// symmetric stream graph mode sends, where a silent row sends a record of its own instead of answering.
 struct RecordingSink {
-    static constexpr bool wants_values = false;
-    std::vector<std::pair<size_t, size_t>> hits; // (src, found)
-    auto self_hit(size_t src, size_t found, int /*phase*/, double /*v_src*/) -> void { hits.emplace_back(src, found); }
+    static constexpr bool wants_values = true;
+    static constexpr bool wants_responses = false;
+    [[nodiscard]] auto incoming_form() const -> detail::QueryForm { return detail::QueryForm::Fused; }
+
+    struct Rec {
+        std::string kind;
+        size_t slot;
+        size_t idx;
+        double v;
+        int phase;
+        bool foll;
+    };
+    std::vector<Rec> recs;
+
+    auto hit(size_t slot, size_t row, double v, int phase, bool foll, bool /*own_rot*/) -> void {
+        recs.push_back({"hit", slot, row, v, phase, foll});
+    }
+    auto mint(size_t slot, size_t idx, double v, int phase) -> void {
+        recs.push_back({"mint", slot, idx, v, phase, false});
+    }
+    auto out_pair(size_t slot, size_t row, int phase) -> void {
+        recs.push_back({"out_pair", slot, row, 0.0, phase, false});
+    }
+    auto out_unanswered(size_t slot, size_t row, double c0, int phase) -> void {
+        recs.push_back({"out_unanswered", slot, row, c0, phase, false});
+    }
+    //! The engine's per-gate bound on the four surfaces above; here it only pre-sizes the log.
+    auto reserve_halves(size_t upper_bound) -> void { recs.reserve(upper_bound); }
 };
 
-// Rows in through the engine's growth door, so the operator's term table follows them.
-auto indexed_op(const std::vector<Monomial<8>> &terms) -> detail::MPOperator<8> {
-    detail::MPOperator<8> op;
-    detail::insert_absent_terms<8>(op, terms.size(), [&](size_t k, size_t base) {
-        assign_row<8>(*op.store, base + k, terms[k]);
+// The same, for the value path: it answers a hit on a silent row, and its response payload names the row
+// it was read from so a case can assert which row answered.
+struct AnsweringSink : RecordingSink {
+    static constexpr bool wants_responses = true;
+
+    [[nodiscard]] auto silent_value(size_t row) const -> double { return 100.0 + static_cast<double>(row); }
+    auto answer(size_t slot, size_t row, double v, int phase) -> void {
+        recs.push_back({"answer", slot, row, v, phase, false});
+    }
+};
+
+constexpr size_t kN = 8;
+using Op = detail::MPOperator<kN>;
+using RowPosT = detail::OperatorIndex<kN>::PosT;
+
+auto indexed_op(const std::vector<Monomial<kN>> &terms) -> Op {
+    Op op;
+    detail::insert_absent_terms<kN>(op, terms.size(), [&](size_t k, size_t base) {
+        assign_row<kN>(*op.store, base + k, terms[k]);
     });
     return op;
 }
 
+auto positions_of(const Monomial<kN> &m) -> std::vector<RowPosT> {
+    std::vector<RowPosT> pos;
+    for (size_t b = m.find_first(); b < m.size(); b = m.find_next(b)) {
+        pos.push_back(static_cast<RowPosT>(b));
+    }
+    return pos;
+}
+
+auto fp_of(const Monomial<kN> &m) -> uint64_t {
+    const auto pos = positions_of(m);
+    return routing::fingerprint_positions(routing::linear_basis<2 * kN>().data(), pos.data(), pos.size());
+}
+
+//! The join tag a record for `m` carries: the same map the store's per-row key uses.
+auto tag_of(const Monomial<kN> &m) -> uint32_t {
+    return detail::join_tag(fp_of(m));
+}
+
+// The scenario every engine case below runs: six tracked anticommuting rows t0..t5, each sending one
+// self-addressed record in stream order. Odd rows carry the pivot (foll).
+//
+//   src  key         rot  phi  v      expectation at the join
+//   t0   t1 (hit)    1    +1   0.5    hit: rotates by the record's rot
+//   t1   X  (absent) 1    -1   0.25   mint at base+0
+//   t2   t3 (hit)    0    +1   0.75   hit: rotates by t3's own rot
+//   t3   t2 (hit)    1    -1   1.5    hit on a leader row (foll clear)
+//   t4   t5 (hit)    0    +1   2.0    hit: rotates by t5's own rot
+//   t5   Y  (absent) 0    +1   3.0    dropped: a silent record that missed mints nothing
+//
+// Own rot bits: t0, t1, t3, t5. Nobody sends key t0 or t4, so those are the unanswered ones.
+struct Scenario {
+    std::vector<Monomial<kN>> terms;
+    Monomial<kN> absent_x = indices_to_bitset<kN>({2, 3});
+    Monomial<kN> absent_y = indices_to_bitset<kN>({4, 5});
+    Op op;
+    detail::GateScratch<kN> scratch;
+    // The scan's product: rows 0..5 are the gate's anticommuting set, all in word 0.
+    std::vector<detail::EvenParityNzWord> nz{{.base = 0, .overlap = 0b11'1111, .foll = 0b10'1010}};
+
+    Scenario() {
+        for (size_t i = 0; i < 6; ++i) {
+            terms.push_back(indices_to_bitset<kN>({i, i + 8}));
+        }
+        op = indexed_op(terms);
+        scratch.nz = nz;
+        scratch.marks.begin(terms.size(), nz);
+        for (size_t i = 0; i < terms.size(); ++i) {
+            if (i % 2 == 1) {
+                scratch.marks.set_foll(i);
+            }
+        }
+        for (const size_t row : {0U, 1U, 3U, 5U}) {
+            scratch.marks.set_rot(row);
+        }
+    }
+
+    // Probes `n` queries against the fixture's store, as the engine does between the exchange and the
+    // resolve.
+    template <typename KeyOf, typename PosOf>
+    auto probe(size_t n, KeyOf &&key_of, PosOf &&pos_of) -> void {
+        scratch.join.begin_queries(n);
+        scratch.join.run(op.term_table(), *op.store, key_of, pos_of, [](size_t, size_t) {});
+    }
+
+    //! An R = 1 scan result: every record is self-addressed, so the wire's own slot stays empty.
+    static auto empty_scan() -> detail::FusedScanResult<kN> {
+        detail::FusedScanResult<kN> res;
+        res.queries.assign(1, VecZ{});
+        res.sent.assign(1, {});
+        return res;
+    }
+
+    auto scan(bool with_c0) -> detail::FusedScanResult<kN> {
+        auto res = empty_scan();
+        if (with_c0) {
+            res.sent_c0.assign(1, {});
+            res.sent_c0[0] = {-1.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        }
+        auto push = [&](const Monomial<kN> &key, int phase, bool rot, double v, size_t row) {
+            res.self.keeps_values = true;
+            res.self.push(positions_of(key), phase, tag_of(key), rot, v);
+            res.sent[0].push_back(
+                detail::SentRecord{.row = static_cast<TermIndex>(row), .phase = static_cast<int8_t>(phase)});
+        };
+        push(terms[1], 1, true, 0.5, 0);
+        push(absent_x, -1, true, 0.25, 1);
+        push(terms[3], 1, false, 0.75, 2);
+        push(terms[2], -1, true, 1.5, 3);
+        push(terms[5], 1, false, 2.0, 4);
+        push(absent_y, 1, false, 3.0, 5);
+        return res;
+    }
+
+    // The value path's stream over the same rows: only the four EMITTING rows send, so every record
+    // carries rot=1 and the three answers a record can get are all present at once.
+    //
+    //   src  key         phi  v      outcome
+    //   t0   t1 (hit)    +1   0.5    symmetric pair with t1: both emit, so neither is answered
+    //   t1   t0 (hit)    -1   0.25   the other half of it
+    //   t3   t2 (hit)    -1   1.5    t2 is SILENT -> response, so t3 is answered and not absent
+    //   t5   X  (absent) +1   3.0    miss -> mint, and t5 takes the absence add
+    // Own rot bits are the fixture's {t0, t1, t3, t5}; t2 and t4 are the silent rows.
+    auto value_scan() -> detail::FusedScanResult<kN> {
+        auto res = empty_scan();
+        res.sent_c0.assign(1, {});
+        res.sent_c0[0] = {0.0, 0.0, 0.0, -1.0};
+        auto push = [&](const Monomial<kN> &key, int phase, double v, size_t row) {
+            res.self.keeps_values = true;
+            res.self.push(positions_of(key), phase, tag_of(key), /*rot=*/true, v);
+            res.sent[0].push_back(
+                detail::SentRecord{.row = static_cast<TermIndex>(row), .phase = static_cast<int8_t>(phase)});
+        };
+        push(terms[1], 1, 0.5, 0);
+        push(terms[0], -1, 0.25, 1);
+        push(terms[2], -1, 1.5, 3);
+        push(absent_x, 1, 3.0, 5);
+        return res;
+    }
+};
+
 } // namespace
 
-BOOST_AUTO_TEST_CASE(matched_epoch_begin_gate_clears_all) {
-    MatchedEpochSet set;
-    set.begin_gate(5);
-    set.mark(2);
-    set.mark(4);
-    BOOST_TEST(set.is_marked(2));
-    BOOST_TEST(set.is_marked(4));
-    BOOST_TEST(!set.is_marked(0));
+// The receiver rule on the self slot: hits rotate iff rot_rec or rot_own, a rot=1 miss mints at base+j, a
+// rot=0 miss is dropped, and the absence pass reports the unanswered E-record and the answered leader.
+BOOST_AUTO_TEST_CASE(one_round_join_applies_the_receiver_rule) {
+    Scenario sc;
+    detail::LayerBuildEngine<kN, RecordingSink> eng(sc.op,
+                                                    mpi::Comm{},
+                                                    /*R_=*/1,
+                                                    /*my_rank_=*/0,
+                                                    sc.scratch,
+                                                    /*combined_size_=*/6,
+                                                    RecordingSink{});
+    eng.exchange_and_join(sc.scan(/*with_c0=*/true));
 
-    set.begin_gate(5);
-    BOOST_TEST(!set.is_marked(2));
-    BOOST_TEST(!set.is_marked(4));
-    set.mark(0);
-    BOOST_TEST(set.is_marked(0));
-    BOOST_TEST(!set.is_marked(2));
+    const auto &r = eng.sink.recs;
+    BOOST_REQUIRE_EQUAL(r.size(), 7U);
+    // Join, in stream order.
+    BOOST_TEST(r[0].kind == "hit");
+    BOOST_TEST(r[0].idx == 1U);
+    BOOST_TEST(r[0].v == 0.5);
+    BOOST_TEST(r[0].phase == 1);
+    BOOST_TEST(r[0].foll);
+    BOOST_TEST(r[1].kind == "mint");
+    BOOST_TEST(r[1].idx == 6U); // base + 0
+    BOOST_TEST(r[1].v == 0.25);
+    BOOST_TEST(r[1].phase == -1);
+    BOOST_TEST(r[2].kind == "hit"); // rot=0 record, but t3's own rot is set
+    BOOST_TEST(r[2].idx == 3U);
+    BOOST_TEST(r[2].v == 0.75);
+    BOOST_TEST(r[2].foll);
+    BOOST_TEST(r[3].kind == "hit");
+    BOOST_TEST(r[3].idx == 2U);
+    BOOST_TEST(r[3].phase == -1);
+    BOOST_TEST(!r[3].foll);
+    BOOST_TEST(r[4].kind == "hit"); // rot=0 record, t5's own rot is set
+    BOOST_TEST(r[4].idx == 5U);
+    BOOST_TEST(r[4].v == 2.0);
+    // Absence pass, ascending ordinal: t0 unanswered (nobody sent key t0) with its c0; t2 an answered
+    // leader whose partner's record carried rot. t4 sent rot=0 and received nothing: neither list. The
+    // followers t1/t3/t5 never appear on the out side.
+    BOOST_TEST(r[5].kind == "out_unanswered");
+    BOOST_TEST(r[5].idx == 0U);
+    BOOST_TEST(r[5].v == -1.0);
+    BOOST_TEST(r[5].phase == 1);
+    BOOST_TEST(r[6].kind == "out_pair");
+    BOOST_TEST(r[6].idx == 2U);
+    BOOST_TEST(r[6].phase == 1);
+
+    // The mint landed as a row, and only it.
+    BOOST_REQUIRE_EQUAL(sc.op.store->size(), 7U);
+    BOOST_TEST((sc.op.store->row(6) == sc.absent_x));
+
+    const auto &t = sc.scratch.marks;
+    BOOST_TEST(!t.received(0));
+    BOOST_TEST(t.received(1));
+    BOOST_TEST(t.received(2));
+    BOOST_TEST(t.received(3));
+    BOOST_TEST(!t.received(4));
+    BOOST_TEST(t.received(5));
+    BOOST_TEST(t.partner_rot(1)); // t0's record
+    BOOST_TEST(t.partner_rot(2)); // t3's record
+    BOOST_TEST(!t.partner_rot(3));
+    BOOST_TEST(!t.partner_rot(5));
 }
 
-// Growing the operator only appends to the tail; old slots stay cleared and new slots are usable.
-BOOST_AUTO_TEST_CASE(matched_epoch_tail_grow) {
-    MatchedEpochSet set;
-    set.begin_gate(4);
-    set.mark(3);
-    BOOST_TEST(set.is_marked(3));
-
-    set.begin_gate(8);
-    BOOST_TEST(!set.is_marked(3));
-    set.mark(7);
-    BOOST_TEST(set.is_marked(7));
-    BOOST_TEST(!set.is_marked(3));
+// The absence pass alone, so both out lists are pinned with their order and payload: t0 is the unanswered
+// E-record (with the sender-side c0), t2 the answered leader (rotating through its partner's rot).
+BOOST_AUTO_TEST_CASE(one_round_absence_pass_reports_unanswered_and_answered_leaders) {
+    Scenario sc;
+    RecordingSink sink;
+    auto scan = sc.scan(/*with_c0=*/true);
+    detail::MissStage<kN> misses;
+    sc.probe(
+        scan.self.size(),
+        [&](size_t q) { return scan.self.tag_of[q]; },
+        [&](size_t q) { return scan.self.positions_at(q); });
+    detail::join_self<kN>(scan.self,
+                          sc.scratch.join,
+                          /*q_base=*/0,
+                          sc.scratch.marks,
+                          /*my_rank=*/0,
+                          /*base=*/6,
+                          misses,
+                          sink,
+                          std::span<const detail::SentRecord>(scan.sent[0]));
+    sink.recs.clear();
+    detail::absence_pass<kN>(sc.scratch.marks, scan.sent, scan.sent_c0, sink);
+    BOOST_REQUIRE_EQUAL(sink.recs.size(), 2U);
+    BOOST_TEST(sink.recs[0].kind == "out_unanswered");
+    BOOST_TEST(sink.recs[0].idx == 0U);
+    BOOST_TEST(sink.recs[0].v == -1.0);
+    BOOST_TEST(sink.recs[0].phase == 1);
+    BOOST_TEST(sink.recs[1].kind == "out_pair");
+    BOOST_TEST(sink.recs[1].idx == 2U);
+    BOOST_TEST(sink.recs[1].phase == 1);
+    BOOST_TEST(misses.size() == 1U);
 }
 
-// Reaches the wrap by assigning cur_, which pins the branch and the counter restart but not the fill.
-BOOST_AUTO_TEST_CASE(matched_epoch_stamp_wrap_resets) {
-    MatchedEpochSet set;
-    set.begin_gate(4); // allocate the backing array
-    // Force the counter to the wrap boundary; a stale slot still equals the pre-wrap counter.
-    set.cur_ = std::numeric_limits<MatchedEpochSet::Stamp>::max();
-    set.mark(1);
-    BOOST_TEST(set.is_marked(1));
+// The value path end to end on one slot: the three answers a record can get, and the four sink surfaces
+// they drive. A hit on the silent row t2 stages no message at all here -- the self slot applies nu's half
+// at once -- but it still marks t3 answered, which is what keeps t3 out of the absence pass.
+BOOST_AUTO_TEST_CASE(one_and_half_round_answers_a_silent_hit_and_leaves_it_out_of_the_absence_pass) {
+    Scenario sc;
+    detail::LayerBuildEngine<kN, AnsweringSink> eng(sc.op, mpi::Comm{}, 1, 0, sc.scratch, 6, AnsweringSink{});
+    eng.exchange_and_join(sc.value_scan());
 
-    set.begin_gate(4); // triggers the fill(0) + cur_ = 0 -> ++cur_ = 1 reset
-    BOOST_TEST(set.cur_ == 1U);
-    BOOST_TEST(!set.is_marked(1));
-    set.mark(2);
-    BOOST_TEST(set.is_marked(2));
+    const auto &r = eng.sink.recs;
+    BOOST_REQUIRE_EQUAL(r.size(), 7U);
+    // t0/t1 are symmetric: each hit lands on a row whose own rot is set, so neither is answered.
+    BOOST_TEST(r[0].kind == "hit");
+    BOOST_TEST(r[0].idx == 1U);
+    BOOST_TEST(r[0].v == 0.5);
+    BOOST_TEST(r[1].kind == "hit");
+    BOOST_TEST(r[1].idx == 0U);
+    BOOST_TEST(r[1].v == 0.25);
+    // t3's record hits the silent t2: mu's half applies, and t2 answers with its own coefficient.
+    BOOST_TEST(r[2].kind == "hit");
+    BOOST_TEST(r[2].idx == 2U);
+    BOOST_TEST(r[2].v == 1.5);
+    BOOST_TEST(r[2].phase == -1);
+    BOOST_TEST(r[3].kind == "answer");
+    BOOST_TEST(r[3].idx == 3U);  // the answer lands on the SENDER's row, not the row that answered
+    BOOST_TEST(r[3].v == 102.0); // silent_value(2)
+    BOOST_TEST(r[3].phase == -1);
+    BOOST_TEST(r[4].kind == "mint");
+    BOOST_TEST(r[4].idx == 6U);
+    BOOST_TEST(r[4].v == 3.0);
+    // t0 is the leader of the one symmetric pair; t5's partner was minted remotely, so it alone is
+    // unanswered. t3 is answered and must NOT appear here, which is the whole point of the mark.
+    BOOST_TEST(r[5].kind == "out_pair");
+    BOOST_TEST(r[5].idx == 0U);
+    BOOST_TEST(r[6].kind == "out_unanswered");
+    BOOST_TEST(r[6].idx == 5U);
+    BOOST_TEST(r[6].v == -1.0);
+
+    const auto &t = sc.scratch.marks;
+    BOOST_TEST(t.answered(3));
+    BOOST_TEST(!t.answered(5)); // absent partner, not a silent one
+    BOOST_TEST(!t.answered(0));
+    BOOST_TEST(!t.received(3)); // t2 sent nothing: the answer is the only thing t3 heard
+    BOOST_TEST(t.received(2));
 }
 
-// Reaches the wrap by counting gates, with the mark at epoch 1 so a missing fill would alias onto it.
-BOOST_AUTO_TEST_CASE(matched_epoch_stamp_wrap_reached_by_gate_count) {
-    constexpr auto kMaxStamp = std::numeric_limits<MatchedEpochSet::Stamp>::max();
-    constexpr size_t kPeriod = static_cast<size_t>(kMaxStamp);
-
-    MatchedEpochSet set;
-    set.begin_gate(4);
-    BOOST_REQUIRE(set.cur_ == MatchedEpochSet::Stamp{1});
-    set.mark(1);
-    BOOST_TEST(set.is_marked(1));
-
-    // One increment per gate, folded into a single assertion rather than 65534 of them.
-    bool one_epoch_per_gate = true;
-    for (size_t k = 2; k <= kPeriod; ++k) {
-        set.begin_gate(4);
-        one_epoch_per_gate = one_epoch_per_gate && (static_cast<size_t>(set.cur_) == k);
-    }
-    BOOST_TEST(one_epoch_per_gate);
-    BOOST_TEST(set.cur_ == kMaxStamp); // boundary reached by counting, not by assignment
-
-    // The wrap: cur_ returns to 1, the surviving mark's own stamp, so a false is_marked(1) is the fill.
-    set.begin_gate(4);
-    BOOST_TEST(set.cur_ == MatchedEpochSet::Stamp{1});
-    BOOST_TEST(!set.is_marked(1));
-    set.mark(2);
-    BOOST_TEST(set.is_marked(2));
-    BOOST_TEST(!set.is_marked(1));
-}
-
-// A self-resolve hit whose index the store only grew into after construction is a real hit -- it must reach
-// the sink -- but it is outside the matched set, whose array is sized to combined_size.
-BOOST_AUTO_TEST_CASE(self_resolve_mark_bounded_by_combined_size) {
-    std::vector<Monomial<8>> terms;
-    for (size_t i = 0; i < 6; ++i) {
-        terms.push_back(indices_to_bitset<8>({i, i + 8}));
-    }
-    detail::MPOperator<8> op = indexed_op(terms);
-    const size_t combined_size = 4; // rows 4 and 5 stand for terms this layer inserted after construction
-
-    MatchedEpochSet matched;
-    // Pre-grown past combined_size on purpose: an unguarded mark then lands in an observable slot rather
-    // than past the end of epoch_, where it would be silent undefined behaviour.
-    matched.begin_gate(op.size());
-
-    detail::LayerBuildEngine<8, RecordingSink> eng(op,
-                                                   mpi::Comm{},
-                                                   /*R_=*/1,
-                                                   /*my_rank_=*/0,
-                                                   matched,
-                                                   combined_size,
-                                                   RecordingSink{});
-    // The self leg is staged as positions, never encoded, so this feeds the stage the scan would fill.
-    using Eng = detail::LayerBuildEngine<8, RecordingSink>;
-    const auto stage_self = [&eng](const Monomial<8> &m, int phase) {
-        std::vector<Eng::RowPosT> pos;
-        for (size_t b = m.find_first(); b < m.size(); b = m.find_next(b)) {
-            pos.push_back(static_cast<Eng::RowPosT>(b));
+// The fused sink turns those joins into half-rotations: +phi_rec*v_rec on hits and mints (mints flagged as
+// inserts), -phi_own*v_mu for an answer, -phi_own*c0 for an absence, nothing for the answered leader.
+BOOST_AUTO_TEST_CASE(one_round_contract_sink_records_one_half_per_touched_slot) {
+    Scenario sc;
+    detail::FusedContract fc;
+    // The pre-gate coefficients: a silent row's own slot is where its response payload comes from, so
+    // this is what the answer for t3 must carry.
+    const VecD coeffs = {0.5, 0.25, 12.0, 1.5, 14.0, 3.0};
+    detail::LayerBuildEngine<kN, detail::ContractSink<kN>> eng(
+        sc.op,
+        mpi::Comm{},
+        1,
+        0,
+        sc.scratch,
+        6,
+        // cos_build/inv_cos left at 1.0: this case is about which slot each half lands on and with which
+        // sign, so the recovery factor is the identity and every value passes through.
+        detail::ContractSink<kN>{.fc = fc, .fused_scale = true, .op_coeffs = coeffs});
+    eng.exchange_and_join(sc.value_scan());
+    BOOST_REQUIRE_EQUAL(fc.halves.size(), 6U);
+    const auto expect = [&](size_t k, size_t idx, double v, int phase, bool insert) {
+        BOOST_TEST_CONTEXT("half " << k) {
+            BOOST_TEST(fc.halves[k].local_idx == idx);
+            BOOST_TEST(fc.halves[k].v_partner == v);
+            BOOST_TEST(fc.halves[k].phase_signed == phase);
+            BOOST_TEST(fc.halves[k].is_insert == insert);
         }
-        eng.self_stage_.push(pos, phase);
     };
-    stage_self(terms[1], 1);
-    stage_self(terms[5], -1);
-    eng.src_idx_r[0] = {0, 2};
+    expect(0, 1, 0.5, 1, false);
+    expect(1, 0, 0.25, -1, false);
+    expect(2, 2, 1.5, -1, false);
+    expect(3, 3, coeffs[2], 1, false); // the answer: -phi_t3 * c[t2]*(1/cos), and here 1/cos is 1
+    expect(4, 6, 3.0, 1, true);
+    expect(5, 5, -1.0, -1, false); // the absence: -phi_t5 * c0
+    // Every slot is touched at most once, which is what lets the apply run in any order.
+    std::vector<size_t> touched;
+    for (const auto &h : fc.halves) {
+        touched.push_back(h.local_idx);
+    }
+    std::ranges::sort(touched);
+    BOOST_TEST((std::ranges::adjacent_find(touched) == touched.end()));
+}
 
-    eng.resolve_self_queries(/*is_leader_pass=*/true);
+// Round 2 across slots: a response names the record by its position in the SENDER's own stream, and the
+// sender maps that back to the row and phase it kept in `sent`. No row index is ever on the wire, in
+// either direction -- which is what makes the answer two words and independent of the peer's row layout.
+BOOST_AUTO_TEST_CASE(one_and_half_round_response_names_the_record_and_the_sender_maps_it_back) {
+    Scenario sc;
+    // Two flat slots. The peer's stream holds two records; the second hits the silent row t2.
+    std::vector<VecZ> wire(2);
+    using QW = detail::QueryWire<kN>;
+    VecZ &peer = wire[1];
+    QW::push(peer, positions_of(sc.terms[1]), 1, /*rot=*/true);
+    QW::push_value(peer, 0.5);
+    QW::push(peer, positions_of(sc.terms[2]), -1, /*rot=*/true);
+    QW::push_value(peer, 1.5);
 
-    // Both keys are in the store, so both resolve as hits and neither may be deferred as a miss.
-    BOOST_TEST(eng.deferred_self_misses.empty());
-    BOOST_TEST_REQUIRE(eng.sink.hits.size() == 2U);
-    BOOST_TEST(eng.sink.hits[0].second == 1U);
-    BOOST_TEST(eng.sink.hits[1].second == 5U);
-    BOOST_TEST(matched.is_marked(1));
-    BOOST_TEST(!matched.is_marked(4));
-    BOOST_TEST(!matched.is_marked(5));
+    std::vector<std::span<const size_t>> views;
+    detail::IncomingRecords<kN> pr;
+    detail::decode_incoming_records<kN>(detail::slot_streams(wire, views), detail::QueryForm::Fused, pr);
+    BOOST_REQUIRE_EQUAL(pr.nq_total, 2U);
+    sc.probe(pr.nq_total, [&](size_t g) { return pr.tag_of[g]; }, [&](size_t g) { return pr.positions_at(g); });
+
+    AnsweringSink sink;
+    detail::MissStage<kN> misses;
+    std::vector<VecZ> responses(2);
+    detail::join_incoming<kN>(pr, sc.scratch.join, /*q_base=*/0, sc.scratch.marks, /*base=*/6, misses, sink, responses);
+    // t1's own rot is set, so that hit needs no answer; t2's is not, so record 1 of slot 1's stream does.
+    BOOST_TEST(responses[0].empty());
+    BOOST_REQUIRE_EQUAL(responses[1].size(), detail::kResponseWords);
+    BOOST_TEST(responses[1][0] == 1U);
+    BOOST_TEST(detail::decode_value(responses[1][1]) == 102.0); // silent_value(2)
+
+    // The other direction: an answer to record 1 of this slot's own stream to slot 1.
+    std::vector<std::vector<detail::SentRecord>> sent(2);
+    sent[1] = {detail::SentRecord{.row = 4, .phase = 1}, detail::SentRecord{.row = 5, .phase = -1}};
+    std::vector<VecZ> answers(2);
+    detail::push_response(answers[1], 1, 7.5);
+    sink.recs.clear();
+    detail::apply_responses<kN>(sc.scratch.marks, sent, detail::slot_streams(answers, views), sink);
+    BOOST_REQUIRE_EQUAL(sink.recs.size(), 1U);
+    BOOST_TEST(sink.recs[0].kind == "answer");
+    BOOST_TEST(sink.recs[0].slot == 1U);
+    BOOST_TEST(sink.recs[0].idx == 5U); // sent[slot 1][1].row, not the index on the wire
+    BOOST_TEST(sink.recs[0].v == 7.5);
+    BOOST_TEST(sink.recs[0].phase == -1); // sent[slot 1][1].phase, so the half is +1 * 7.5
+    BOOST_TEST(sc.scratch.marks.answered(5));
+    BOOST_TEST(!sc.scratch.marks.answered(4));
+}
+
+// The graph sink's layout: in = [in_pairs (hits on followers), in_mints], out = [out_pairs (answered
+// leaders), out_unanswered], and finalize's sin_send = [in..., out...] / sin_recv = [(out, -phi)..., (in, +phi)...].
+BOOST_AUTO_TEST_CASE(one_round_graph_sink_lays_out_in_and_out_blocks) {
+    Scenario sc;
+    detail::LayerBuildEngine<kN, detail::GraphSink<kN>>
+        eng(sc.op, mpi::Comm{}, 1, 0, sc.scratch, 6, detail::GraphSink<kN>{1, 0});
+    eng.exchange_and_join(sc.scan(/*with_c0=*/false));
+    const auto &a = eng.sink.acc[0];
+    const auto entries = [](const std::vector<detail::PhasedEntry> &v) {
+        std::vector<std::pair<size_t, int>> out;
+        for (const auto &e : v) {
+            out.emplace_back(e.idx, e.phase);
+        }
+        return out;
+    };
+    using P = std::vector<std::pair<size_t, int>>;
+    BOOST_TEST((entries(a.in_pairs) == P{{1, 1}, {3, 1}, {5, 1}}));
+    BOOST_TEST((entries(a.in_mints) == P{{6, -1}}));
+    BOOST_TEST((entries(a.out_pairs) == P{{2, 1}}));
+    BOOST_TEST((entries(a.out_unanswered) == P{{0, 1}}));
+
+    CosMask cos;
+    const auto core = eng.finish(CosMask{}, &cos);
+    BOOST_REQUIRE(core != nullptr);
+    const auto slot = detail::cross_rank_slot(core->cross_rank, 0);
+    BOOST_REQUIRE_EQUAL(slot.sin_send_count, 6U);
+    BOOST_TEST(slot.in_count == 4U);
+    const std::vector<size_t> b = {1, 3, 5, 6, 2, 0};
+    for (size_t k = 0; k < 6; ++k) {
+        BOOST_TEST(detail::slot_sin_send_index(slot, k) == b[k]);
+    }
+    const std::vector<std::pair<size_t, int>> d = {{2, -1}, {0, -1}, {1, 1}, {3, 1}, {5, 1}, {6, -1}};
+    for (size_t k = 0; k < 6; ++k) {
+        BOOST_TEST_CONTEXT("sin_recv " << k) {
+            BOOST_TEST(detail::slot_sin_recv_index(slot, k) == d[k].first);
+            BOOST_TEST(detail::slot_sin_recv_phase(slot, k) == d[k].second);
+        }
+    }
+    // The mint is a rotation endpoint born after the scan, so the cos mask covers it.
+    BOOST_TEST(cos.total_count == 1U);
+}
+
+namespace {
+
+template <size_t N>
+auto majorana_anticommutes(const Monomial<N> &m, const Monomial<N> &g) -> bool {
+    return ((m.count() * g.count()) - m.count_and(g)) % 2 == 1;
+}
+
+template <size_t N, Algebra A>
+auto emit_phase_of(const Monomial<N> &m, const Monomial<N> &g) -> int {
+    const auto ctx = A::make_gen_context(g);
+    const Monomial<N> partner = m ^ g;
+    return A::emit_phase(A::rotation_sign(ctx, m, partner), m.count(), g.count(), m.count_and(g));
+}
+
+template <size_t N>
+auto random_monomial(std::mt19937_64 &rng, size_t k) -> Monomial<N> {
+    Monomial<N> m;
+    std::uniform_int_distribution<size_t> bit(0, Monomial<N>::size() - 1);
+    while (m.count() < k) {
+        m.set(bit(rng));
+    }
+    return m;
+}
+
+} // namespace
+
+// The identity the one-round protocol's exactness rests on: the two endpoints of a pair emit opposite
+// phases, phi(M^G, G) = -phi(M, G), in both algebras. Each side then applies the OTHER side's record with
+// its phase as sent, and gets exactly today's two adds.
+BOOST_AUTO_TEST_CASE(emit_phase_antisymmetry) {
+    constexpr size_t N = 24;
+    std::mt19937_64 rng(20260902);
+    size_t majorana = 0;
+    size_t pauli = 0;
+    for (size_t trial = 0; trial < 6000; ++trial) {
+        const auto m = random_monomial<N>(rng, 1 + (rng() % 8));
+        const auto g = random_monomial<N>(rng, 1 + (rng() % 6));
+        if (majorana_anticommutes<N>(m, g)) {
+            const int fwd = emit_phase_of<N, MajoranaAlgebra<N>>(m, g);
+            const int back = emit_phase_of<N, MajoranaAlgebra<N>>(m ^ g, g);
+            BOOST_REQUIRE_EQUAL(back, -fwd);
+            ++majorana;
+        }
+        if (pauli_anticommutes<N>(m, g)) {
+            const int fwd = emit_phase_of<N, PauliAlgebra<N>>(m, g);
+            const int back = emit_phase_of<N, PauliAlgebra<N>>(m ^ g, g);
+            BOOST_REQUIRE_EQUAL(back, -fwd);
+            ++pauli;
+        }
+    }
+    BOOST_TEST(majorana > 1000U);
+    BOOST_TEST(pauli > 1000U);
+}
+
+/* -- The receiver rule end to end, on two-term Majorana operators ---------------------------------- */
+
+namespace {
+
+constexpr size_t kM = 4;
+
+//! A Majorana term with the given ENCODED (real) coefficient: the dict holds coeff * i^C(k,2).
+auto term(OperatorDict &dict, const VecZ &idx, double encoded) -> void {
+    dict[idx] = hermitian_coefficient<kM>(indices_to_bitset<kM>(idx)) * encoded;
+}
+
+struct Knobs {
+    std::optional<double> lower_atol = std::nullopt;
+    std::optional<double> upper_atol = std::nullopt;
+    unsigned int cutoff = 2 * kM;
+    std::optional<unsigned int> schrodinger = std::nullopt;
+    VecZ initial_state = {};
+};
+
+auto make(const OperatorDict &dict, const Knobs &k) -> MonomialPropagator<kM> {
+    return MonomialPropagator<kM>(dict,
+                                  k.cutoff,
+                                  k.initial_state,
+                                  k.schrodinger,
+                                  MPI_COMM_SELF,
+                                  k.lower_atol,
+                                  k.upper_atol,
+                                  CutoffType::Length,
+                                  std::nullopt);
+}
+
+//! The evolved coefficient of `idx` (nullopt when the term is not tracked), from the live picture vector.
+auto coeff_of(MonomialPropagator<kM> &sim, const VecZ &idx) -> std::optional<double> {
+    const auto want = indices_to_bitset<kM>(idx);
+    const VecD &c = sim.mp_op().get_operator();
+    std::optional<double> out;
+    sim.indexing().for_each([&](const Monomial<kM> &mono, size_t i) {
+        if (mono == want && i < c.size()) {
+            out = c[i];
+        }
+    });
+    return out;
+}
+
+//! One gate G at angle theta over `dict`, with the knobs; returns the propagator for inspection.
+auto run_gate(const OperatorDict &dict,
+              const VecZ &gate,
+              double theta,
+              const Knobs &k,
+              std::optional<size_t> rot_k = {}) -> MonomialPropagator<kM> {
+    auto sim = make(dict, k);
+    sim.propagate({gate}, VecZ{0}, VecD{1.0}, VecD{theta}, rot_k);
+    return sim;
+}
+
+const VecZ kG = {0, 1};  // |G| = 2
+const VecZ kNu = {0, 2}; // anticommutes with G (2*2 - 1 odd); partner mu = {1, 2}
+const VecZ kMu = {1, 2};
+constexpr double kTheta = 0.37;
+
+} // namespace
+
+// Both endpoints below lower_atol: the pair does not rotate, so each coefficient equals its solo
+// evolution (cos-scaled only; a solo term's absent partner contributes nothing).
+BOOST_AUTO_TEST_CASE(receiver_rule_both_below_atol_do_not_rotate) {
+    const Knobs k{.lower_atol = 1e-6};
+    OperatorDict both;
+    term(both, kNu, 1e-12);
+    term(both, kMu, -3e-12);
+    OperatorDict solo_nu;
+    term(solo_nu, kNu, 1e-12);
+    OperatorDict solo_mu;
+    term(solo_mu, kMu, -3e-12);
+    auto pair = run_gate(both, kG, kTheta, k);
+    auto nu = run_gate(solo_nu, kG, kTheta, k);
+    auto mu = run_gate(solo_mu, kG, kTheta, k);
+    BOOST_TEST(pair.size() == 2U);
+    BOOST_TEST(*coeff_of(pair, kNu) == *coeff_of(nu, kNu));
+    BOOST_TEST(*coeff_of(pair, kMu) == *coeff_of(mu, kMu));
+    // And the solo runs minted nothing: below the threshold a term does not emit.
+    BOOST_TEST(nu.size() == 1U);
+    BOOST_TEST(mu.size() == 1U);
+}
+
+// One endpoint below lower_atol: the other's emission rotates the pair, and BOTH adds happen with the
+// same values as with the threshold off -- the below-threshold side's silent record is what makes that
+// bit-identical.
+BOOST_AUTO_TEST_CASE(receiver_rule_one_below_atol_still_rotates_both) {
+    OperatorDict both;
+    term(both, kNu, 1.0);
+    term(both, kMu, 1e-12);
+    auto gated = run_gate(both, kG, kTheta, Knobs{.lower_atol = 1e-6});
+    auto exact = run_gate(both, kG, kTheta, Knobs{});
+    BOOST_TEST(gated.size() == 2U);
+    BOOST_TEST(*coeff_of(gated, kNu) == *coeff_of(exact, kNu));
+    BOOST_TEST(*coeff_of(gated, kMu) == *coeff_of(exact, kMu));
+    // The rotation really happened: the small side moved by sin*|c_nu| >> 1e-12.
+    BOOST_TEST(std::abs(*coeff_of(gated, kMu)) > 0.1);
+}
+
+// A source over the rotation length cap does not emit and is not cos-scaled, but its in-cap partner's
+// record still rotates it: c'_mu = c_mu + sin*phi*c_nu against c'_mu = cos*c_mu + sin*phi*c_nu uncapped,
+// while the in-cap side is bit-identical either way.
+BOOST_AUTO_TEST_CASE(receiver_rule_capped_source_is_rotated_by_its_partner) {
+    const VecZ g = {0, 1, 2};     // odd |G|: anticommutes with disjoint odd-weight terms
+    const VecZ nu = {3};          // pop 1: in cap
+    const VecZ mu = {0, 1, 2, 3}; // pop 4: over cap 3
+    OperatorDict both;
+    term(both, nu, 0.8);
+    term(both, mu, -0.6);
+    auto capped = run_gate(both, g, kTheta, Knobs{}, /*rot_k=*/3);
+    auto uncapped = run_gate(both, g, kTheta, Knobs{});
+    // The same two operations on nu either way (cos*c_nu, then + sin*phi_mu*c_mu); the two apply paths
+    // (fused cos sweep vs the two-pass cos mask) are separate loops the compiler may contract
+    // differently, so this is a 1-ULP check rather than a bit-identity one.
+    BOOST_TEST(std::abs(*coeff_of(capped, nu) - *coeff_of(uncapped, nu))
+               <= std::numeric_limits<double>::epsilon() * std::abs(*coeff_of(uncapped, nu)));
+    const double cos2 = std::cos(2 * kTheta);
+    // Both runs added the same sine term to mu; only the cos scale differs.
+    BOOST_TEST(*coeff_of(capped, mu) - (-0.6) == *coeff_of(uncapped, mu) - (cos2 * -0.6),
+               boost::test_tools::tolerance(1e-15));
+    BOOST_TEST(std::abs(*coeff_of(capped, mu) - (-0.6)) > 0.1); // it did rotate
+}
+
+// upper_atol rescues a partner the structural cutoff rejects: the partner is minted and the source's
+// value is what the wide-cutoff run gives.
+BOOST_AUTO_TEST_CASE(receiver_rule_rescued_partner_is_minted) {
+    const VecZ g = {0, 1, 2};
+    const VecZ nu = {4};          // pop 1 passes cutoff 2
+    const VecZ mu = {0, 1, 2, 4}; // pop 4 fails cutoff 2 and is not paired
+    OperatorDict one;
+    term(one, nu, 0.9);
+    auto rescued = run_gate(one, g, kTheta, Knobs{.upper_atol = 0.0, .cutoff = 2});
+    auto dropped = run_gate(one, g, kTheta, Knobs{.cutoff = 2});
+    auto wide = run_gate(one, g, kTheta, Knobs{});
+    BOOST_TEST(rescued.size() == 2U);
+    BOOST_TEST(dropped.size() == 1U);
+    BOOST_TEST(*coeff_of(rescued, mu) == *coeff_of(wide, mu));
+    BOOST_TEST(*coeff_of(rescued, nu) == *coeff_of(wide, nu));
+    BOOST_TEST(*coeff_of(dropped, nu) == std::cos(2 * kTheta) * 0.9);
+}
+
+// An initial term over the structural cutoff (the initial operator is never filtered) whose partner
+// passes: only the partner emits, and the pair must still rotate on both sides. This is what the per-call
+// over_cutoff_possible flag exists for -- without it the over-cutoff side would never send, and its
+// partner would see it as absent.
+BOOST_AUTO_TEST_CASE(receiver_rule_initial_over_cutoff_term_rotates_with_its_partner) {
+    const VecZ g = {0, 1, 2};
+    const VecZ nu = {4};          // pop 1: passes cutoff 1
+    const VecZ mu = {0, 1, 2, 4}; // pop 4: tracked (initial) but over cutoff 1
+    OperatorDict both;
+    term(both, nu, 0.7);
+    term(both, mu, 0.4);
+    auto tight = run_gate(both, g, kTheta, Knobs{.cutoff = 1});
+    auto wide = run_gate(both, g, kTheta, Knobs{});
+    BOOST_TEST(tight.size() == 2U);
+    BOOST_TEST(*coeff_of(tight, nu) == *coeff_of(wide, nu));
+    BOOST_TEST(*coeff_of(tight, mu) == *coeff_of(wide, mu));
+    BOOST_TEST(std::abs(*coeff_of(tight, mu) - std::cos(2 * kTheta) * 0.4) > 0.1); // rotated, not just scaled
+
+    // With cutoff 0 neither side passes and nothing is rescued: the pair only cos-scales.
+    auto zero = run_gate(both, g, kTheta, Knobs{.cutoff = 0});
+    BOOST_TEST(*coeff_of(zero, nu) == std::cos(2 * kTheta) * 0.7);
+    BOOST_TEST(*coeff_of(zero, mu) == std::cos(2 * kTheta) * 0.4);
+}
+
+// Schrodinger: the sender computes c0(mu), the coefficient an absent paired partner would be minted with,
+// off the partner's positions -- the state score for a fully paired mu, 0 otherwise -- and the scan
+// carries it parallel to the sent ordinals so the absence pass can supply the source's half without the
+// partner.
+BOOST_AUTO_TEST_CASE(scan_c0_is_the_state_score_of_a_paired_absent_partner) {
+    using A = MajoranaAlgebra<kM>;
+    // G = {1,3,4,5}: nu1={1,2} -> mu1={2,3,4,5} paired, nu2={3} -> mu2={1,4,5} unpaired, nu3={0,3} ->
+    // mu3={0,1,4,5} paired. Mode 1 occupied => mask bit 2 => c0(mu1) = (-1)^(1+2) = -1, c0(mu3) = +1.
+    const auto gen = indices_to_bitset<kM>({1, 3, 4, 5});
+    const std::vector<Monomial<kM>> rows = {indices_to_bitset<kM>({1, 2}),
+                                            indices_to_bitset<kM>({3}),
+                                            indices_to_bitset<kM>({0, 3})};
+    detail::MPOperator<kM> op;
+    detail::insert_absent_terms<kM>(op, rows.size(), [&](size_t k, size_t base) {
+        assign_row<kM>(*op.store, base + k, rows[k]);
+    });
+    const VecD coeffs(rows.size(), 1.0);
+    const CutoffFn<kM> fn = detail::LengthCutoff<kM>{2 * kM, kM};
+    const detail::CutoffEvaluator<kM> eval(fn);
+    const auto cut = detail::build_majorana_evolution_cutoff_state(std::nullopt, std::cref(coeffs), std::nullopt, 0.3);
+    const auto router = routing::Router::splitmix(1);
+    const auto mask = initial_state_mask<kM>(VecZ{1});
+    detail::GateScratch<kM> scratch;
+    const auto res = detail::fused_find_and_collect<kM, A, /*CaptureValues=*/true>(op,
+                                                                                   gen,
+                                                                                   eval,
+                                                                                   cut,
+                                                                                   coeffs,
+                                                                                   std::nullopt,
+                                                                                   /*over_cutoff_possible=*/false,
+                                                                                   /*my_rank=*/0,
+                                                                                   router,
+                                                                                   scratch,
+                                                                                   nullptr,
+                                                                                   1.0,
+                                                                                   &mask);
+    // All three rows anticommute; the join's row side is built later, from these words.
+    size_t n_anti = 0;
+    for (const auto &w : scratch.nz) {
+        n_anti += static_cast<size_t>(std::popcount(w.overlap));
+    }
+    BOOST_REQUIRE_EQUAL(n_anti, 3U);
+    BOOST_REQUIRE_EQUAL(res.self.size(), 3U); // R = 1: every record is self-addressed and staged
+    const auto &sent = res.sent[0];
+    const auto &c0 = res.sent_c0[0];
+    BOOST_REQUIRE_EQUAL(sent.size(), 3U);
+    BOOST_REQUIRE_EQUAL(c0.size(), 3U);
+    for (size_t j = 0; j < 3; ++j) {
+        BOOST_TEST(sent[j].row == static_cast<TermIndex>(j));
+    }
+    BOOST_TEST(c0[0] == -1.0);
+    BOOST_TEST(c0[1] == 0.0);
+    BOOST_TEST(c0[2] == 1.0);
+    // The rot bit rides with the record: all three sources are above threshold with a structurally
+    // admitted partner, so all three rotate.
+    for (size_t q = 0; q < 3; ++q) {
+        BOOST_TEST(res.self.rot_of[q] == 1);
+        BOOST_TEST(res.self.val_of[q] == 1.0);
+        BOOST_TEST(scratch.marks.rot(q));
+    }
+    // Without a state mask (Heisenberg) no c0 is carried at all.
+    detail::GateScratch<kM> scratch_h;
+    const auto heis = detail::fused_find_and_collect<kM, A, true>(op,
+                                                                  gen,
+                                                                  eval,
+                                                                  cut,
+                                                                  coeffs,
+                                                                  std::nullopt,
+                                                                  false,
+                                                                  0,
+                                                                  router,
+                                                                  scratch_h,
+                                                                  nullptr,
+                                                                  1.0,
+                                                                  nullptr);
+    BOOST_TEST(heis.sent_c0.size() == 0U);
+    BOOST_TEST(heis.sent[0].size() == 3U);
+}
+
+// The position-form state score agrees with the dense one in both algebras.
+BOOST_AUTO_TEST_CASE(state_phase_positions_matches_state_phase) {
+    constexpr size_t N = 24;
+    std::mt19937_64 rng(20260903);
+    for (size_t trial = 0; trial < 400; ++trial) {
+        VecZ occupied;
+        for (size_t m = 0; m < N; ++m) {
+            if ((rng() & 1U) != 0U) {
+                occupied.push_back(m);
+            }
+        }
+        const auto mask = initial_state_mask<N>(occupied);
+        Monomial<N> paired;
+        for (size_t m = 0; m < N; ++m) {
+            if ((rng() & 1U) != 0U) {
+                paired.set(2 * m);
+                paired.set((2 * m) + 1);
+            }
+        }
+        std::vector<uint16_t> pos;
+        for (size_t b = paired.find_first(); b < paired.size(); b = paired.find_next(b)) {
+            pos.push_back(static_cast<uint16_t>(b));
+        }
+        BOOST_TEST(MajoranaAlgebra<N>::state_phase_positions(pos.data(), pos.size(), mask)
+                   == MajoranaAlgebra<N>::state_phase(paired, mask));
+        const auto z_string = random_monomial<N>(rng, 1 + (rng() % 10));
+        std::vector<uint16_t> zpos;
+        for (size_t b = z_string.find_first(); b < z_string.size(); b = z_string.find_next(b)) {
+            zpos.push_back(static_cast<uint16_t>(b));
+        }
+        BOOST_TEST(PauliAlgebra<N>::state_phase_positions(zpos.data(), zpos.size(), mask)
+                   == PauliAlgebra<N>::state_phase(z_string, mask));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(cutoff_context_abs_coeff_for) {
@@ -190,7 +851,7 @@ BOOST_AUTO_TEST_CASE(cutoff_context_abs_coeff_for) {
     BOOST_TEST(on.abs_coeff_for(3, coeffs) == 0.0); // out of range -> 0
 }
 
-// is_above_upper is the rescue predicate: enabled AND |sin|·|coeff| >= upper_atol (inclusive).
+// is_above_upper is the rescue predicate: enabled AND |sin|*|coeff| >= upper_atol (inclusive).
 BOOST_AUTO_TEST_CASE(cutoff_context_is_above_upper) {
     CutoffContext ctx;
     ctx.abs_sin_val = 0.5;
@@ -205,7 +866,7 @@ BOOST_AUTO_TEST_CASE(cutoff_context_is_above_upper) {
     BOOST_TEST(!ctx.is_above_upper(1.0));
 }
 
-// is_below_sin is the lower-atol drop predicate: enabled AND |sin|·|coeff| <= atol (inclusive).
+// is_below_sin is the lower-atol drop predicate: enabled AND |sin|*|coeff| <= atol (inclusive).
 BOOST_AUTO_TEST_CASE(cutoff_context_is_below_sin) {
     CutoffContext ctx;
     ctx.abs_sin_val = 2.0;

--- a/cpp/tests/fused_cos_sweep_tests.cpp
+++ b/cpp/tests/fused_cos_sweep_tests.cpp
@@ -14,7 +14,13 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <bit>
+#include <cmath>
+#include <cstdint>
 #include <optional>
+
+#include "monoprop/detail/evolution/layer_build/FusedApply.h"
+#include "monoprop/detail/evolution/layer_build/GateSinks.h"
 
 #include "TestUtilities.h"
 
@@ -76,4 +82,99 @@ BOOST_FIXTURE_TEST_CASE(fused_sweep_matches_graph_replay_schrodinger, ExampleDat
 
 BOOST_FIXTURE_TEST_CASE(fused_sweep_matches_graph_replay_schrodinger_atol, ExampleDataFix) {
     check_agreement(data, SimulatorConfig{.schrodinger_cutoff = 2 * n_modes, .atol = 1e-10}, "schrodinger atol=1e-10");
+}
+
+// Which endpoint of a pair reads a RECOVERED partner value, stored*(1/cos), and which reads the record's
+// exact pre-cos double (GateSinks.h ContractSink::hit has the argument). The partner value below is a
+// measured one on which the recovery is not the identity, so each check can actually fail.
+BOOST_AUTO_TEST_CASE(fused_sink_recovers_only_the_found_endpoints_value) {
+    constexpr double kParam = 0.01976005125;
+    constexpr double kPartner = -0.9945421981876392;
+    const double cos_build = std::cos(2 * kParam);
+    const double inv_cos = 1.0 / cos_build;
+    const double swept = cos_build * kPartner; // what the scan leaves in the partner's own slot
+    const double recovered = swept * inv_cos;
+    const auto bits = [](double x) { return std::bit_cast<uint64_t>(x); };
+    BOOST_REQUIRE(bits(recovered) != bits(kPartner));
+
+    monoprop::VecD coeffs{swept};
+    monoprop::detail::FusedContract fc;
+    fc.halves.reserve(4);
+    monoprop::detail::ContractSink<ExampleDataFix::n_modes> sink{.fc = fc,
+                                                                 .fused_scale = true,
+                                                                 .op_coeffs = coeffs,
+                                                                 .cos_build = cos_build,
+                                                                 .inv_cos = inv_cos};
+    sink.hit(0, 0, kPartner, 1, /*foll=*/false, /*own_rot=*/true);  // emitting leader: recovered
+    sink.hit(0, 0, kPartner, 1, /*foll=*/true, /*own_rot=*/true);   // follower: the record's own double
+    sink.hit(0, 0, kPartner, 1, /*foll=*/false, /*own_rot=*/false); // silent leader: its partner queried
+    BOOST_REQUIRE_EQUAL(fc.halves.size(), 3u);
+    BOOST_CHECK_EQUAL(bits(fc.halves[0].v_partner), bits(recovered));
+    BOOST_CHECK_EQUAL(bits(fc.halves[1].v_partner), bits(kPartner));
+    BOOST_CHECK_EQUAL(bits(fc.halves[2].v_partner), bits(kPartner));
+    // A response's payload is always the found endpoint's own slot, recovered off the sweep.
+    BOOST_CHECK_EQUAL(bits(sink.silent_value(0)), bits(recovered));
+
+    // Without the sweep nothing is recovered: the array is pre-gate and the record already exact.
+    monoprop::detail::FusedContract fc2;
+    fc2.halves.reserve(2);
+    monoprop::detail::ContractSink<ExampleDataFix::n_modes> two_pass{.fc = fc2,
+                                                                     .fused_scale = false,
+                                                                     .op_coeffs = coeffs,
+                                                                     .cos_build = cos_build,
+                                                                     .inv_cos = inv_cos};
+    two_pass.hit(0, 0, kPartner, 1, /*foll=*/false, /*own_rot=*/true);
+    BOOST_CHECK_EQUAL(bits(fc2.halves[0].v_partner), bits(kPartner));
+    BOOST_CHECK_EQUAL(bits(two_pass.silent_value(0)), bits(swept));
+}
+
+// The apply's rounding shape is pinned, not inferred. `c += sin*phi*v` and `fma(sin*phi, v, c)` are the
+// same expression and differ by 1 ULP, and which one a merged loop compiles to is the optimiser's choice;
+// these two (swept coefficient, partner value) pairs are a measured first divergence of
+// lih_fermionic_spin_exact under the Schrodinger cutoff, where the two shapes disagree.
+BOOST_AUTO_TEST_CASE(fused_apply_rounds_each_arm_once) {
+    // The layer's angle, from that fixture's first gate: cos(2p) = 0.9992191823830495.
+    constexpr double kParam = 0.01976005125;
+    const double cos_val = std::cos(2 * kParam);
+    const double sin_val = std::sin(2 * kParam);
+
+    struct Pair {
+        double pre_cos; // the coefficient as the wire carries it, before the gate's cos sweep
+        double partner; // v_partner
+    };
+    constexpr Pair kPairs[] = {
+        {-0.0789579320133996, -0.9976581568252995},
+        {0.0394789660066998, 0.9968779488844999},
+    };
+
+    for (const Pair &tc : kPairs) {
+        const double swept = cos_val * tc.pre_cos; // what the scan leaves in a pre-gate slot
+        const double sin_phase = sin_val * 1.0;    // phi = +1
+        // volatile pins the intermediate roundings, so the reference for "rounds twice" cannot itself be
+        // contracted into the fma it is meant to differ from.
+        volatile const double sine_add = sin_phase * tc.partner;
+        const double rounds_twice = swept + sine_add;
+        const double rounds_once = std::fma(sin_phase, tc.partner, swept);
+
+        monoprop::detail::FusedContract fc;
+        fc.halves.push_back({.local_idx = 0, .phase_signed = 1, .is_insert = false, .v_partner = tc.partner});
+        monoprop::VecD coeffs{swept};
+        monoprop::detail::apply_fused_contract(fc, coeffs, monoprop::CosMask{}, kParam, true);
+
+        BOOST_TEST_CONTEXT("plain arm pre_cos=" << tc.pre_cos << " partner=" << tc.partner) {
+            // A pair on which the two shapes agree would make the check below vacuous.
+            BOOST_CHECK(std::bit_cast<uint64_t>(rounds_once) != std::bit_cast<uint64_t>(rounds_twice));
+            BOOST_CHECK_EQUAL(std::bit_cast<uint64_t>(coeffs[0]), std::bit_cast<uint64_t>(rounds_once));
+        }
+
+        // The insert arm folds the gate's cos in itself, with the sine product rounded before the sum.
+        monoprop::detail::FusedContract fc_mint;
+        fc_mint.halves.push_back({.local_idx = 0, .phase_signed = 1, .is_insert = true, .v_partner = tc.partner});
+        monoprop::VecD mint{tc.pre_cos};
+        monoprop::detail::apply_fused_contract(fc_mint, mint, monoprop::CosMask{}, kParam, true);
+        const double mint_once = std::fma(cos_val, tc.pre_cos, sin_phase * tc.partner);
+        BOOST_TEST_CONTEXT("insert arm pre_cos=" << tc.pre_cos) {
+            BOOST_CHECK_EQUAL(std::bit_cast<uint64_t>(mint[0]), std::bit_cast<uint64_t>(mint_once));
+        }
+    }
 }

--- a/cpp/tests/graph_pair_order_tests.cpp
+++ b/cpp/tests/graph_pair_order_tests.cpp
@@ -1,0 +1,334 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Graph mode's positional pairing under the one-round exchange, over an in-process ShmComm world: for
+// every ordered pair of slots (p, q) the out-part p recorded for q has the length of the in-part q
+// recorded for p (that is the whole contract replay's index-free sin exchange rests on), and replaying the
+// graph reproduces the fused propagate on the same operator within a few ULP, term for term.
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+#include "monoprop/Evolution.h"
+#include "monoprop/algebra/AlgebraCommon.h"
+#include "monoprop/core/Monomial.h"
+#include "monoprop/detail/evolution/CosineRecompute.h"
+#include "monoprop/detail/evolution/layer_build/Engine.h"
+#include "monoprop/detail/evolution/layer_build/FusedApply.h"
+#include "monoprop/detail/graph/MPGraphLayers.h"
+#include "monoprop/detail/graph_encoding/MPGraphEncodingStorage.h"
+#include "monoprop/detail/mpi/Comm.h"
+#include "monoprop/detail/mpi/MPIUtils.h"
+#include "monoprop/detail/mpi/ShmComm.h"
+#include "monoprop/detail/operator/MPOperator.h"
+#include "monoprop/detail/operator/RowAccess.h"
+
+#include "ThreadHarness.h"
+
+using namespace monoprop;
+
+namespace {
+
+constexpr size_t kN = 8;
+
+struct Problem {
+    std::vector<Monomial<kN>> terms;
+    std::vector<double> coeffs; // parallel to terms
+    std::vector<Monomial<kN>> gates;
+    std::vector<double> angles;
+};
+
+auto random_monomial(std::mt19937_64 &rng, size_t k) -> Monomial<kN> {
+    Monomial<kN> m;
+    std::uniform_int_distribution<size_t> bit(0, (2 * kN) - 1);
+    while (m.count() < k) {
+        m.set(bit(rng));
+    }
+    return m;
+}
+
+// Weights 1..6 keep every initial term inside the structural cutoff below (so over_cutoff_possible is
+// false, as the propagator would compute it); coefficients span six decades so lower_atol splits the
+// pairs into rotating, silent and mixed ones.
+auto make_problem(uint64_t seed, size_t n_terms, size_t n_gates) -> Problem {
+    std::mt19937_64 rng(seed);
+    Problem p;
+    std::uniform_real_distribution<double> mag(-6.0, 0.0);
+    std::uniform_real_distribution<double> ang(0.1, 1.2);
+    while (p.terms.size() < n_terms) {
+        const auto m = random_monomial(rng, 1 + (rng() % 6));
+        bool dup = false;
+        for (const auto &t : p.terms) {
+            dup |= (t == m);
+        }
+        if (!dup) {
+            p.terms.push_back(m);
+            p.coeffs.push_back(((rng() & 1U) != 0U ? 1.0 : -1.0) * std::pow(10.0, mag(rng)));
+        }
+    }
+    for (size_t g = 0; g < n_gates; ++g) {
+        p.gates.push_back(random_monomial(rng, 1 + (rng() % 4)));
+        p.angles.push_back(ang(rng));
+    }
+    return p;
+}
+
+// ULP distance of two doubles with the same sign; a sign change or a NaN is "infinite".
+auto ulp_distance(double a, double b) -> uint64_t {
+    if (a == b) {
+        return 0;
+    }
+    if (std::isnan(a) || std::isnan(b) || std::signbit(a) != std::signbit(b)) {
+        return UINT64_MAX;
+    }
+    const auto ia = std::bit_cast<int64_t>(a);
+    const auto ib = std::bit_cast<int64_t>(b);
+    return static_cast<uint64_t>(ia > ib ? ia - ib : ib - ia);
+}
+
+struct SlotResult {
+    std::vector<std::shared_ptr<LayerCore>> cores; // one per gate
+    std::vector<Monomial<kN>> rows_fused;
+    std::vector<Monomial<kN>> rows_graph;
+    VecD coeffs_fused;
+    VecD coeffs_graph;
+    // Per gate, before the arms are re-synchronised (so each gate is compared on identical inputs): the
+    // worst ULP distance between the two arms' coefficients, and the worst deviation in units of the
+    // one-product rounding bound (see run_slot). `compared` counts rows.
+    std::vector<uint64_t> worst_ulp;
+    std::vector<double> worst_bound_ratio;
+    size_t compared = 0;
+    bool rows_agree = true;
+};
+
+auto rows_of(const detail::MPOperator<kN> &op) -> std::vector<Monomial<kN>> {
+    std::vector<Monomial<kN>> out;
+    for (size_t i = 0; i < op.store->size(); ++i) {
+        out.push_back(op.store->row(i));
+    }
+    return out;
+}
+
+// One slot's run of both arms over the same gates. Each arm owns its operator: the two must grow the
+// same rows in the same order, which the comparison in the caller checks.
+auto run_slot(mpi::Comm comm, size_t my_rank, const Problem &p, std::optional<double> lower_atol) -> SlotResult {
+    const auto router = router_for<kN>(comm);
+    std::vector<Monomial<kN>> owned;
+    VecD owned_c;
+    for (size_t i = 0; i < p.terms.size(); ++i) {
+        if (find_rank<kN>(p.terms[i], router) == my_rank) {
+            owned.push_back(p.terms[i]);
+            owned_c.push_back(p.coeffs[i]);
+        }
+    }
+    auto seed = [&](detail::MPOperator<kN> &op) {
+        op.basis = Basis::Majorana;
+        detail::insert_absent_terms<kN>(op, owned.size(), [&](size_t k, size_t base) {
+            assign_row<kN>(*op.store, base + k, owned[k]);
+        });
+    };
+    detail::MPOperator<kN> op_f;
+    detail::MPOperator<kN> op_g;
+    seed(op_f);
+    seed(op_g);
+    const CutoffFn<kN> cutoff_fn = detail::LengthCutoff<kN>{6, kN};
+
+    SlotResult res;
+    res.coeffs_fused = owned_c;
+    res.coeffs_graph = owned_c;
+    detail::GateScratch<kN> scratch_f;
+    detail::GateScratch<kN> scratch_g;
+    for (size_t g = 0; g < p.gates.size(); ++g) {
+        const double theta = p.angles[g];
+        const VecD pre = res.coeffs_graph; // both arms start the gate from these values
+        // Fused arm, as evolve_mode_contract_immediately_ drives it.
+        {
+            CosMask cos;
+            detail::FusedContract fc;
+            bool fused_scale = false;
+            detail::build_layer<kN>(op_f,
+                                    p.gates[g],
+                                    cutoff_fn,
+                                    lower_atol,
+                                    std::cref(res.coeffs_fused),
+                                    std::nullopt,
+                                    theta,
+                                    std::nullopt,
+                                    /*over_cutoff_possible=*/false,
+                                    scratch_f,
+                                    comm,
+                                    &cos,
+                                    &fc,
+                                    /*schrodinger=*/false,
+                                    &res.coeffs_fused,
+                                    &fused_scale);
+            res.coeffs_fused.resize(op_f.store->size(), 0.0);
+            detail::apply_fused_contract(fc, res.coeffs_fused, cos, theta, fused_scale);
+        }
+        // Graph arm, as evolve_mode_graph_with_coeffs_ drives it: build, extend, replay.
+        {
+            auto cos = std::make_shared<CosMask>();
+            auto core = detail::build_layer<kN>(op_g,
+                                                p.gates[g],
+                                                cutoff_fn,
+                                                lower_atol,
+                                                std::cref(res.coeffs_graph),
+                                                std::nullopt,
+                                                theta,
+                                                std::nullopt,
+                                                /*over_cutoff_possible=*/false,
+                                                scratch_g,
+                                                comm,
+                                                cos.get());
+            if (core == nullptr) {
+                throw std::runtime_error("graph build returned no layer");
+            }
+            res.coeffs_graph.resize(op_g.store->size(), 0.0);
+            Layer layer(core);
+            const detail::LayerCosScale cos_scale = [cos](size_t, double *c, double v) {
+                detail::scale_cos_mask(c, *cos, v);
+            };
+            evolve_step(res.coeffs_graph, layer, theta, comm, cos_scale);
+            res.cores.push_back(std::move(core));
+        }
+        // Compare this gate on its own, then hand the graph arm's values to the fused arm: the two arms
+        // round differently (the fused mint folds cos and sin into one expression, the replay scales then
+        // adds), and letting a 1-ULP difference feed 13 more gates of cancellation measures accumulation,
+        // not equivalence.
+        if (op_f.store->size() != op_g.store->size()) {
+            res.rows_agree = false;
+            throw std::runtime_error("the two arms grew different row counts");
+        }
+        for (size_t i = 0; i < op_f.store->size(); ++i) {
+            if (!(op_f.store->row(i) == op_g.store->row(i))) {
+                res.rows_agree = false;
+                throw std::runtime_error("the two arms grew different rows");
+            }
+        }
+        // Both arms compute cos·c then c += sin·φ·v with the same operands; the compiler is free to
+        // contract the product into the add in one loop and not the other, so the two results may differ
+        // by one rounding of the product p = sin·φ·v, i.e. by eps·|p| ≤ eps·(|c_before| + |c_after|).
+        // Where c_before and p cancel that is many ULP of the result, so the ULP distance alone is not the
+        // criterion: a row passes if it is within 4 ULP or within 4 such roundings.
+        uint64_t worst = 0;
+        double worst_ratio = 0.0;
+        for (size_t i = 0; i < res.coeffs_fused.size(); ++i) {
+            const double a = res.coeffs_fused[i];
+            const double b = res.coeffs_graph[i];
+            const double before = i < pre.size() ? pre[i] : 0.0;
+            const double bound =
+                std::numeric_limits<double>::epsilon() * (std::abs(before) + std::max(std::abs(a), std::abs(b)));
+            worst = std::max(worst, ulp_distance(a, b));
+            worst_ratio = std::max(worst_ratio, bound > 0.0 ? std::abs(a - b) / bound : (a == b ? 0.0 : 1e300));
+            ++res.compared;
+        }
+        res.worst_ulp.push_back(worst);
+        res.worst_bound_ratio.push_back(worst_ratio);
+        res.coeffs_fused = res.coeffs_graph;
+    }
+    res.rows_fused = rows_of(op_f);
+    res.rows_graph = rows_of(op_g);
+    return res;
+}
+
+auto check_world(size_t S, uint64_t seed, std::optional<double> lower_atol) -> void {
+    const Problem p = make_problem(seed, /*n_terms=*/400, /*n_gates=*/14);
+    mpi::ShmComm sh(static_cast<int>(S));
+    std::vector<SlotResult> results(S);
+    const auto errs = test_utils::run_comm_threads(sh, static_cast<int>(S), [&](mpi::ShmComm &world, int r) {
+        results[static_cast<size_t>(r)] =
+            run_slot(mpi::Comm::make_shm(&world, r), static_cast<size_t>(r), p, lower_atol);
+    });
+    for (const auto &e : errs) {
+        if (e) {
+            std::rethrow_exception(e);
+        }
+    }
+
+    // (1) The pairing contract: my out-part for q is exactly as long as q's in-part for me, every gate.
+    size_t cross_pairs = 0;
+    size_t self_pairs = 0;
+    for (size_t g = 0; g < p.gates.size(); ++g) {
+        for (size_t a = 0; a < S; ++a) {
+            for (size_t b = 0; b < S; ++b) {
+                const auto ab = detail::cross_rank_slot(results[a].cores[g]->cross_rank, b);
+                const auto ba = detail::cross_rank_slot(results[b].cores[g]->cross_rank, a);
+                BOOST_REQUIRE_GE(ab.sin_send_count, ab.in_count);
+                const size_t out_ab = ab.sin_send_count - ab.in_count;
+                BOOST_TEST_CONTEXT("gate " << g << " slots " << a << "->" << b) {
+                    BOOST_TEST(out_ab == ba.in_count);
+                }
+                (a == b ? self_pairs : cross_pairs) += ba.in_count;
+            }
+        }
+    }
+    BOOST_TEST(cross_pairs > 0);
+    BOOST_TEST(self_pairs > 0);
+
+    // (2) Both arms grew the same rows in the same order, and per gate the replay reproduces the fused
+    // values to within a few ULP on every row.
+    uint64_t worst = 0;
+    double worst_ratio = 0.0;
+    size_t compared = 0;
+    for (size_t r = 0; r < S; ++r) {
+        const auto &res = results[r];
+        BOOST_REQUIRE(res.rows_agree);
+        BOOST_REQUIRE_EQUAL(res.rows_fused.size(), res.rows_graph.size());
+        BOOST_REQUIRE_EQUAL(res.worst_ulp.size(), p.gates.size());
+        for (size_t g = 0; g < p.gates.size(); ++g) {
+            BOOST_TEST_CONTEXT("slot " << r << " gate " << g << " worst_ulp " << res.worst_ulp[g]
+                                       << " worst_bound_ratio " << res.worst_bound_ratio[g]) {
+                BOOST_TEST((res.worst_ulp[g] <= 4U || res.worst_bound_ratio[g] <= 4.0));
+            }
+            worst = std::max(worst, res.worst_ulp[g]);
+            worst_ratio = std::max(worst_ratio, res.worst_bound_ratio[g]);
+        }
+        compared += res.compared;
+    }
+    BOOST_TEST_MESSAGE("S=" << S << " atol=" << lower_atol.value_or(0.0) << " compared=" << compared
+                            << " worst_ulp=" << worst << " worst_bound_ratio=" << worst_ratio
+                            << " cross_pairs=" << cross_pairs << " self_pairs=" << self_pairs);
+    BOOST_TEST(compared > p.terms.size());
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(graph_pair_order_two_slots_exact) {
+    check_world(2, 0x0A11CE, std::nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(graph_pair_order_two_slots_with_lower_atol) {
+    check_world(2, 0x0B0B, 1e-4);
+}
+
+BOOST_AUTO_TEST_CASE(graph_pair_order_four_slots_exact) {
+    check_world(4, 0xC0FFEE, std::nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(graph_pair_order_four_slots_with_lower_atol) {
+    check_world(4, 0xD00D, 1e-3);
+}

--- a/cpp/tests/mp_operator_tests.cpp
+++ b/cpp/tests/mp_operator_tests.cpp
@@ -352,28 +352,29 @@ BOOST_AUTO_TEST_CASE(mp_operator_estimate_memory_usage_tracks_inverted_index_pre
     BOOST_CHECK_GT(after.inverted_index_bytes, 0U); // present arm
 }
 
-// matched_scratch_bytes is summed by total_bytes() and accumulated by operator+= for the facade's sum.
-BOOST_AUTO_TEST_CASE(mp_operator_breakdown_counts_matched_scratch_in_total_and_sum) {
+// gate_scratch_bytes is summed by total_bytes() and accumulated by operator+= for the facade's sum.
+BOOST_AUTO_TEST_CASE(mp_operator_breakdown_counts_gate_scratch_in_total_and_sum) {
     detail::MPOperatorMemoryBreakdown<8> acc;
     acc.op_coeffs_bytes = 100;
-    acc.matched_scratch_bytes = 7;
+    acc.gate_scratch_bytes = 7;
     BOOST_CHECK_EQUAL(acc.total_bytes(), 107U);
 
     detail::MPOperatorMemoryBreakdown<8> other;
     other.op_coeffs_bytes = 20;
-    other.matched_scratch_bytes = 3;
+    other.gate_scratch_bytes = 3;
 
     acc += other;
-    BOOST_CHECK_EQUAL(acc.matched_scratch_bytes, 10U);
+    BOOST_CHECK_EQUAL(acc.gate_scratch_bytes, 10U);
     BOOST_CHECK_EQUAL(acc.total_bytes(), 130U);
 
     // An operator on its own has no stamp array to report.
     auto bare = build_indexed_op({indices_to_bitset<8>({0, 1})});
-    BOOST_CHECK_EQUAL(detail::estimate_memory_usage<8>(bare).matched_scratch_bytes, 0U);
+    BOOST_CHECK_EQUAL(detail::estimate_memory_usage<8>(bare).gate_scratch_bytes, 0U);
 }
 
-// epoch_ is empty until the first begin_gate, so this must apply a gate before the bytes can be nonzero.
-BOOST_AUTO_TEST_CASE(mp_operator_breakdown_matched_scratch_nonzero_after_a_gate) {
+// The scratch is empty until the first gate builds its table, so this must apply a gate before the bytes
+// can be nonzero.
+BOOST_AUTO_TEST_CASE(mp_operator_breakdown_gate_scratch_nonzero_after_a_gate) {
     constexpr size_t kModes = 2;
     OperatorDict ham;
     ham[VecZ{0, 1}] = cd{0.0, 1.0};
@@ -387,17 +388,17 @@ BOOST_AUTO_TEST_CASE(mp_operator_breakdown_matched_scratch_nonzero_after_a_gate)
                                           std::nullopt,
                                           CutoffType::Length,
                                           std::nullopt);
-    BOOST_CHECK_EQUAL(sim.operator_memory_usage().matched_scratch_bytes, 0U); // no gate applied yet
+    BOOST_CHECK_EQUAL(sim.operator_memory_usage().gate_scratch_bytes, 0U); // no gate applied yet
 
     const std::vector<VecZ> monos{{0}};
     sim.build_graph(monos, VecZ{0}, VecD{1.0});
 
     const auto live = sim.operator_memory_usage();
-    BOOST_CHECK_GT(live.matched_scratch_bytes, 0U);
+    BOOST_CHECK_GT(live.gate_scratch_bytes, 0U);
 
     auto without = live;
-    without.matched_scratch_bytes = 0;
-    BOOST_CHECK_EQUAL(live.total_bytes() - without.total_bytes(), live.matched_scratch_bytes);
+    without.gate_scratch_bytes = 0;
+    BOOST_CHECK_EQUAL(live.total_bytes() - without.total_bytes(), live.gate_scratch_bytes);
 }
 
 // init_operator_entries is a count: accumulated by operator+= but never summed into total_bytes().

--- a/cpp/tests/mpi_fresh_insert_equivalence.cpp
+++ b/cpp/tests/mpi_fresh_insert_equivalence.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Multi-rank equivalence for the Schrödinger fresh-insert arm of ContractSink::on_resolved, where a
-// fresh partner is state-scored (majorana_state_phase / pauli_state_phase) rather than left at 0. The
+// Multi-rank equivalence for the Schrödinger fresh-insert arm of the one-round join, where a fresh
+// partner is state-scored (majorana_state_phase / pauli_state_phase) rather than left at 0: the mint at
+// the receiver and the sender's own absence half both carry that score. The
 // Heisenberg R>1 resolve/apply paths are already covered by exact_upper_atol_rescue and
 // mpi_distributed_layer_equivalence. Only runs at world >= 2. Oracle: serial<->world equivalence --
 // the deterministic base+j miss-prefix must sum the same terms at any rank count, to near()'s rtol.

--- a/cpp/tests/mpi_utils_tests.cpp
+++ b/cpp/tests/mpi_utils_tests.cpp
@@ -166,54 +166,119 @@ BOOST_AUTO_TEST_CASE(mpi_utils_scan_routing_agrees_with_find_rank) {
     for (size_t i = 0; i < 2000; ++i) {
         terms.push_back(draw_well_formed<kN>(rng, kLogical, 1 + (rng() % 6)));
     }
-    auto op = build_op(terms);
     const Monomial<kN> gen = draw_well_formed<kN>(rng, kLogical, 4);
-    VecD coeffs(op.store->size(), 1.0);
 
     const CutoffFn<kN> fn = detail::LengthCutoff<kN>{10, kLogical};
     const detail::CutoffEvaluator<kN> eval(fn);
-    const auto cut = detail::build_majorana_evolution_cutoff_state(std::nullopt,
-                                                                   std::cref(coeffs),
-                                                                   std::nullopt,
-                                                                   std::optional<double>{0.3});
 
-    // BOTH routers, because the agreement is a property of the pair and not of either map: the scan
-    // routes the partner it just built and find_rank routes what the resolve side decoded, so a
-    // divergence introduced by either shows up here whichever routing the geometry resolves to.
-    for (const bool linear : {false, true}) {
-        size_t checked = 0;
-        size_t self_checked = 0;
-        for (const size_t ranks : {2U, 4U, 8U}) {
+    // Each rank is handed exactly the terms it owns, as MonomialPropagator seeds it: the emit path
+    // routes by rank(M) ^ rank_shift(G), which is only the owner of M^G when M really is local.
+    //
+    // The partner count is a property of the operator and the gate, not of where the partners live, so
+    // the sum over the ranks is the same for every router; routing only moves a partner between ranks
+    // and between the encoded (cross-rank) and staged (self-owned) sides. Pinning that invariance is
+    // stronger than a floor: a routing bug that drops partners moves the total, and one that misroutes
+    // them moves the split.
+    size_t routers = 0;
+    std::optional<size_t> first_total;
+    for (const size_t ranks : {2U, 4U, 8U}) {
+        // BOTH routers, because the agreement is a property of the pair and not of either hash: the
+        // scan routes off the partner's fingerprint (Router::dest_from_fingerprint) or the dense hash,
+        // and find_rank calls Router::dest, so a divergence introduced by one of them shows up here
+        // whichever routing the geometry resolves to.
+        for (const bool linear : {false, true}) {
             const auto router = routing::Router::for_modes<kN>(ranks, /*partitions=*/1, linear);
             BOOST_REQUIRE_EQUAL(router.is_linear(), linear);
-            const auto res = detail::fused_find_and_collect<kN, MajoranaAlgebra<kN>>(op,
-                                                                                     gen,
-                                                                                     eval,
-                                                                                     cut,
-                                                                                     coeffs,
-                                                                                     std::nullopt,
-                                                                                     router,
-                                                                                     0,
-                                                                                     false,
-                                                                                     nullptr,
-                                                                                     1.0);
-            BOOST_REQUIRE_EQUAL(res.leader_queries.size(), ranks);
-            // The scan routes a self-owned partner to the stage, so bucket 0 must be empty here.
-            BOOST_REQUIRE(res.leader_queries[0].empty());
-            BOOST_REQUIRE(res.follower_queries[0].empty());
-            check_bucket_ownership(res.leader_queries, router, checked);
-            check_bucket_ownership(res.follower_queries, router, checked);
-            check_self_ownership(res.leader_self, router, /*my_rank=*/0, self_checked);
-            check_self_ownership(res.follower_self, router, /*my_rank=*/0, self_checked);
+            const size_t shift = router.rank_shift<kN>(gen);
+            // Per router, not summed over them: the floors are what stops the loop passing on an empty
+            // scan, and a sum lets one router carry the other.
+            size_t checked = 0;
+            size_t self_checked = 0;
+            for (size_t my_rank = 0; my_rank < ranks; ++my_rank) {
+                std::vector<Monomial<kN>> owned;
+                for (const auto &t : terms) {
+                    if (find_rank<kN>(t, router) == my_rank) {
+                        owned.push_back(t);
+                    }
+                }
+                BOOST_REQUIRE(!owned.empty());
+                auto op = build_op(owned);
+                VecD coeffs(op.store->size(), 1.0);
+                const auto cut = detail::build_majorana_evolution_cutoff_state(std::nullopt,
+                                                                               std::cref(coeffs),
+                                                                               std::nullopt,
+                                                                               std::optional<double>{0.3});
+                detail::GateScratch<kN> scratch;
+                const auto res = detail::fused_find_and_collect<kN, MajoranaAlgebra<kN>, /*CaptureValues=*/false>(
+                    op,
+                    gen,
+                    eval,
+                    cut,
+                    coeffs,
+                    std::nullopt,
+                    /*over_cutoff_possible=*/false,
+                    my_rank,
+                    router,
+                    scratch,
+                    nullptr,
+                    1.0);
+                // The fold found anticommuting rows: they are what the join's row side is built from.
+                BOOST_REQUIRE(!scratch.nz.empty());
+                BOOST_REQUIRE_EQUAL(res.queries.size(), ranks);
+                BOOST_REQUIRE_EQUAL(res.sent.size(), ranks);
+                // The scan routes a self-owned partner to the stage, so my own bucket must be empty,
+                // and the stage's parallel record list is the one for the self slot.
+                BOOST_REQUIRE(res.queries[my_rank].empty());
+                BOOST_REQUIRE_EQUAL(res.sent[my_rank].size(), res.self.size());
+                // One record per sending source, so the per-slot source lists account for every record
+                // and are ascending in row: the absence pass and the graph sink's out lists rely on that.
+                for (size_t r = 0; r < ranks; ++r) {
+                    std::vector<TermIndex> rows;
+                    for (const auto &rec : res.sent[r]) {
+                        rows.push_back(rec.row);
+                    }
+                    BOOST_REQUIRE(std::is_sorted(rows.begin(), rows.end()));
+                    BOOST_REQUIRE((std::adjacent_find(rows.begin(), rows.end()) == rows.end()));
+                    if (r != my_rank) {
+                        BOOST_REQUIRE_EQUAL(
+                            detail::QueryWire<kN>::count_queries(res.queries[r], detail::QueryForm::Plain),
+                            rows.size());
+                    }
+                    for (const auto row : rows) {
+                        BOOST_REQUIRE(static_cast<size_t>(row) < op.store->size());
+                    }
+                }
+                check_bucket_ownership(res.queries, router, checked);
+                check_self_ownership(res.self, router, my_rank, self_checked);
+            }
+            BOOST_TEST_MESSAGE("ranks=" << ranks << " linear=" << router.is_linear() << " shift=" << shift
+                                        << " encoded=" << checked << " staged=" << self_checked);
+            const size_t total = checked + self_checked;
+            if (first_total.has_value()) {
+                BOOST_TEST(total == *first_total); // routing moves partners, it does not create or lose them
+            }
+            else {
+                first_total = total;
+            }
+            // The floors sit below the observed minimum of each arm and only catch a scan that emitted
+            // nothing; the invariance check above is the sharp one.
+            BOOST_TEST(total > 300U);
+            if (!router.is_linear()) {
+                // Splitmix re-hashes the partner, so both sides are populated at every rank count.
+                BOOST_TEST(checked > 150U);
+                BOOST_TEST(self_checked > 40U);
+            }
+            else if (shift != 0) {
+                // Fanout 1: every partner leaves for my_rank ^ shift, so nothing stays self-owned.
+                BOOST_TEST(self_checked == 0U);
+            }
+            else {
+                BOOST_TEST(checked == 0U); // a shift of zero keeps every partner on its own rank
+            }
+            ++routers;
         }
-        // Without this the loop above passes trivially if the scan emitted nothing. The floors are per
-        // router, not summed over them: a sum lets one router carry the other. The total floor is what is
-        // invariant across the split; each arm keeps its own so a bug that sends everything one way fails.
-        BOOST_TEST_MESSAGE("linear=" << linear << " encoded=" << checked << " staged=" << self_checked);
-        BOOST_TEST(checked + self_checked > 1000U);
-        BOOST_TEST(checked > 500U);
-        BOOST_TEST(self_checked > 200U);
     }
+    BOOST_TEST(routers == 6U); // the floors above are per router, so the router count is part of them
 }
 
 // A Schrodinger propagator seeds a slot by walking the whole paired basis and keeping find_rank ==

--- a/cpp/tests/position_kernels_tests.cpp
+++ b/cpp/tests/position_kernels_tests.cpp
@@ -1,0 +1,165 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The position-only emit kernels against their dense oracles: the rotation sign of both algebras from a
+// term's positions, and the (k, d) digest predicates against the bitset cutoffs they replace.
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "monoprop/algebra/Algebra.h"
+#include "monoprop/algebra/AlgebraCommon.h"
+#include "monoprop/core/Monomial.h"
+#include "monoprop/detail/operator/OperatorIndex.h"
+
+using namespace monoprop;
+
+namespace {
+
+template <size_t NumModes>
+auto random_monomial(std::mt19937_64 &rng, size_t k) -> Monomial<NumModes> {
+    Monomial<NumModes> m;
+    std::uniform_int_distribution<size_t> bit(0, Monomial<NumModes>::size() - 1);
+    k = std::min(k, Monomial<NumModes>::size()); // a narrow system cannot hold more positions than it has
+    while (m.count() < k) {
+        m.set(bit(rng));
+    }
+    return m;
+}
+
+template <size_t NumModes>
+auto positions_of(const Monomial<NumModes> &m) -> std::vector<typename detail::OperatorIndex<NumModes>::PosT> {
+    std::vector<typename detail::OperatorIndex<NumModes>::PosT> pos;
+    for (size_t b = m.find_first(); b < m.size(); b = m.find_next(b)) {
+        pos.push_back(static_cast<typename detail::OperatorIndex<NumModes>::PosT>(b));
+    }
+    return pos;
+}
+
+template <size_t NumModes, Algebra A>
+auto check_sign_from_positions(uint64_t seed, size_t max_gen_weight) -> void {
+    std::mt19937_64 rng(seed);
+    size_t checked = 0;
+    for (size_t trial = 0; trial < 3000; ++trial) {
+        const auto gen = random_monomial<NumModes>(rng, 1 + (rng() % max_gen_weight));
+        const auto ctx = A::make_gen_context(gen);
+        BOOST_REQUIRE(A::sign_from_positions_ok(ctx));
+        for (size_t t = 0; t < 4; ++t) {
+            const auto mono = random_monomial<NumModes>(rng, rng() % 12);
+            const auto pos = positions_of<NumModes>(mono);
+            const int dense = A::rotation_sign(ctx, mono, mono ^ gen);
+            const int sparse = A::rotation_sign_positions(ctx, pos.data(), pos.size());
+            BOOST_REQUIRE_EQUAL(dense, sparse);
+            ++checked;
+        }
+    }
+    BOOST_TEST(checked == 12000U);
+}
+
+//! The paired-mode count of an ascending position list, written against the definition.
+auto reference_paired(const std::vector<uint16_t> &pos) -> size_t {
+    size_t d = 0;
+    for (size_t j = 0; j + 1 < pos.size(); ++j) {
+        if ((pos[j] % 2 == 0) && (pos[j + 1] == pos[j] + 1)) {
+            ++d;
+        }
+    }
+    return d;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(position_sign_matches_dense_majorana) {
+    check_sign_from_positions<4, MajoranaAlgebra<4>>(1, 4);
+    check_sign_from_positions<32, MajoranaAlgebra<32>>(2, 8);
+    check_sign_from_positions<64, MajoranaAlgebra<64>>(3, 10);
+    check_sign_from_positions<128, MajoranaAlgebra<128>>(4, 12);
+    check_sign_from_positions<250, MajoranaAlgebra<250>>(5, 16);
+}
+
+BOOST_AUTO_TEST_CASE(position_sign_matches_dense_pauli) {
+    check_sign_from_positions<4, PauliAlgebra<4>>(11, 4);
+    check_sign_from_positions<32, PauliAlgebra<32>>(12, 8);
+    check_sign_from_positions<64, PauliAlgebra<64>>(13, 12);
+    check_sign_from_positions<128, PauliAlgebra<128>>(14, 16);
+    check_sign_from_positions<250, PauliAlgebra<250>>(15, 20);
+}
+
+// A Pauli generator on more than 32 qubits has no compact word; the kernel says so instead of guessing.
+BOOST_AUTO_TEST_CASE(position_sign_pauli_declines_wide_generators) {
+    constexpr size_t kN = 64;
+    Monomial<kN> wide;
+    for (size_t q = 0; q < 33; ++q) {
+        wide.set(2 * q);
+    }
+    Monomial<kN> narrow;
+    for (size_t q = 0; q < 32; ++q) {
+        narrow.set(2 * q);
+    }
+    BOOST_TEST(!PauliAlgebra<kN>::sign_from_positions_ok(PauliAlgebra<kN>::make_gen_context(wide)));
+    BOOST_TEST(PauliAlgebra<kN>::sign_from_positions_ok(PauliAlgebra<kN>::make_gen_context(narrow)));
+}
+
+// The (k, d) digest predicates against the bitset ones, for both structural cutoffs and the paired
+// exception, on well-formed monomials over a logical width below the storage width.
+BOOST_AUTO_TEST_CASE(position_digest_matches_the_bitset_cutoffs) {
+    constexpr size_t kN = 32;
+    constexpr size_t kLogical = 30;
+    std::mt19937_64 rng(77);
+    std::uniform_int_distribution<size_t> pos_dist(2 * (kN - kLogical), (2 * kN) - 1);
+    const auto draw = [&](size_t k) {
+        Monomial<kN> m;
+        while (m.count() < k) {
+            m.set(pos_dist(rng));
+        }
+        return m;
+    };
+    size_t paired_seen = 0;
+    for (size_t trial = 0; trial < 5000; ++trial) {
+        const auto term = draw(rng() % 9);
+        std::vector<uint16_t> pos;
+        for (size_t b = term.find_first(); b < term.size(); b = term.find_next(b)) {
+            pos.push_back(static_cast<uint16_t>(b));
+        }
+        const size_t k = term.count();
+        const size_t d = reference_paired(pos);
+        // The digest is exactly what the two bitset sums carry: k − 2d is the xor sum, k − d the or sum.
+        const auto sums = cutoff_sums<kN>(term, kLogical);
+        BOOST_REQUIRE_EQUAL(k - (2 * d), sums.xor_sum);
+        BOOST_REQUIRE_EQUAL(k - d, sums.or_sum);
+        BOOST_REQUIRE_EQUAL(digest_is_paired(k, d), is_paired<kN>(term));
+        paired_seen += static_cast<size_t>(digest_is_paired(k, d) && k > 0);
+        for (const unsigned int cutoff : {0U, 2U, 4U, 6U}) {
+            BOOST_REQUIRE_EQUAL(length_keeps(k, d, cutoff), length_cutoff<kN>(term, cutoff, kLogical));
+            BOOST_REQUIRE_EQUAL(support_keeps(k, d, cutoff), support_cutoff<kN>(term, cutoff, kLogical));
+            const CutoffFn<kN> lfn = detail::LengthCutoff<kN>{cutoff, kLogical};
+            const detail::CutoffEvaluator<kN> leval(lfn);
+            BOOST_REQUIRE(leval.has_digest_form());
+            BOOST_REQUIRE_EQUAL(leval.passes_from_digest(k, d), leval.passes_with_popcount(term, k));
+            const CutoffFn<kN> sfn = detail::SupportCutoff<kN>{cutoff, kLogical};
+            const detail::CutoffEvaluator<kN> seval(sfn);
+            BOOST_REQUIRE(seval.has_digest_form());
+            BOOST_REQUIRE_EQUAL(seval.passes_from_digest(k, d), seval.passes_with_popcount(term, k));
+        }
+    }
+    BOOST_TEST(paired_seen > 0U);
+    // An opaque cutoff has no digest form, so nothing may answer it from (k, d).
+    const CutoffFn<kN> opaque = [](const Monomial<kN> &m) { return m.count() < 3; };
+    BOOST_TEST(!detail::CutoffEvaluator<kN>(opaque).has_digest_form());
+}

--- a/cpp/tests/sparse_query_tests.cpp
+++ b/cpp/tests/sparse_query_tests.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "monoprop/detail/evolution/layer_build/Common.h"
+#include "monoprop/detail/evolution/layer_build/PartnerMerge.h"
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
 
 #include "dense_query_reference.h"
@@ -358,23 +359,24 @@ BOOST_AUTO_TEST_CASE(sparse_record_encoding_is_deterministic) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(sparse_record_pair_count_recomputes_d_from_positions) {
+BOOST_AUTO_TEST_CASE(sparse_record_paired_position_count_recomputes_d_from_positions) {
     // d is recomputed from positions, so it must agree with the definition: mode m owns bits 2m, 2m+1.
+    auto pairs = [](const std::vector<uint16_t> &pos) { return count_paired_positions(pos.data(), pos.size()); };
     std::mt19937_64 rng(0xD1D1ULL);
     for (size_t trial = 0; trial < 100; ++trial) {
         const auto pos = scattered(rng() % 30, 256, rng);
-        BOOST_TEST(QueryWire<128>::pair_count(pos) == reference_pair_count(pos));
+        BOOST_TEST(pairs(pos) == reference_pair_count(pos));
     }
     const std::vector<uint16_t> straddle{1, 2, 5, 6};
-    BOOST_TEST(QueryWire<128>::pair_count(straddle) == 0U);
+    BOOST_TEST(pairs(straddle) == 0U);
     const std::vector<uint16_t> real{2, 3, 6, 7};
-    BOOST_TEST(QueryWire<128>::pair_count(real) == 2U);
+    BOOST_TEST(pairs(real) == 2U);
     std::vector<uint16_t> paired;
     for (uint16_t m = 0; m < 16; ++m) {
         paired.push_back(static_cast<uint16_t>(2 * m));
         paired.push_back(static_cast<uint16_t>(2 * m + 1));
     }
-    BOOST_TEST(QueryWire<128>::pair_count(paired) == paired.size() / 2);
+    BOOST_TEST(pairs(paired) == paired.size() / 2);
 }
 
 namespace {
@@ -395,29 +397,32 @@ BOOST_AUTO_TEST_CASE(sparse_record_fused_stream_interleaves_values_and_stays_wal
     std::mt19937_64 rng(0xF5EDULL);
     std::vector<std::vector<uint16_t>> terms;
     std::vector<double> vals;
-    VecZ plain;
+    std::vector<bool> rots;
+    VecZ fused;
     for (size_t i = 0; i < 24; ++i) {
         terms.push_back(scattered(rng() % 45, 256, rng));
         vals.push_back(static_cast<double>(i) * 0.5 - 3.25);
+        rots.push_back((i % 3) != 1);
         Monomial<128> m;
         for (const auto p : terms.back()) {
             m.set(p);
         }
         const auto pos = positions_of<128>(m);
-        (void)QW::push(plain, pos, 1);
+        (void)QW::push(fused, pos, 1, rots.back());
+        QW::push_value(fused, vals.back());
     }
-    VecZ fused;
-    QW::build_fused(plain, vals, fused);
 
     const QueryForm form = QueryForm::Fused;
     BOOST_TEST(QW::count_queries(fused, form) == terms.size());
     size_t off = 0;
     for (size_t i = 0; i < terms.size(); ++i) {
         BOOST_TEST(QW::k_at(fused, off) == terms[i].size());
+        BOOST_TEST(QW::rot_at(fused, off) == rots[i]);
         BOOST_TEST(QW::value_at(fused, off) == vals[i]);
         std::vector<uint16_t> out(terms[i].size() + 1);
         const auto rq = QW::read_query(fused, form, off, out);
         BOOST_TEST(rq.phase == 1);
+        BOOST_TEST(rq.rot == rots[i]);
         out.resize(terms[i].size());
         BOOST_TEST(out == terms[i], boost::test_tools::per_element());
         off = QW::next_off(fused, form, off);
@@ -431,14 +436,15 @@ BOOST_AUTO_TEST_CASE(sparse_record_fused_value_channel_is_bit_exact_and_reusable
     using QW = QueryWire<128>;
     const QueryForm form = QueryForm::Fused;
 
-    auto push_terms = [](VecZ &buf, const std::vector<std::vector<uint16_t>> &terms) {
-        for (const auto &t : terms) {
+    auto push_terms = [](VecZ &buf, const std::vector<std::vector<uint16_t>> &terms, const std::vector<double> &vals) {
+        for (size_t i = 0; i < terms.size(); ++i) {
             Monomial<128> m;
-            for (const auto p : t) {
+            for (const auto p : terms[i]) {
                 m.set(p);
             }
             const auto pos = positions_of<128>(m);
             (void)QW::push(buf, pos, 1);
+            QW::push_value(buf, vals[i]);
         }
     };
 
@@ -465,10 +471,8 @@ BOOST_AUTO_TEST_CASE(sparse_record_fused_value_channel_is_bit_exact_and_reusable
     };
     BOOST_REQUIRE_EQUAL(terms.size(), values.size());
 
-    VecZ plain;
-    push_terms(plain, terms);
     VecZ fused;
-    QW::build_fused(plain, values, fused);
+    push_terms(fused, terms, values);
 
     size_t off = 0;
     for (size_t i = 0; i < values.size(); ++i) {
@@ -478,24 +482,22 @@ BOOST_AUTO_TEST_CASE(sparse_record_fused_value_channel_is_bit_exact_and_reusable
     }
     BOOST_TEST(off == fused.size());
 
-    // Buffer reuse: sizes must be exact, or a shorter gate reads the previous gate's trailing words.
-    VecZ plain_big;
+    // Buffer reuse: the per-slot buffers are cleared, not reallocated, between gates, so a shorter gate
+    // must leave exactly its own words behind.
+    VecZ out;
     std::vector<double> vbig;
     std::vector<std::vector<uint16_t>> big;
     for (size_t r = 0; r < 32; ++r) {
         big.push_back({static_cast<uint16_t>(r), static_cast<uint16_t>(r + 60)});
         vbig.push_back(static_cast<double>(r) * 1.5 - 7.0);
     }
-    push_terms(plain_big, big);
-    VecZ out;
-    QW::build_fused(plain_big, vbig, out);
+    push_terms(out, big, vbig);
     const size_t cap_after_big = out.capacity();
 
-    VecZ plain_small;
     const std::vector<double> vsmall = {42.0, -42.0, 0.25};
     const std::vector<std::vector<uint16_t>> small = {{1}, {2, 3}, {4, 5, 6}};
-    push_terms(plain_small, small);
-    QW::build_fused(plain_small, vsmall, out);
+    out.clear();
+    push_terms(out, small, vsmall);
     BOOST_TEST(QW::count_queries(out, form) == vsmall.size());
     BOOST_CHECK_GE(out.capacity(), cap_after_big);
     off = 0;
@@ -505,12 +507,45 @@ BOOST_AUTO_TEST_CASE(sparse_record_fused_value_channel_is_bit_exact_and_reusable
         off = QW::next_off(out, form, off);
     }
     BOOST_TEST(off == out.size());
+}
 
-    // Empty input: the self slot is cleared before the exchange, into a buffer holding stale words.
-    VecZ empty;
-    VecZ dirty{1, 2, 3};
-    QW::build_fused(empty, {}, dirty);
-    BOOST_TEST(dirty.empty());
+// The rot bit sits between the phase and k fields: every (k, phase, rot) combination round-trips through
+// the header, including the long-k escape, and flipping rot changes exactly that bit of the first word.
+BOOST_AUTO_TEST_CASE(sparse_record_rot_bit_round_trips_across_header_shapes) {
+    using QW = QueryWire<128>;
+    for (const size_t k : {0U, 1U, 2U, 7U, 30U, 31U, 32U, 40U, 100U}) {
+        std::vector<uint16_t> pos;
+        for (size_t j = 0; j < k; ++j) {
+            pos.push_back(static_cast<uint16_t>(2 * j + (j % 2))); // strictly ascending, mixed gaps
+        }
+        for (const int phase : {-1, 0, 1}) {
+            VecZ a;
+            VecZ b;
+            (void)QW::push(a, pos, phase, false);
+            (void)QW::push(b, pos, phase, true);
+            BOOST_REQUIRE_EQUAL(a.size(), b.size());
+            const auto ha = QW::header_at(a, 0);
+            const auto hb = QW::header_at(b, 0);
+            BOOST_TEST(ha.k == k);
+            BOOST_TEST(hb.k == k);
+            BOOST_TEST(ha.phase == phase);
+            BOOST_TEST(hb.phase == phase);
+            BOOST_TEST(!ha.rot);
+            BOOST_TEST(hb.rot);
+            BOOST_TEST(!QW::rot_at(a, 0));
+            BOOST_TEST(QW::rot_at(b, 0));
+            BOOST_TEST((static_cast<uint64_t>(a[0]) ^ static_cast<uint64_t>(b[0])) == (uint64_t{1} << QW::kPhaseBits));
+            for (size_t w = 1; w < a.size(); ++w) {
+                BOOST_TEST(a[w] == b[w]);
+            }
+            std::vector<uint16_t> out(k);
+            const auto d = QW::read_positions(b, 0, out);
+            BOOST_TEST(d.rot);
+            BOOST_TEST(d.phase == phase);
+            BOOST_TEST(d.next == b.size());
+            BOOST_TEST(out == pos, boost::test_tools::per_element());
+        }
+    }
 }
 
 // Positions with exactly k entries whose widest gap is exactly `gw`: one gap of 2^(gw-1) -- the smallest

--- a/cpp/tests/sparse_resolve_tests.cpp
+++ b/cpp/tests/sparse_resolve_tests.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The position-form resolve path, differentially against the queries the caller built and the dense
-// Monomial-keyed insert path, neither of which is the code under test.
+// The receiver side of the one-round exchange: the incoming records decoded (IncomingRecords), matched
+// against the operator's term table (TableJoin), joined under the receiver rule (join_incoming) and the
+// misses inserted (MissStage / insert_misses) -- differentially against the records the caller built, the
+// dense Monomial-keyed insert path and the table's by-value find, none of which is the code under test.
 
 #include <boost/test/unit_test.hpp>
 
@@ -26,8 +28,11 @@
 #include <vector>
 
 #include "monoprop/core/Monomial.h"
+#include "monoprop/detail/evolution/layer_build/GateScratch.h"
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
 #include "monoprop/detail/evolution/layer_build/Resolve.h"
+#include "monoprop/detail/evolution/layer_build/TableJoin.h"
+#include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
 #include "monoprop/detail/operator/OperatorIndex.h"
 #include "monoprop/detail/operator/RowKey.h"
@@ -85,6 +90,39 @@ auto make_op(const std::vector<Monomial<NumModes>> &terms) -> detail::MPOperator
     return op;
 }
 
+// The per-gate state a gate that finds EVERY row anticommuting would leave behind: marks cleared over
+// all of them. This is the receiver-side oracle the decode and join run against; the rows themselves are
+// reached through the operator's term table, spilled ones included, exactly as the engine reaches them.
+template <size_t NumModes>
+struct AllRowsGate {
+    detail::TableJoin<NumModes> join;
+    detail::RowMarks marks;
+    std::vector<detail::EvenParityNzWord> nz;
+
+    explicit AllRowsGate(const detail::MPOperator<NumModes> &op) {
+        const size_t n = op.store->size();
+        for (size_t base = 0; base < n; base += 64) {
+            const size_t k = std::min<size_t>(64, n - base);
+            nz.push_back(detail::EvenParityNzWord{.base = base,
+                                                  .overlap = (k == 64) ? ~uint64_t{0} : ((uint64_t{1} << k) - 1U),
+                                                  .foll = 0});
+        }
+        marks.begin(n, nz);
+    }
+
+    // Probes a decoded batch's keys in record order against the operator's term table.
+    template <typename Records>
+    auto match(const detail::MPOperator<NumModes> &op, const Records &pr) -> void {
+        join.begin_queries(pr.nq_total);
+        join.run(
+            op.term_table(),
+            *op.store,
+            [&](size_t q) { return pr.tag_of[q]; },
+            [&](size_t q) { return pr.positions_at(q); },
+            [](size_t, size_t) {});
+    }
+};
+
 template <size_t NumModes>
 auto draw_distinct(std::mt19937_64 &rng, size_t n) -> std::vector<Monomial<NumModes>> {
     std::vector<Monomial<NumModes>> out;
@@ -117,21 +155,58 @@ auto positions_of(const Monomial<NumModes> &m) -> std::vector<uint16_t> {
     return pos;
 }
 
+// Record q of sender s carries phase (+1, -1 alternating), rot = (q % 3 != 2) and value 0.5 + q.
+auto record_phase(size_t q) -> int {
+    return ((q % 2) == 0) ? 1 : -1;
+}
+auto record_rot(size_t q) -> bool {
+    return (q % 3) != 2;
+}
+auto record_value(size_t q) -> double {
+    return 0.5 + static_cast<double>(q);
+}
+
 template <size_t NumModes>
 auto serialize(const std::vector<std::vector<Monomial<NumModes>>> &queries, bool fused) -> std::vector<VecZ> {
     std::vector<VecZ> incoming(queries.size());
     for (size_t s = 0; s < queries.size(); ++s) {
+        VecZ &buf = incoming[s];
         for (size_t q = 0; q < queries[s].size(); ++q) {
-            const int phase = ((q % 2) == 0) ? 1 : -1;
             const auto pos = positions_of<NumModes>(queries[s][q]);
-            detail::QueryWire<NumModes>::push(incoming[s], pos, phase);
+            detail::QueryWire<NumModes>::push(buf, pos, record_phase(q), record_rot(q));
             if (fused) {
-                detail::QueryWire<NumModes>::push_value(incoming[s], 0.5 + static_cast<double>(q));
+                detail::QueryWire<NumModes>::push_value(buf, record_value(q));
             }
         }
     }
     return incoming;
 }
+
+// Records every sink call with its slot, so the join order and the slot attribution are both pinned.
+struct RecordingSink {
+    // No value column: the decode's own value checks above cover it, and join_incoming reads val_of only
+    // when a sink asks for it -- which the Plain half of this case has none of.
+    static constexpr bool wants_values = false;
+    static constexpr bool wants_responses = false;
+
+    struct Rec {
+        char kind; // 'h' hit, 'm' mint
+        size_t slot;
+        size_t idx;
+        double v;
+        int phase;
+        bool foll;
+    };
+    std::vector<Rec> recs;
+    auto hit(size_t slot, size_t row, double v, int phase, bool foll, bool /*own_rot*/) -> void {
+        recs.push_back({'h', slot, row, v, phase, foll});
+    }
+    auto mint(size_t slot, size_t idx, double v, int phase) -> void {
+        recs.push_back({'m', slot, idx, v, phase, false});
+    }
+    auto out_pair(size_t, size_t, int) -> void { BOOST_FAIL("the join never reports out-side entries"); }
+    auto out_unanswered(size_t, size_t, double, int) -> void { BOOST_FAIL("the join never reports out-side entries"); }
+};
 
 template <size_t NumModes>
 auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t n_query, size_t rank_count, bool fused)
@@ -151,7 +226,7 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
         for (size_t w = 0; w < Monomial<NumModes>::num_words(); ++w) {
             key.push_back(m.word(w));
         }
-        // A repeat would break the one-index-per-miss contract; the engine gets distinctness from ^G.
+        // A repeat would violate the mint's distinctness precondition; the engine gets it from ^G.
         if (!queried.insert(key).second) {
             continue;
         }
@@ -161,13 +236,18 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
     BOOST_REQUIRE(hits_planned > 0);
     BOOST_REQUIRE(misses_planned > 0);
 
+    // The flat record order the receiver must reproduce: senders ascending, each in stream order.
     std::vector<Monomial<NumModes>> expect_mono;
     std::vector<int> expect_phase;
+    std::vector<bool> expect_rot;
+    std::vector<double> expect_value;
     std::vector<size_t> expect_sender;
     for (size_t s = 0; s < rank_count; ++s) {
         for (size_t q = 0; q < queries[s].size(); ++q) {
             expect_mono.push_back(queries[s][q]);
-            expect_phase.push_back(((q % 2) == 0) ? 1 : -1);
+            expect_phase.push_back(record_phase(q));
+            expect_rot.push_back(record_rot(q));
+            expect_value.push_back(fused ? record_value(q) : 0.0);
             expect_sender.push_back(s);
         }
     }
@@ -176,11 +256,17 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
     const detail::QueryForm form = fused ? detail::QueryForm::Fused : detail::QueryForm::Plain;
 
     auto op = make_op<NumModes>(seed_terms);
-    const auto pr = detail::probe_incoming_queries<NumModes>(incoming, op, rank_count, form);
-
+    AllRowsGate<NumModes> gate(op);
+    std::vector<std::span<const size_t>> views;
+    detail::IncomingRecords<NumModes> pr;
+    detail::decode_incoming_records<NumModes>(detail::slot_streams(incoming, views), form, pr);
+    gate.match(op, pr);
     BOOST_REQUIRE_EQUAL(pr.nq_total, expect_mono.size());
     BOOST_REQUIRE(pr.nq_total > 0);
+    BOOST_REQUIRE_EQUAL(pr.goff.size(), rank_count + 1);
+    BOOST_REQUIRE_EQUAL(pr.goff.back(), pr.nq_total);
     BOOST_REQUIRE_EQUAL(pr.pos_off.size(), pr.nq_total);
+    BOOST_REQUIRE_EQUAL(pr.val_of.empty(), !fused);
 
     std::set<std::vector<uint64_t>> seeded;
     for (const auto &m : seed_terms) {
@@ -193,26 +279,44 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
 
     size_t hits_seen = 0;
     size_t wide_seen = 0;
-    std::vector<Monomial<NumModes>> expected_misses;
+    size_t dropped_seen = 0;
+    std::vector<Monomial<NumModes>> expected_mints; // rot=1 misses, in flat record order
+    std::vector<size_t> expected_mint_slot;
+    std::vector<size_t> expected_hit_row;
     for (size_t g = 0; g < pr.nq_total; ++g) {
         const Monomial<NumModes> &want = expect_mono[g];
-        BOOST_TEST((pr.mono_at(g) == want));
+        const auto pos = pr.positions_at(g);
+        Monomial<NumModes> got;
+        for (const auto p : pos) {
+            got.set(static_cast<size_t>(p));
+        }
+        BOOST_TEST((got == want));
         BOOST_TEST(pr.k_of[g] == want.count());
         BOOST_TEST(pr.phase_of[g] == expect_phase[g]);
-        BOOST_TEST(pr.sender_of[g] == expect_sender[g]);
-        BOOST_TEST(pr.is_paired_at(g) == monoprop::is_paired<NumModes>(want));
+        BOOST_TEST((pr.rot_of[g] != 0) == expect_rot[g]);
+        BOOST_TEST(pr.value_at(g) == expect_value[g]);
+        const size_t s = expect_sender[g];
+        BOOST_TEST(pr.goff[s] <= g);
+        BOOST_TEST(g < pr.goff[s + 1]);
 
         std::vector<uint64_t> key;
         for (size_t w = 0; w < Monomial<NumModes>::num_words(); ++w) {
             key.push_back(want.word(w));
         }
         const bool want_hit = seeded.count(key) != 0;
-        BOOST_TEST((pr.idx_of[g] < pr.base) == want_hit);
+        const size_t row = gate.join.hit(g);
+        BOOST_TEST((row != detail::TableJoin<NumModes>::kMissing) == want_hit);
         if (want_hit) {
+            BOOST_TEST((op.store->row(row) == want));
+            expected_hit_row.push_back(row);
             ++hits_seen;
         }
+        else if (expect_rot[g]) {
+            expected_mints.push_back(want);
+            expected_mint_slot.push_back(s);
+        }
         else {
-            expected_misses.push_back(want);
+            ++dropped_seen;
         }
         VecZ scratch;
         const auto want_pos = positions_of<NumModes>(want);
@@ -220,28 +324,67 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
             ++wide_seen;
         }
     }
-    // Vacuous-pass guards: no hit means the confirm never ran, no wide record means the cursor didn't.
+    // Vacuous-pass guards: no hit means the confirm never ran, no wide record means the cursor didn't,
+    // no dropped record means the rot=0 miss arm never ran.
     BOOST_TEST(hits_seen > 0);
     BOOST_TEST(wide_seen > 0);
+    BOOST_TEST(dropped_seen > 0);
+    BOOST_REQUIRE(!expected_mints.empty());
 
-    // The miss list, term for term and index for index: miss j is the j-th absent query in
-    // (sender, record) order and takes row base+j, which is the assignment the insert writes at.
-    BOOST_REQUIRE_EQUAL(pr.miss_g.size(), expected_misses.size());
-    for (size_t j = 0; j < pr.miss_g.size(); ++j) {
-        BOOST_TEST((expect_mono[pr.miss_g[j]] == expected_misses[j]));
-        BOOST_TEST(pr.idx_of[pr.miss_g[j]] == pr.base + j);
+    // The join: every hit applies (no row has its rot bit set, so only rot=1 records rotate a hit),
+    // every rot=1 miss mints at base + j in flat record order, every rot=0 miss is dropped.
+    const size_t base = op.store->size();
+    detail::MissStage<NumModes> misses;
+    RecordingSink sink;
+    std::vector<VecZ> responses; // wants_responses is false, so the join never touches it
+    detail::join_incoming<NumModes>(pr, gate.join, /*q_base=*/0, gate.marks, base, misses, sink, responses);
+    BOOST_REQUIRE_EQUAL(misses.size(), expected_mints.size());
+    size_t mints_seen = 0;
+    size_t hit_calls = 0;
+    for (const auto &r : sink.recs) {
+        if (r.kind == 'm') {
+            BOOST_REQUIRE(mints_seen < expected_mints.size());
+            BOOST_TEST(r.idx == base + mints_seen);
+            BOOST_TEST(r.slot == expected_mint_slot[mints_seen]);
+            Monomial<NumModes> minted;
+            for (const auto p : misses.positions_at(mints_seen)) {
+                minted.set(static_cast<size_t>(p));
+            }
+            BOOST_TEST((minted == expected_mints[mints_seen]));
+            ++mints_seen;
+        }
+        else {
+            ++hit_calls;
+            BOOST_TEST(r.idx < base);
+            BOOST_TEST((std::find(expected_hit_row.begin(), expected_hit_row.end(), r.idx) != expected_hit_row.end()));
+            BOOST_TEST(r.slot < rank_count);
+        }
     }
+    BOOST_TEST(mints_seen == expected_mints.size());
+    // Only rot=1 records rotate an unmarked hit, so the hit calls are the rot=1 hits.
+    size_t rot_hits = 0;
+    for (size_t g = 0; g < pr.nq_total; ++g) {
+        const size_t row = gate.join.hit(g);
+        if (row != detail::TableJoin<NumModes>::kMissing) {
+            BOOST_TEST(gate.marks.received(row));
+            if (expect_rot[g]) {
+                ++rot_hits;
+            }
+        }
+    }
+    BOOST_TEST(hit_calls == rot_hits);
+    BOOST_TEST(rot_hits > 0);
 
-    detail::insert_incoming_misses<NumModes>(op, pr);
+    detail::insert_misses<NumModes>(op, misses, base);
 
     // The second implementation: the dense Monomial-keyed path, sharing no code with set_positions.
     auto ref = make_op<NumModes>(seed_terms);
-    detail::insert_absent_terms<NumModes>(ref, expected_misses.size(), [&](size_t j, size_t base) {
-        assign_row<NumModes>(*ref.store, base + j, expected_misses[j]);
+    detail::insert_absent_terms<NumModes>(ref, expected_mints.size(), [&](size_t j, size_t b) {
+        assign_row<NumModes>(*ref.store, b + j, expected_mints[j]);
     });
 
     BOOST_REQUIRE_EQUAL(op.store->size(), ref.store->size());
-    BOOST_TEST(op.store->size() > pr.base);
+    BOOST_TEST(op.store->size() > base);
     size_t overflow_seen = 0;
     for (size_t i = 0; i < ref.store->size(); ++i) {
         BOOST_TEST((op.store->row(i) == ref.store->row(i)));
@@ -274,12 +417,20 @@ BOOST_AUTO_TEST_CASE(sparse_resolve_probe_matches_narrow_positions) {
 BOOST_AUTO_TEST_CASE(sparse_resolve_probe_matches_wide_positions) {
     std::mt19937_64 rng(20260815);
     static_assert(sizeof(detail::OperatorIndex<250>::PosT) == 2, "this case exists to cover the wide store");
-    check_probe_matches_the_queries<250>(rng, /*n_seed=*/60, /*n_query=*/140, /*rank_count=*/4, /*fused=*/false);
+    check_probe_matches_the_queries<250>(rng,
+                                         /*n_seed=*/60,
+                                         /*n_query=*/140,
+                                         /*rank_count=*/4,
+                                         /*fused=*/false);
 }
 
 BOOST_AUTO_TEST_CASE(sparse_resolve_probe_matches_fused_layout) {
     std::mt19937_64 rng(20260816);
-    check_probe_matches_the_queries<250>(rng, /*n_seed=*/50, /*n_query=*/120, /*rank_count=*/2, /*fused=*/true);
+    check_probe_matches_the_queries<250>(rng,
+                                         /*n_seed=*/50,
+                                         /*n_query=*/120,
+                                         /*rank_count=*/2,
+                                         /*fused=*/true);
 }
 
 BOOST_AUTO_TEST_CASE(sparse_resolve_probe_matches_single_sender) {
@@ -322,61 +473,60 @@ BOOST_AUTO_TEST_CASE(sparse_resolve_set_positions_matches_set) {
     BOOST_TEST(from_pos.overflow_size() == from_mono.overflow_size());
 }
 
-BOOST_AUTO_TEST_CASE(sparse_resolve_finds_dense_inserted_keys) {
-    // The key identity, isolated: a key folded off decoded positions must equal the one folded off the
-    // dense term the row was written from, or the probe misses a row that is there -- and legally.
+BOOST_AUTO_TEST_CASE(sparse_resolve_join_matches_the_by_value_oracle) {
+    // The gate join against the term table's own by-value find over the same rows: every seeded term,
+    // asked for as a query, matches its own row, and a genuinely absent term matches nothing. Spilled
+    // (wide) rows are in the draw, which is what pins the fingerprint of a row with no position array.
     constexpr size_t kN = 250;
     using PosT = detail::OperatorIndex<kN>::PosT;
     std::mt19937_64 rng(20260819);
     const auto terms = draw_distinct<kN>(rng, 300);
     auto op = make_op<kN>(terms);
-
-    std::vector<PosT> flat;
-    std::vector<size_t> off;
-    std::vector<uint32_t> kk;
-    for (const auto &m : terms) {
-        off.push_back(flat.size());
-        const auto pos = positions_of<kN>(m);
-        flat.insert(flat.end(), pos.begin(), pos.end());
-        kk.push_back(static_cast<uint32_t>(pos.size()));
-    }
-    const auto key_at = [&](size_t q) { return detail::key_of_positions<2 * kN>(flat.data() + off[q], kk[q]); };
-    const auto pos_at = [&](size_t q) { return std::span<const PosT>(flat).subspan(off[q], kk[q]); };
-
-    std::vector<size_t> out(terms.size(), 0);
-    op.term_table().find_batch(*op.store, terms.size(), key_at, pos_at, std::span<size_t>(out));
-    for (size_t i = 0; i < terms.size(); ++i) {
-        BOOST_TEST_INFO("term " << i);
-        BOOST_REQUIRE(out[i] != detail::TermTable::kNotFound);
-        BOOST_TEST(out[i] == i);
-        BOOST_TEST(key_at(i) == detail::key_of<2 * kN>(terms[i]));
-        BOOST_TEST(op.term_table().find(*op.store, terms[i]) == i); // and by value
-    }
+    const uint64_t *labels = routing::linear_basis<2 * kN>().data();
 
     const auto absent = draw_distinct<kN>(rng, 50);
-    std::vector<PosT> aflat;
-    std::vector<size_t> aoff;
-    std::vector<uint32_t> akk;
-    for (const auto &m : absent) {
-        aoff.push_back(aflat.size());
-        const auto pos = positions_of<kN>(m);
-        aflat.insert(aflat.end(), pos.begin(), pos.end());
-        akk.push_back(static_cast<uint32_t>(pos.size()));
-    }
-    std::vector<size_t> aout(absent.size(), 0);
-    op.term_table().find_batch(
-        *op.store,
-        absent.size(),
-        [&](size_t q) { return detail::key_of_positions<2 * kN>(aflat.data() + aoff[q], akk[q]); },
-        [&](size_t q) { return std::span<const PosT>(aflat).subspan(aoff[q], akk[q]); },
-        std::span<size_t>(aout));
+    std::vector<Monomial<kN>> asked = terms;
     size_t genuinely_absent = 0;
-    for (size_t i = 0; i < absent.size(); ++i) {
+    for (const auto &m : absent) {
         // draw_distinct may re-draw a seeded term; only genuinely absent ones are evidence.
-        if (op.term_table().find(*op.store, absent[i]) == detail::TermTable::kNotFound) {
-            BOOST_TEST(aout[i] == detail::TermTable::kNotFound);
+        if (op.term_table().find(*op.store, m) == detail::TermTable::kNotFound) {
+            asked.push_back(m);
             ++genuinely_absent;
         }
     }
     BOOST_TEST(genuinely_absent > 0);
+
+    std::vector<std::vector<PosT>> query_pos;
+    query_pos.reserve(asked.size());
+    for (const auto &m : asked) {
+        query_pos.push_back(positions_of<kN>(m));
+    }
+    AllRowsGate<kN> gate(op);
+    std::vector<uint32_t> keys;
+    for (size_t q = 0; q < asked.size(); ++q) {
+        const uint64_t fp = routing::fingerprint_positions(labels, query_pos[q].data(), query_pos[q].size());
+        BOOST_REQUIRE_EQUAL(fp, routing::linear_hash<2 * kN>(asked[q]));
+        keys.push_back(detail::join_tag(fp));
+    }
+    gate.join.begin_queries(asked.size());
+    gate.join.run(
+        op.term_table(),
+        *op.store,
+        [&](size_t q) { return keys[q]; },
+        [&](size_t q) { return std::span<const PosT>(query_pos[q]); },
+        [](size_t, size_t) {});
+
+    size_t spilled = 0;
+    for (size_t i = 0; i < terms.size(); ++i) {
+        BOOST_REQUIRE(gate.join.hit(i) != detail::TableJoin<kN>::kMissing);
+        BOOST_TEST(gate.join.hit(i) == i);
+        BOOST_TEST(op.term_table().find(*op.store, terms[i]) == i);
+        if (!op.store->row_positions(i).inlined()) {
+            ++spilled;
+        }
+    }
+    BOOST_TEST(spilled > 0);
+    for (size_t q = terms.size(); q < asked.size(); ++q) {
+        BOOST_TEST(gate.join.hit(q) == detail::TableJoin<kN>::kMissing);
+    }
 }

--- a/cpp/tests/term_table_tests.cpp
+++ b/cpp/tests/term_table_tests.cpp
@@ -25,6 +25,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <random>
 #include <set>
 #include <span>
@@ -105,7 +106,9 @@ auto find_term(const Op &op, const Monomial<kN> &m) -> size_t {
     return op.term_table().find(*op.store, key_of(m), std::span<const PosT>(pos));
 }
 
-// out[q] = the row of query q, or TermTable::kNotFound, through the batched pipeline.
+// out[q] = the row of query q, or TermTable::kNotFound, through the batched pipeline. `on_hit` fires once
+// per confirmed row, which is what the gate join marks its rows with, so it is counted here too: the
+// hit count the probe returns must equal the calls it made.
 auto probe_batch(const Op &op, const std::vector<Monomial<kN>> &asked) -> std::vector<size_t> {
     std::vector<uint32_t> keys;
     std::vector<std::vector<PosT>> pos;
@@ -113,13 +116,26 @@ auto probe_batch(const Op &op, const std::vector<Monomial<kN>> &asked) -> std::v
         keys.push_back(key_of(m));
         pos.push_back(positions_of(m));
     }
-    std::vector<size_t> out(asked.size(), 0);
-    op.term_table().find_batch(
+    constexpr TermIndex kMissing = std::numeric_limits<TermIndex>::max();
+    std::vector<TermIndex> rows(asked.size(), 0);
+    size_t on_hit_calls = 0;
+    const size_t hits = op.term_table().find_batch(
         *op.store,
         asked.size(),
         [&keys](size_t q) { return keys[q]; },
         [&pos](size_t q) { return std::span<const PosT>(pos[q]); },
-        std::span<size_t>(out));
+        [&on_hit_calls](size_t /*q*/, size_t /*row*/) { ++on_hit_calls; },
+        std::span<TermIndex>(rows),
+        kMissing);
+    BOOST_TEST(on_hit_calls == hits);
+    std::vector<size_t> out;
+    out.reserve(asked.size());
+    size_t found = 0;
+    for (const TermIndex row : rows) {
+        out.push_back(row == kMissing ? detail::TermTable::kNotFound : static_cast<size_t>(row));
+        found += static_cast<size_t>(row != kMissing);
+    }
+    BOOST_TEST(found == hits);
     return out;
 }
 

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -39,8 +39,9 @@ larger `lower_atol` (see [Truncation and cutoffs](/features/cutoff)).
 | `monoprop_NUM_THREADS` | one partition per physical core | Caps the number of partitions. Set it to run fewer partitions than cores. |
 | `monoprop_PARTITIONS` | `auto` | `auto` = one partition per core (capped by `monoprop_NUM_THREADS`); an integer `N` = exactly `N` partitions; `off` = one partition holding the whole operator. |
 
-Two further variables control which MPI rank owns a term; they belong with the
-distribution axis and are documented under [Rank routing](#rank-routing) below.
+Three further variables belong with the distribution axis rather than this one and are
+documented under [Rank routing](#rank-routing) below: two control which MPI rank owns a term,
+and one reports the gate exchange's wire volume.
 
 ```bash
 # Run 8 partitions instead of one-per-core:
@@ -92,6 +93,19 @@ resident for the whole of it while nothing resting names them. One transport ser
 partitions of a rank, so it is a per-rank figure: exactly one partition reports it and a sum over
 partitions counts a rank's staging once. A pure-MPI rank reports 0, because there its payload
 buffers belong to the in-flight exchange handle and die with the gate that opened the round.
+
+`gate_scratch_bytes` is the per-gate layer-build scratch, which the propagator owns so that its
+capacity survives the gate: the anticommuting fold's words, the protocol's per-row marks, the join's
+hit slots, the miss stage and the decoded incoming records. It carries no state between gates.
+`d_gate_buffers_hwm_bytes` is outside the total for the opposite reason to the fields above: it is
+not a subset of any of them but a quantity no resting field can hold. The records a gate puts on the
+wire, the ones it receives, the responses it stages and the answers it applies are all freed when
+the gate returns, so by the time a caller can ask, nothing of them is left to measure -- yet on a
+wide gate they are the largest thing the call adds to resident memory. The engine therefore stamps
+their combined size at the two instants where the set is widest, and the field carries the maximum
+over the gates of the last `propagate` or `build_graph`. Across partitions the values are summed,
+which is an upper bound rather than a simultaneous figure: each partition's peak is over its own
+timeline.
 
 ### Peak memory of large runs: pin glibc's `mmap` threshold
 
@@ -208,8 +222,10 @@ $\mathrm{key}(M) = h(M) \gg 32$, which a persistent open-addressing table over e
 term is hashed by (`indexing_bytes`: four-byte slots holding a row index below a hash
 prefilter, at a load of at most 0.7). No key is resident: the table folds a row's key off the
 row's own positions when it indexes it -- streaming the store on a rebuild, and reading the rows
-a gate has just minted on an append. A gate's queries are answered by one batched,
-prefetch-pipelined probe per query, with every key match confirmed against the row's positions.
+a gate has just minted on an append -- and the emit path folds the partner's, off the positions
+the partner product has just produced. A record names its partner by that key, and the gate's
+join is one batched, prefetch-pipelined probe per record -- proportional to the records, not to
+the anticommuting set -- with every key match confirmed against the row's positions.
 
 Taking the key as a plain projection rather than a mixed one keeps it linear,
 $\mathrm{key}(M \oplus G) = \mathrm{key}(M) \oplus \mathrm{key}(G)$, so a rank folds the same
@@ -219,6 +235,34 @@ share a key prefix. Collisions become structured -- two terms share a key exactl
 symmetric difference has key zero -- but the labels are `mix64` outputs, so the projection is
 uniform, and a key match was never more than a prefilter: the confirm against the positions is
 what decides a partner, so a collision costs a compare and never a wrong answer.
+
+Every gate is then one exchange round for the terms that rotate. A term $M$ that anticommutes with
+$G$ and passes the rotation gate sends one record — the partner's positions, the rotation phase
+$\varphi(M, G)$, one bit saying whether $M$'s own side rotates, and in the fused path $M$'s pre-gate
+coefficient — to the partner's owner, all of them in one `alltoallv`. The owner of $M \oplus G$ joins
+the key against its own stored terms: a hit is the partner, and the pair rotates if either side asked
+for it, each owner applying the record it received ($\varphi(M \oplus G, G) = -\varphi(M, G)$, so the
+two adds are exactly the two-term rotation); a miss mints the partner. Graph mode records the same
+joins as the layer's in/out endpoint lists, so the replay pairs them positionally without exchanging
+indices.
+
+A pair where both sides rotate is answered by that one round alone: each side receives the other's
+record. Where only one side rotates it is not, because a term below `lower_atol` still owns a
+coefficient its rotating partner needs, and only that term can supply it. Making every such term
+send a record of its own would put the whole anticommuting set on the wire and into the join — in
+the `lower_atol` regime, six times the records for the same rotations. So the *hit* carries the
+answer back instead: a record that lands on a silent row applies its own half there and returns
+that row's coefficient in a second, small message, naming the record by its position in the
+sender's stream. The sender applies its half from the answer. That makes three distinguishable
+outcomes for a record, and they are what tells a tracked partner from an absent one: the partner's
+own record arrived, or an answer arrived, or neither — and neither means absent, because only the
+partner's owner could have replied at all. Every add is the same add the two-pass protocol made,
+with the same value on the same side of the pair, so the round-and-a-half protocol reproduces it
+bit for bit at the volume of the rotations rather than of the anticommuting set.
+
+Graph mode has no coefficients and therefore no silent terms to answer: it keeps the symmetric
+predicate, sending for every anticommuting term whose partner is structurally admissible, which is
+what its positional in/out pairing is proved on.
 
 Linear routing is a switch and not a dial: the rank index takes every bit of $h$ or none of
 them, and none of them is `splitmix`, which reproduces the dense `hash % (R × S)` bit for
@@ -238,6 +282,7 @@ that bound into an identity.
 | --- | --- | --- |
 | `monoprop_ROUTING` | `linear` | `splitmix` selects the dense all-to-all; `linear`, or unset, takes every rank bit from $h$ and requires a power-of-two $R$. Any other value is rejected at startup rather than silently defaulting. |
 | `monoprop_ROUTE_SEED` | `6768574230969066775` | Decimal `uint64` from which every rank derives the same basis $\{v_i\}$ with no communication. The same value must reach every rank: a mismatch in either of these variables, or in the partition count, is caught by two allreduces at propagator construction and raised, because under linear routing it deadlocks the exchange instead of corrupting it. |
+| `monoprop_COMMPROF` | `0` | `1` writes one `COMMPROF` line per slot to stderr at the end of each `propagate` or `build_graph` call, naming the gates that exchanged and the records and answers that slot sent, in total and per gate. Report-only; nothing reads it back. Any other value is rejected at startup. |
 
 ### Single-node (`MPI.COMM_SELF`)
 

--- a/src/monoprop/bindings/binder.h
+++ b/src/monoprop/bindings/binder.h
@@ -263,7 +263,7 @@ auto bind_monomial_propagator(nb::module_ &mod) -> void {
                                              {"init_operator_bytes", b.init_operator_bytes},
                                              {"initial_state_bytes", b.initial_state_bytes},
                                              {"inverted_index_bytes", b.inverted_index_bytes},
-                                             {"matched_scratch_bytes", b.matched_scratch_bytes},
+                                             {"gate_scratch_bytes", b.gate_scratch_bytes},
                                              {"total_bytes", b.total_bytes()},
                                              // Diagnostics, outside total_bytes().
                                              {"d_invidx_dense_bytes", b.inverted_index_dense_bytes},
@@ -278,6 +278,7 @@ auto bind_monomial_propagator(nb::module_ &mod) -> void {
                                              {"d_row_restrides", b.row_restrides},
                                              {"d_pool_mapped_bytes", b.pool_mapped_bytes},
                                              {"d_wire_staging_bytes", b.wire_staging_bytes},
+                                             {"d_gate_buffers_hwm_bytes", b.gate_buffers_hwm_bytes},
                                              {"d_pool_free_chunk_bytes", b.pool_free_chunk_bytes}};
     });
 

--- a/tests/test_monoprop_smoke.py
+++ b/tests/test_monoprop_smoke.py
@@ -182,7 +182,7 @@ _OPERATOR_LEDGER_KEYS = (
     "init_operator_bytes",
     "initial_state_bytes",
     "inverted_index_bytes",
-    "matched_scratch_bytes",
+    "gate_scratch_bytes",
 )
 _OPERATOR_DIAGNOSTIC_KEYS = (
     "d_invidx_dense_bytes",
@@ -192,6 +192,7 @@ _OPERATOR_DIAGNOSTIC_KEYS = (
     "d_state_coeffs_nonzero",
     "d_init_operator_entries",
     "d_op_coeffs_slack_bytes",
+    "d_gate_buffers_hwm_bytes",
     "d_row_wide_rows",
     "d_row_inline_width",
     "d_row_restrides",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

A gate used to be two passes over the whole comm: every rotating row, silent or not, published a
query; a leader rank answered them against its rows; the answers came back; then the followers
replayed the pairing to learn what the leader had decided. This PR replaces that with one round and
a half, symmetric, no leader and no follower replay: only an emitting row sends a record, a `TableJoin`
probes the persistent term table (`TermTable`, PR 4) once per gate, and only the one case a receiver
cannot settle alone — a record landing on a row the receiver itself did not emit from — comes back in
a second, smaller round. An absence pass over the sent records, not over the whole operator, closes
out everything that matched nowhere.

Three algebra kernels (`rotation_sign_positions`, `state_phase_positions`, the digest-based cutoff
predicates) let the new join read a term as the row store's own ascending position list and never
expand it to a bitset. `Engine.h` is reduced to `LayerBuildEngine` and `build_layer` (one arm, the
collective one); `GateSinks.h` splits what a hit does (`GraphSink`, `ContractSink`) from how it is
found; `GateScratch.h` is the per-gate arena (`RowMarks`, `MissStage`, `IncomingRecords`) reused
across gates under the engine's existing 4× release rule.

This is PR 5 of 7, based on `perf/stack-4-term-table`. It is the memory payoff of the stack — the
protocol it replaces is what staged and exchanged a dense pass over every rotating row regardless of
how many actually needed to move — and it costs 8-9% time on Hubbard at this level, which PR 6 and
PR 7 are expected to recover (their own measurements are quoted in their bodies). The next PR
(`perf/stack-6-pair-once`) settles a mutual pair from one record instead of two.

## Changes

**Engine**
- `cpp/monoprop/algebra/Algebra.h`, `AlgebraCommon.h`, `PauliAlgebra.h`: `rotation_sign_positions`,
  `state_phase_positions`, `pauli_rotation_sign_compact`, and the digest cutoff predicates
  (`digest_is_paired`/`length_keeps`/`support_keeps`, `CutoffEvaluator::has_digest_form`/
  `passes_from_digest`) — pure additions, no existing path calls them yet.
- `cpp/monoprop/detail/evolution/layer_build/GateScratch.h` (new, 280 lines): the per-gate arena
  (`RowMarks`, `MissStage`, `IncomingRecords`).
- `cpp/monoprop/detail/evolution/layer_build/TableJoin.h` (new, 102 lines): one `find_batch` group
  per gate.
- `cpp/monoprop/detail/evolution/layer_build/GateSinks.h` (new, 240 lines): `GraphSink`,
  `ContractSink`, `append_inserted_endpoints`.
- `cpp/monoprop/detail/evolution/layer_build/Engine.h` (404 lines): `LayerBuildEngine` + `build_layer`,
  the collective arm only.
- `cpp/monoprop/detail/evolution/layer_build/Resolve.h` (348 lines): the join and its three passes
  (`join_self`, `join_incoming`, `join_absence`); each record's header decoded once, its tag folded
  inside the decode loop; `value_at`'s branch hoisted by `if constexpr` on the sink.
- `cpp/monoprop/detail/evolution/layer_build/Scan.h` (655 lines): the emit rewritten as one templated
  pass, five loop-invariant flags hoisted out of `emit_row`, two per-record asserts demoted to
  per-gate.
- `cpp/monoprop/detail/evolution/layer_build/Common.h`, `FusedApply.h`, `PartnerMerge.h`,
  `QueryWire.h`: the reshaped wire/apply records (`SentRecord`, `HalfRotationRec`, `PartnerAcc`,
  `FusedContract`) a one-round protocol needs; `FusedApply.h` is one loop over one stream.
- `cpp/monoprop/detail/operator/MPOperator.h`, `TermTable.h`: `find_batch` grows an `OnHit` callback;
  `matched_scratch_bytes` renamed `gate_scratch_bytes` (`d_gate_buffers_hwm_bytes`); the five
  `d_gate_*_max` counters and histograms are dropped.
- `cpp/include/monoprop/MonomialPropagator.h`/`.inl`, `src/monoprop/bindings/binder.h`:
  `gate_scratch_`, `over_cutoff_possible_` agreed across the comm once per call,
  `report_comm_profile_` under `monoprop_COMMPROF`, and the renamed/dropped ledger keys.

**Tests**
- `cpp/tests/position_kernels_tests.cpp` (new, 165 lines): both signs against `rotation_sign` over
  12,000 (generator, term) pairs per algebra at four widths, the digest predicates against
  `cutoff_sums`/`is_paired`/`length_cutoff`/`support_cutoff`.
- `cpp/tests/evolution_detail_tests.cpp` (rewritten, 882 lines), `sparse_resolve_tests.cpp`,
  `sparse_query_tests.cpp`, `mpi_utils_tests.cpp`: adapted to the join/scaffolding rewrite.
- `cpp/tests/graph_pair_order_tests.cpp` (new, 334 lines), `fused_cos_sweep_tests.cpp` (+101 lines:
  `fused_sink_recovers_only_the_found_endpoints_value`, `fused_apply_rounds_each_arm_once`).
- `cpp/tests/mp_operator_tests.cpp`, `tests/test_monoprop_smoke.py`, `cpp/tests/README.md`: the
  ledger key rename.

**Docs**
- `docs/content/docs/features/parallelism.mdx`: the protocol paragraphs (one exchange round; the
  round-and-a-half for asymmetric pairs; graph mode's symmetric send predicate), the join-key
  paragraph, `gate_scratch_bytes`/`d_gate_buffers_hwm_bytes`, the `monoprop_COMMPROF` env row.

## Measurements

Gated positional (`--raw-only`) against the second exactness reference (the x2 raw-bit reference), not
against main's: gate record md5 `b8eed0dbdf10f6531eee0910732e345d`. `bitne 0`, `maxULP 0`,
`msetne 0`, `monoseq!= 0` over all 35 golden cells.

**Exactness in detail.** PRs 1-4 are bit-identical to main's raw coefficient bits. PR 5 differs from
main's raw bits in exactly two coefficients (Δ = 1.39e-17): the merged apply loop pins one rounding
with `std::fma` where main's two separate loops relied on GCC's default `-ffp-contract=fast` to
contract each into a single `vfmadd`. Merging the two loops into one over `fc.halves` lets GCC hoist
the common `sin * phase * v` product above the `is_insert` branch, leaving the plain arm a bare add —
two roundings instead of one, on every rotation half of every gate. Measured directly (not inferred):
without the `fma` pin, 2,639,965 of 6,024,567 coefficients over the 35 golden cells move from main
(median 1-8 ULP, worst case 17,501 ULP), with term sets and monomial sets identical throughout —
the signature of an extra rounding, not a wrong value. With the pin, the result is bit-identical to
the x2 raw-bit reference (the x2 raw-bit reference itself differs from main by the same two coefficients, for
the unrelated reason recorded in its own history). The 1e-12-quantised results are identical to main's
in both cases.

Paired A/B, 3 interleaved reps against origin/main c5e88c8 and the predecessor, ratios only:

| rung | time st5/mainB | peak RSS (kernel) st5/mainB | time st4/mainB (predecessor) | peak st4/mainB (predecessor) |
| --- | ---: | ---: | ---: | ---: |
| L1-hubbard | 1.093 | 0.763 | 1.002 | 0.797 |
| L1-pauli | 0.982 | 0.791 | 1.005 | 0.784 |
| M2a-hubbard | 1.081 | 0.776 | 0.987 | 0.811 |

The memory payoff lands (peak 0.76-0.79× main; `gate_scratch_bytes` replaces the old
`matched_scratch_bytes` at 0.6-0.7× on top of that). Time is +8-9% on Hubbard at both shapes measured
here (L1-hubbard 1.093, M2a-hubbard 1.081) and within noise on Pauli (0.982) — consistent with this
protocol's own standalone ladder, so it is the one-round design at this level, not a port defect. This
level's stop rule (M2a ≤ 1.05× main) is not met on its own; PR 6 and PR 7 are expected to recover it,
and the decision is made at PR 7's tip-vs-main ladder.

## Notes for reviewers

- `RowBlock`/`row_block`/`positions_at` (added inert in PR 4) get their first consumer here, in
  `Scan.h`'s emit pass. `TableJoin.h` has no `live_bytes()` and no `TimeProf`/`MemProf` counters —
  diagnostics stay out of this stack per the decision recorded in PR 2's Notes.
- Settling a mutual pair from one record (`8e25ad0`'s pair-once half) and dropping the absent
  partner's buffered zero in Heisenberg (`0f6b9b3`) are **not** in this PR — they are PR 6's.
  `mpi::WindowVec`-typed per-slot arrays stay out of scope too: PR 3 deferred that array re-basing to
  PR 7, so this PR keeps the flat `[R]` per-slot `std::vector`s PR 3/PR 4 leave in place.
- Every touched file is at or below its pre-stack line count except `GateScratch.h` (absorbs two
  structures by design) and `QueryWire.h`/`PartnerMerge.h` (small growth from the `Header`-taking
  overloads and `count_paired_positions` moving in); nothing was cut from invariant documentation to
  hit a number.
- Which endpoint of a pair reads the recovered value vs. the record's own pre-cos double is fixed and
  load-bearing (`GateSinks.h`'s `ContractSink::hit`): the half landing on an emitting row recovers,
  the half on a silent row reads its record's own value. Getting this backwards is 1 ULP on every
  asymmetric pair; `fused_sink_recovers_only_the_found_endpoints_value` pins both endpoints of one
  pair, not the pair's sum.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable (n/a — the repository has no `CHANGELOG`)

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (claude-sonnet-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
