### PR TITLE
perf(evolution): ⚡ settle a mutual pair from the leader's record alone

### DIFF
--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -131,6 +131,9 @@ struct LayerBuildEngine {
         const size_t n_self = scan.self.size();
         const std::span<const SentRecord> sent_self(scan.sent[my_rank]);
         assert(sent_self.size() == n_self && "one sent record per self query");
+        // Pair-once needs the self stage's sent records (the source row of each self query) and a skip
+        // sentinel no hit row can equal (TableJoin::kSkippedRow): hit rows are below `base`.
+        const bool pair_once = sink_pairs_once<Sink>() && n_self != 0 && base < TableJoin<NumModes>::kSkippedRow;
         join.begin_queries(n_self + pr.nq_total);
         // One batched probe of the term table over the whole query space, in resolve order. The table
         // covers every row of the store (the previous gate's mints were appended by reindex_after_growth),
@@ -142,14 +145,24 @@ struct LayerBuildEngine {
             [&](size_t q) -> std::span<const RowPosT> {
                 return (q < n_self) ? scan.self.positions_at(q) : pr.positions_at(q - n_self);
             },
+            // The pair-once skip: a self record whose source row a record has already confirmed, and
+            // which is the follower of its pair, was settled by the leader's record (Resolve.h join_self).
+            [&](size_t q) -> bool {
+                if (!pair_once || q >= n_self) {
+                    return false;
+                }
+                const size_t src = sent_self[q].row;
+                return marks.matched(src) && marks.foll(src);
+            },
             [&](size_t /*q*/, size_t row) { marks.set_matched(row); });
 
         // Both output buffers of the resolve phase are sized here, before the first push, because the
         // join has just settled the two counts they depend on. Every sink call is keyed on either a
         // distinct query -- a hit pushes at most one half, a miss mints at most one -- or a distinct
-        // record this slot sent, since a record is answered (round 2, or a self silent hit) or absent but
-        // never both, and a row sends exactly one record because it has exactly one partner. So
-        // |Q| + |sent| bounds the gate's halves, and |Q| - |hits| bounds its mints exactly.
+        // record this slot sent, since a record is answered (round 2, a self silent hit, or the follower's
+        // half of a pair the leader's record settled) or absent but never both, and a row sends exactly
+        // one record because it has exactly one partner. So |Q| + |sent| bounds the gate's halves, and
+        // |Q| - |hits| bounds its mints exactly (a skipped query counts as a hit).
         size_t n_sent = 0;
         for (const auto &records : scan.sent) {
             n_sent += records.size();
@@ -165,8 +178,16 @@ struct LayerBuildEngine {
         }
         size_t answered = 0;
         if (n_self != 0) {
-            answered =
-                join_self<NumModes>(scan.self, join, /*q_base=*/0, marks, my_rank, base, misses, sink, sent_self);
+            answered = join_self<NumModes>(scan.self,
+                                           join,
+                                           /*q_base=*/0,
+                                           marks,
+                                           my_rank,
+                                           base,
+                                           misses,
+                                           sink,
+                                           sent_self,
+                                           pair_once);
         }
         answered += join_incoming<NumModes>(pr, join, /*q_base=*/n_self, marks, base, misses, sink, responses);
 

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -385,7 +385,8 @@ auto build_layer(MPOperator<NumModes> &local_op,
                                              .fused_scale = fused_scale,
                                              .op_coeffs = coeffs,
                                              .cos_build = cos_build,
-                                             .inv_cos = inv_cos});
+                                             .inv_cos = inv_cos,
+                                             .absences_carry_c0 = schrodinger});
     }
     else {
         storage = run(GraphSink<NumModes>{R, my_rank});

--- a/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
+++ b/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
@@ -39,7 +39,10 @@ namespace monoprop::detail {
  *  a pair the row is); the probe sets `matched` the moment a record confirms the row; the resolve sets
  *  `received` (the partner's record arrived, i.e. the partner is tracked) and `partner_rot` (that
  *  record's rot bit); round 2 sets `answered` (the partner is tracked but silent, and sent its
- *  coefficient back instead of a record).
+ *  coefficient back instead of a record). `matched` and `received` name the same event at two moments:
+ *  the probe runs over the whole gate before the resolve does, so a resolve-time rule that read
+ *  `matched` would see confirms the resolve has not reached yet, which is why the two are kept apart
+ *  (the pair-once rule reads `matched` at the probe and `received` at the resolve, Resolve.h join_self).
  *
  *  Only rows of Anti(G) are ever set or read, and Anti(G) is exactly the set bits of the gate's `nz`
  *  words, so a gate clears its state by zeroing one word per nz word rather than the whole operator's
@@ -272,8 +275,8 @@ struct GateScratch {
             wire += slot.capacity() * sizeof(size_t);
         }
         return join.memory_bytes() + marks.memory_bytes() + (nz.capacity() * sizeof(EvenParityNzWord))
-               + (partner.capacity() * sizeof(PosT)) + (gen.capacity() * sizeof(uint16_t))
-               + misses.memory_bytes() + incoming_records.memory_bytes() + wire;
+               + (partner.capacity() * sizeof(PosT)) + (gen.capacity() * sizeof(uint16_t)) + misses.memory_bytes()
+               + incoming_records.memory_bytes() + wire;
     }
 };
 

--- a/cpp/monoprop/detail/evolution/layer_build/GateSinks.h
+++ b/cpp/monoprop/detail/evolution/layer_build/GateSinks.h
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #pragma once
 
 // The two sinks the gate exchange resolves into. A sink owns the divergent state and supplies the
@@ -158,10 +157,13 @@ template <size_t NumModes>
 struct ContractSink {
     static constexpr bool wants_values = true;
     static constexpr bool wants_responses = true;
+    //! A mutual pair's two halves from the leader's record alone (Resolve.h join_self): the follower's
+    //! half is silent_value(follower), which is what the follower's own record would have delivered.
+    static constexpr bool pairs_once = true;
     [[nodiscard]] auto incoming_form() const -> QueryForm { return QueryForm::Fused; }
 
     FusedContract &fc;
-    bool fused_scale;      // the fused cos sweep ran: inserted endpoints fold cos in at the apply, not here
+    bool fused_scale;       // the fused cos sweep ran: inserted endpoints fold cos in at the apply, not here
     const VecD &op_coeffs;  // the very array the scan read, not a copy: under the sweep every
                             // anticommuting slot in it already holds fl(c * cos)
     double cos_build = 1.0; // cos(2*theta), the factor the sweep applied

--- a/cpp/monoprop/detail/evolution/layer_build/GateSinks.h
+++ b/cpp/monoprop/detail/evolution/layer_build/GateSinks.h
@@ -166,6 +166,11 @@ struct ContractSink {
                             // anticommuting slot in it already holds fl(c * cos)
     double cos_build = 1.0; // cos(2*theta), the factor the sweep applied
     double inv_cos = 1.0;   // fl(1/cos_build) under the sweep, 1.0 without it
+    // Does an absent partner's half carry a value at all? Only the Schrodinger picture scores a fresh
+    // term's pre-gate coefficient (Scan.h `state_mask`); in Heisenberg `c0` is the literal 0.0 that
+    // absence_pass substitutes. Equal to absence_pass's own `has_c0` by construction: `sent_c0` is
+    // windowed exactly when the scan was given a state mask.
+    bool absences_carry_c0 = false;
 
     /*! @brief One rotation half onto tracked row `row`, from the record that found it.
      *
@@ -196,10 +201,14 @@ struct ContractSink {
         push_half_(HalfRotationRec{row_of_(idx), static_cast<int8_t>(phase), /*is_insert=*/true, v});
     }
     auto out_pair(size_t /*slot*/, size_t /*row*/, int /*phase*/) -> void {}
-    // Pushed in Heisenberg too, where c0 is exactly 0.0: the signed-zero add is what a fresh Heisenberg
-    // partner's source received before, and skipping it would leave a coefficient sitting at -0.0 where
-    // the add turns it into +0.0.
+    // Skipped in Heisenberg, where c0 is exactly 0.0: the half's add is `c += sin*(-phase)*0.0`, which
+    // cannot change any coefficient's VALUE -- its one and only effect is that a coefficient sitting at
+    // -0.0 stays there instead of being turned into +0.0, and -0.0 == +0.0. Keeping it costs a 16-byte
+    // half and one random-access `+=` per mint of every gate.
     auto out_unanswered(size_t /*slot*/, size_t row, double c0, int phase) -> void {
+        if (!absences_carry_c0) {
+            return;
+        }
         push_half_(HalfRotationRec{row_of_(row), static_cast<int8_t>(-phase), /*is_insert=*/false, c0});
     }
     // One allocation per gate instead of a doubling chain: `fc` is built fresh for each gate, so every

--- a/cpp/monoprop/detail/evolution/layer_build/Resolve.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Resolve.h
@@ -46,6 +46,8 @@ namespace monoprop::detail {
 //   answer(slot, row, v, phase)         a response arrived for this slot's row: its half is -phase*v
 // plus, once per gate before any of them:
 //   reserve_halves(n)                   at most n of the recording calls above will follow this gate
+// and, iff the sink declares `static constexpr bool pairs_once`, join_self may settle a mutual pair from
+// the leader's record alone, pushing the follower's half through answer() (see join_self).
 // `slot` is always the flat slot of the peer the record came from / went to.
 //
 // How a partner is found is entirely TableJoin's business: the join reads `join.hit(q)` and nothing
@@ -185,6 +187,19 @@ template <size_t NumModes, typename Sink>
     return false;
 }
 
+//! Whether `Sink` settles mutual pairs from the leader's record alone (join_self). False unless declared.
+template <typename Sink>
+[[nodiscard]] consteval auto sink_pairs_once() -> bool {
+    if constexpr (requires { Sink::pairs_once; }) {
+        static_assert(!Sink::pairs_once || Sink::wants_responses,
+                      "pair-once reads the follower's swept slot through silent_value/answer");
+        return Sink::pairs_once;
+    }
+    else {
+        return false;
+    }
+}
+
 /*! @brief The records this slot addressed to itself, in stream order.
  *
  *  They occupy the join's query indices [q_base, q_base + stage.size()), which is the front of the query
@@ -194,6 +209,18 @@ template <size_t NumModes, typename Sink>
  *  which is why a silent hit needs no response here: both halves are on this slot, so the sender's is
  *  applied at once instead of travelling. `answered` is still marked, so the absence pass reads the pair
  *  alike however the answer arrived.
+ *
+ *  PAIR-ONCE (`pair_once`, a sink that declares `pairs_once`). A mutual pair -- both endpoints rotating,
+ *  so each one's record hits the other's source -- is settled by the LEADER's record when that record is
+ *  resolved first: it pushes its own half and, in place of the follower's record, the follower's half
+ *  {source, -phase, silent_value(row)}. That is the very half the follower's record would have
+ *  delivered, because phase_foll = -phase_lead (Engine.h) and the follower's record would have recovered
+ *  fl(fl(v*cos)*inv_cos) = op_coeffs[row]*inv_cos = silent_value(row) from the same swept slot. The
+ *  follower's record is then recognised by `received(source) && foll(source)` -- only its partner's
+ *  record can set `received` on its source, keys being injective per gate -- and is skipped here and at
+ *  the probe (TableJoin::run's skip, on `matched`). In the follower-first order both records take the
+ *  ordinary arm, so the result is the same and only the saving is lost. Mint order is untouched: a
+ *  skipped record counts as a hit, and hits never mint.
  *
  *  @return How many self records were answered without the wire.
  */
@@ -206,11 +233,41 @@ auto join_self(const SelfQueryStage<NumModes> &stage,
                size_t base,
                MissStage<NumModes> &misses,
                Sink &sink,
-               std::span<const SentRecord> sent_self) -> size_t {
+               std::span<const SentRecord> sent_self,
+               bool pair_once = false) -> size_t {
     assert(!Sink::wants_responses || sent_self.size() == stage.size());
+    assert((!pair_once || sink_pairs_once<Sink>()) && "pair-once needs a sink that declares it");
     size_t answered = 0;
     for (size_t q = 0; q < stage.size(); ++q) {
+        [[maybe_unused]] size_t src = 0;
+        [[maybe_unused]] bool src_received = false;
+        if constexpr (sink_pairs_once<Sink>()) {
+            if (pair_once) {
+                src = sent_self[q].row;
+                src_received = marks.received(src);
+                // A skipped probe implies the leader's record settled this pair before this one was reached.
+                assert(!join.skipped(q_base + q) || (src_received && marks.foll(src)));
+                if (src_received && marks.foll(src)) {
+                    continue; // the follower's record of a settled pair: both halves are already pushed
+                }
+            }
+        }
+        // One read of the join's outcome per query, whichever arm takes it; a skipped query has none.
         const size_t row = join.hit(q_base + q);
+        if constexpr (sink_pairs_once<Sink>()) {
+            if (pair_once && !src_received && row != TableJoin<NumModes>::kMissing && marks.rot(row)
+                && marks.foll(row)) {
+                // The leader's record onto a rotating follower whose own record is still to come.
+                marks.set_received(row);
+                marks.set_partner_rot(row);
+                marks.set_received(src);
+                marks.set_partner_rot(src);
+                const int phase = static_cast<int>(stage.phase_of[q]);
+                sink.hit(my_rank, row, stage.value_at(q), phase, /*foll=*/true, /*own_rot=*/true);
+                sink.answer(my_rank, src, sink.silent_value(row), phase);
+                continue;
+            }
+        }
         const bool answer = join_record<NumModes>(marks,
                                                   my_rank,
                                                   row,

--- a/cpp/monoprop/detail/evolution/layer_build/TableJoin.h
+++ b/cpp/monoprop/detail/evolution/layer_build/TableJoin.h
@@ -21,6 +21,10 @@
 // the one row holding it, if any, so a gate's join is |Q| probes -- O(records) -- and never touches the
 // anticommuting rows no record names. At most one query can match a row: keys are M^G over globally
 // distinct sources and ^G is injective, so no two queries of one gate name the same monomial.
+//
+// A self record's probe may be SKIPPED by the caller's rule (Resolve.h join_self settles a mutual pair
+// from the leader's record, leaving the follower's record nothing to find). This class only records the
+// outcome, so the resolve can tell a skipped query from a miss.
 
 #include <algorithm>
 #include <cassert>
@@ -44,6 +48,11 @@ public:
     //! "No row matched this query". Valid rows are below the TermIndex ceiling, so the sentinel is free.
     static constexpr size_t kMissing = static_cast<size_t>(std::numeric_limits<TermIndex>::max());
     static constexpr TermIndex kMissingRow = std::numeric_limits<TermIndex>::max();
+    /*! @brief A query whose probe the caller skipped (pair-once). One below the missing sentinel: only
+     *  rows below the gate's insert base are ever stored here, so the engine enables the skip only while
+     *  that base is below it.
+     */
+    static constexpr TermIndex kSkippedRow = kMissingRow - 1;
 
     /*! @brief Sizes the hit slots, the join's only output, for a gate of `n_queries` records.
      *
@@ -56,47 +65,61 @@ public:
         }
         hit_.assign(n_queries, kMissingRow);
         hits_ = 0;
+        skipped_ = 0;
     }
 
     /*! @brief Probes every query against @a table, filling hit().
      *
-     *  `key_of(q)` / `pos_of(q)` are query q's join key and ascending positions; `on_hit(q, row)` is
-     *  TermTable::find_batch's, run at every confirm in query order within a group (the probe-phase mark).
+     *  `key_of(q)` / `pos_of(q)` are query q's join key and ascending positions; `skip(q)` and
+     *  `on_hit(q, row)` are TermTable::find_batch's (the pair-once rule and the probe-phase mark).
      *  @pre table.rows() == store.size(): the table covers every row a record could name.
      */
-    template <typename KeyOf, typename PosOf, typename OnHit>
+    template <typename KeyOf, typename PosOf, typename Skip, typename OnHit>
     auto run(const TermTable &table,
              const OperatorIndex<NumModes> &store,
              KeyOf &&key_of,
              PosOf &&pos_of,
+             Skip &&skip,
              OnHit &&on_hit) -> void {
         assert(table.rows() == store.size() && "the term table must cover the whole store before a gate probes it");
-        hits_ = table.find_batch(store,
-                                 hit_.size(),
-                                 std::forward<KeyOf>(key_of),
-                                 std::forward<PosOf>(pos_of),
-                                 std::forward<OnHit>(on_hit),
-                                 std::span<TermIndex>(hit_),
-                                 kMissingRow);
+        const auto stats = table.find_batch(store,
+                                            hit_.size(),
+                                            std::forward<KeyOf>(key_of),
+                                            std::forward<PosOf>(pos_of),
+                                            std::forward<Skip>(skip),
+                                            std::forward<OnHit>(on_hit),
+                                            std::span<TermIndex>(hit_),
+                                            kMissingRow,
+                                            kSkippedRow);
+        // A skipped query is a settled one: its partner is tracked, so it can never mint. Counting it as
+        // a hit keeps queries() - hits() the exact mint bound the resolve sizes by.
+        hits_ = stats.hits + stats.skipped;
+        skipped_ = stats.skipped;
     }
 
-    //! The row query `q` matched, or kMissing: the partner is absent from this slot.
+    //! The row query `q` matched, or kMissing: the partner is absent from this slot. @pre !skipped(q).
     [[nodiscard]] auto hit(size_t q) const -> size_t {
         const TermIndex row = hit_[q];
+        assert(row != kSkippedRow && "a skipped query has no row; test skipped() first");
         return (row == kMissingRow) ? kMissing : static_cast<size_t>(row);
     }
+    //! Whether query `q`'s probe was skipped under the caller's rule.
+    [[nodiscard]] auto skipped(size_t q) const -> bool { return hit_[q] == kSkippedRow; }
 
     [[nodiscard]] auto queries() const -> size_t { return hit_.size(); }
-    //! Queries that confirmed a row, so queries() - hits() is the gate's exact mint count.
+    //! Queries settled without a mint -- confirmed or skipped -- so queries() - hits() is the mint count.
     [[nodiscard]] auto hits() const -> size_t { return hits_; }
+    //! Of hits(), the probes the pair-once rule skipped.
+    [[nodiscard]] auto skipped_count() const -> size_t { return skipped_; }
 
     [[nodiscard]] auto memory_bytes() const -> size_t { return hit_.capacity() * sizeof(TermIndex); }
 
 private:
     static constexpr size_t kMinSlots = 16;
 
-    std::vector<TermIndex> hit_; // query -> matching row, kMissingRow for a miss
-    size_t hits_ = 0;            // rows confirmed this gate: what the resolve phase sizes by
+    std::vector<TermIndex> hit_; // query -> matching row, kMissingRow for a miss, kSkippedRow for a skip
+    size_t hits_ = 0;            // confirmed + skipped this gate: what the resolve phase sizes by
+    size_t skipped_ = 0;
 };
 
 } // namespace monoprop::detail

--- a/cpp/monoprop/detail/operator/TermTable.h
+++ b/cpp/monoprop/detail/operator/TermTable.h
@@ -54,6 +54,12 @@ public:
     //! Keys probed together per pipeline pass; the depth the prefetches run ahead by.
     static constexpr size_t kGroup = 16;
 
+    //! What one find_batch() settled: rows confirmed, and queries its caller declined to probe.
+    struct BatchStats {
+        size_t hits = 0;
+        size_t skipped = 0;
+    };
+
     //! Rows indexed: rows [0, rows()) of the store this was last rebuilt from or appended with.
     [[nodiscard]] auto rows() const -> size_t { return rows_; }
     [[nodiscard]] auto slots() const -> size_t { return slots_.size(); }
@@ -128,45 +134,62 @@ public:
         return find(store, key_of_positions<2 * NumModes>(pos.data(), k), std::span<const PosT>(pos.data(), k));
     }
 
-    /*! @brief Probes @a n queries in order, out[q] = the confirmed row of query q, or @a not_found.
+    /*! @brief Probes @a n queries in order, out[q] = query q's confirmed row, @a not_found or @a skipped.
      *
      *  `key_of(q)` is query q's join key and `pos_of(q)` its ascending positions (the confirm).
+     *  `skip(q)` is consulted once per query, in order, before it is probed: a query it declines costs
+     *  nothing and is recorded as @a skipped. Its answer may depend on the confirms of queries more than
+     *  one group (kGroup) ahead of it, which is what a pair-once rule reads (Resolve.h join_self).
      *  `on_hit(q, row)` runs at every confirm, in query order within a group.
      *
      *  Same result as n calls to find(), query by query. The group pipeline overlaps the three dependent
      *  misses of a probe (slot line, chain walk, row) across kGroup queries; a prefilter match that the
      *  row refutes resumes the chain synchronously, which a 32-bit collision is rare enough to afford.
-     *
-     *  @return How many queries confirmed a row.
      */
-    template <size_t NumModes, typename KeyOf, typename PosOf, typename OnHit>
+    template <size_t NumModes, typename KeyOf, typename PosOf, typename Skip, typename OnHit>
     auto find_batch(const OperatorIndex<NumModes> &store,
                     size_t n,
                     KeyOf &&key_of,
                     PosOf &&pos_of,
+                    Skip &&skip,
                     OnHit &&on_hit,
                     std::span<TermIndex> out,
-                    TermIndex not_found) const -> size_t {
+                    TermIndex not_found,
+                    TermIndex skipped) const -> BatchStats {
         assert(out.size() >= n && "one output slot per query");
-        size_t hits = 0;
+        BatchStats stats;
+        // An empty table confirms nothing, so the group pipeline would only carry the skip decision.
         if (rows_ == 0) {
-            std::fill_n(out.begin(), n, not_found);
-            return 0;
+            for (size_t q = 0; q < n; ++q) {
+                const bool declined = skip(q);
+                out[q] = declined ? skipped : not_found;
+                stats.skipped += static_cast<size_t>(declined);
+            }
+            return stats;
         }
-        std::array<bool, kGroup> cand{};
+        enum class Lane : uint8_t { skipped, miss, cand };
+        std::array<Lane, kGroup> lane{};
         std::array<size_t, kGroup> at{};
         std::array<uint32_t, kGroup> pf{};
         const uint32_t *const slots = slots_.data();
         for (size_t base = 0; base < n; base += kGroup) {
             const size_t g = std::min(kGroup, n - base);
             for (size_t j = 0; j < g; ++j) {
+                if (skip(base + j)) {
+                    lane[j] = Lane::skipped;
+                    continue;
+                }
                 const uint64_t h = spread(key_of(base + j));
                 at[j] = h & mask_;
                 pf[j] = prefilter_(h);
+                lane[j] = Lane::cand;
                 __builtin_prefetch(&slots[at[j]], 0, 0);
             }
             for (size_t j = 0; j < g; ++j) {
-                cand[j] = false;
+                if (lane[j] != Lane::cand) {
+                    continue;
+                }
+                lane[j] = Lane::miss;
                 for (size_t s = at[j];; s = (s + 1) & mask_) {
                     const uint32_t e = slots[s];
                     if (e == kEmpty) {
@@ -174,7 +197,7 @@ public:
                     }
                     if ((static_cast<uint64_t>(e) >> shift_) == pf[j]) {
                         at[j] = s;
-                        cand[j] = true;
+                        lane[j] = Lane::cand;
                         store.prefetch_row(e & mask_);
                         break;
                     }
@@ -182,7 +205,12 @@ public:
             }
             for (size_t j = 0; j < g; ++j) {
                 const size_t q = base + j;
-                if (!cand[j]) {
+                if (lane[j] == Lane::skipped) {
+                    out[q] = skipped;
+                    ++stats.skipped;
+                    continue;
+                }
+                if (lane[j] == Lane::miss) {
                     out[q] = not_found;
                     continue;
                 }
@@ -195,11 +223,11 @@ public:
                     continue;
                 }
                 out[q] = static_cast<TermIndex>(row);
-                ++hits;
+                ++stats.hits;
                 on_hit(q, row);
             }
         }
-        return hits;
+        return stats;
     }
 
     /*! @brief The hash a key's slot and prefilter are cut from: splitmix64's finalizer over the key.

--- a/cpp/tests/evolution_detail_tests.cpp
+++ b/cpp/tests/evolution_detail_tests.cpp
@@ -389,7 +389,7 @@ BOOST_AUTO_TEST_CASE(one_round_contract_sink_records_one_half_per_touched_slot) 
         6,
         // cos_build/inv_cos left at 1.0: this case is about which slot each half lands on and with which
         // sign, so the recovery factor is the identity and every value passes through.
-        detail::ContractSink<kN>{.fc = fc, .fused_scale = true, .op_coeffs = coeffs});
+        detail::ContractSink<kN>{.fc = fc, .fused_scale = true, .op_coeffs = coeffs, .absences_carry_c0 = true});
     eng.exchange_and_join(sc.value_scan());
     BOOST_REQUIRE_EQUAL(fc.halves.size(), 6U);
     const auto expect = [&](size_t k, size_t idx, double v, int phase, bool insert) {
@@ -413,6 +413,37 @@ BOOST_AUTO_TEST_CASE(one_round_contract_sink_records_one_half_per_touched_slot) 
     }
     std::ranges::sort(touched);
     BOOST_TEST((std::ranges::adjacent_find(touched) == touched.end()));
+}
+
+// The same scenario without a c0 side channel -- the Heisenberg shape, where absence_pass substitutes
+// the literal 0.0. That half would add sin*(-phase)*0.0, so the sink drops it: five halves instead of
+// six, the missing one being exactly the one on the absent partner's slot, every other half unchanged.
+// `absences_carry_c0` is what says which shape this is, and build_layer sets it from `schrodinger` --
+// the same condition that decides whether the scan was given a state mask at all.
+BOOST_AUTO_TEST_CASE(contract_sink_skips_the_absence_half_when_no_c0_travels) {
+    Scenario sc;
+    detail::FusedContract fc;
+    const VecD coeffs = {0.5, 0.25, 12.0, 1.5, 14.0, 3.0};
+    detail::LayerBuildEngine<kN, detail::ContractSink<kN>> eng(
+        sc.op,
+        mpi::Comm{},
+        1,
+        0,
+        sc.scratch,
+        6,
+        detail::ContractSink<kN>{.fc = fc, .fused_scale = true, .op_coeffs = coeffs, .absences_carry_c0 = false});
+    eng.exchange_and_join(sc.value_scan());
+    BOOST_REQUIRE_EQUAL(fc.halves.size(), 5U);
+    for (const auto &h : fc.halves) {
+        BOOST_TEST(h.local_idx != 5U); // t5's absence half is the one that is gone
+    }
+    // The five that remain are the five the c0-carrying case produced, in the same order.
+    BOOST_TEST(fc.halves[0].local_idx == 1U);
+    BOOST_TEST(fc.halves[1].local_idx == 0U);
+    BOOST_TEST(fc.halves[2].local_idx == 2U);
+    BOOST_TEST(fc.halves[3].local_idx == 3U);
+    BOOST_TEST(fc.halves[4].local_idx == 6U);
+    BOOST_TEST(fc.halves[4].is_insert);
 }
 
 // Round 2 across slots: a response names the record by its position in the SENDER's own stream, and the

--- a/cpp/tests/evolution_detail_tests.cpp
+++ b/cpp/tests/evolution_detail_tests.cpp
@@ -169,7 +169,13 @@ struct Scenario {
     template <typename KeyOf, typename PosOf>
     auto probe(size_t n, KeyOf &&key_of, PosOf &&pos_of) -> void {
         scratch.join.begin_queries(n);
-        scratch.join.run(op.term_table(), *op.store, key_of, pos_of, [](size_t, size_t) {});
+        scratch.join.run(
+            op.term_table(),
+            *op.store,
+            key_of,
+            pos_of,
+            [](size_t) { return false; },
+            [&](size_t /*q*/, size_t row) { scratch.marks.set_matched(row); });
     }
 
     //! An R = 1 scan result: every record is self-addressed, so the wire's own slot stays empty.

--- a/cpp/tests/pair_once_tests.cpp
+++ b/cpp/tests/pair_once_tests.cpp
@@ -1,0 +1,411 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Pair-once (Resolve.h join_self): the value path settles a mutual pair from the leader's record alone
+// when that record is resolved first, and skips the follower's record at the probe. This runs the real
+// engine with the real ContractSink over a hand-built gate that has every case at once -- twenty
+// leader-first mutual pairs (far enough apart that the follower's probe is skipped by the pipeline, not
+// only by the resolve), one follower-first mutual pair, a rotating leader onto a silent follower, a
+// rotating follower onto a silent leader, and two absent partners -- and compares the halves, the mints
+// and the marks bit for bit against the same gate resolved with two records per pair. The exact number
+// of probes the skip saves is deliberately not asserted: it is a property of the transport, and the
+// pair exchange changes which records reach the resolve first.
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <set>
+#include <span>
+#include <tuple>
+#include <vector>
+
+#include "monoprop/core/Monomial.h"
+#include "monoprop/detail/evolution/layer_build/Common.h"
+#include "monoprop/detail/evolution/layer_build/Engine.h"
+#include "monoprop/detail/evolution/layer_build/GateScratch.h"
+#include "monoprop/detail/evolution/layer_build/GateSinks.h"
+#include "monoprop/detail/evolution/layer_build/Resolve.h"
+#include "monoprop/detail/evolution/layer_build/Scan.h"
+#include "monoprop/detail/evolution/layer_build/TableJoin.h"
+#include "monoprop/detail/mpi/Comm.h"
+#include "monoprop/detail/operator/MPOperator.h"
+#include "monoprop/detail/operator/RowKey.h"
+
+using namespace monoprop;
+
+namespace {
+
+constexpr size_t kN = 64;
+using Op = detail::MPOperator<kN>;
+using Store = detail::OperatorIndex<kN>;
+using PosT = Store::PosT;
+
+auto key_of(const Monomial<kN> &m) -> uint32_t {
+    return detail::key_of<2 * kN>(m);
+}
+
+auto mono(std::initializer_list<size_t> bits) -> Monomial<kN> {
+    Monomial<kN> m;
+    for (const size_t b : bits) {
+        m.set(b);
+    }
+    return m;
+}
+
+auto positions_of(const Monomial<kN> &m) -> std::vector<PosT> {
+    std::vector<PosT> pos;
+    for (size_t b = m.find_first(); b < m.size(); b = m.find_next(b)) {
+        pos.push_back(static_cast<PosT>(b));
+    }
+    return pos;
+}
+
+// Appends `terms` as rows [base, base + n) through the engine's own growth door, so the table follows.
+auto append_terms(Op &op, const std::vector<Monomial<kN>> &terms) -> size_t {
+    return detail::insert_absent_terms<kN>(op, terms.size(), [&](size_t k, size_t base) {
+        const auto pos = positions_of(terms[k]);
+        op.store->set_positions(base + k, std::span<const PosT>(pos));
+    });
+}
+
+auto draw_distinct(std::mt19937_64 &rng, size_t n) -> std::vector<Monomial<kN>> {
+    std::vector<Monomial<kN>> out;
+    std::set<std::vector<uint64_t>> seen;
+    std::uniform_int_distribution<size_t> bit(0, Monomial<kN>::size() - 1);
+    std::uniform_int_distribution<size_t> pop(1, 8);
+    while (out.size() < n) {
+        Monomial<kN> m;
+        const size_t k = pop(rng);
+        while (m.count() < k) {
+            m.set(bit(rng));
+        }
+        std::vector<uint64_t> words;
+        for (size_t w = 0; w < Monomial<kN>::num_words(); ++w) {
+            words.push_back(m.word(w));
+        }
+        if (seen.insert(words).second) {
+            out.push_back(m);
+        }
+    }
+    return out;
+}
+
+// The gate. Pivot bit 0: a follower has it set, a leader has not. Rows and their records:
+//   [0, 20)    leaders, rotating, partner row 20 + i        leader-first mutual pairs
+//   [20, 40)   followers, rotating, partner row i - 20
+//   40 / 41    follower C / leader D, both rotating         follower-first mutual pair
+//   42 / 43    leader E rotating / follower F silent        answered on the self slot
+//   44 / 45    follower G rotating / leader H silent        answered on the self slot
+//   46         leader I, rotating, partner X absent         mint at base + 0
+//   47         follower J, rotating, partner Y absent       mint at base + 1
+struct Gate {
+    static constexpr size_t kPairs = 20;
+    static constexpr size_t kRows = 48;
+    static constexpr size_t kTag = 100; // a position every row carries, so no row is a single position
+
+    std::vector<Monomial<kN>> terms;
+    std::vector<Monomial<kN>> record_key; // the partner each rotating row names; empty for a silent row
+    std::vector<bool> foll;
+    std::vector<bool> rot;
+    std::vector<int> phase;
+    std::vector<double> v;
+    Op op;
+    detail::GateScratch<kN> scratch;
+    VecD coeffs;
+    detail::FusedContract fc;
+    double cos_build = std::cos(2.0 * 0.37);
+    double inv_cos = 1.0 / cos_build;
+
+    Gate() : terms(kRows), record_key(kRows), foll(kRows), rot(kRows), phase(kRows), v(kRows), coeffs(kRows) {
+        auto leader = [](size_t k) { return mono({k, kTag}); };
+        auto follower = [](size_t k) { return mono({0, k, kTag}); };
+        auto set = [&](size_t row, Monomial<kN> m, bool is_foll, bool rotates, Monomial<kN> key, int ph) {
+            terms[row] = m;
+            foll[row] = is_foll;
+            rot[row] = rotates;
+            record_key[row] = key;
+            phase[row] = ph;
+        };
+        for (size_t i = 0; i < kPairs; ++i) {
+            set(i, leader(i + 1), false, true, follower(i + 1), +1);
+            set(kPairs + i, follower(i + 1), true, true, leader(i + 1), -1);
+        }
+        set(40, follower(41), true, true, leader(41), -1);
+        set(41, leader(41), false, true, follower(41), +1);
+        set(42, leader(43), false, true, follower(43), +1);
+        set(43, follower(43), true, false, {}, 0);
+        set(44, follower(45), true, true, leader(45), -1);
+        set(45, leader(45), false, false, {}, 0);
+        set(46, leader(47), false, true, follower(47), +1); // {0, 47, kTag} is no row
+        set(47, follower(48), true, true, leader(48), -1);  // {48, kTag} is no row
+        for (size_t i = 0; i < kRows; ++i) {
+            // Pre-cos values no rounding identity holds for by accident: irrational-looking, mixed signs.
+            v[i] = (i % 2 == 0 ? 1.0 : -1.0) / (static_cast<double>(i) + 3.0);
+            if (!rot[i]) {
+                v[i] *= 1e-9; // silent: below any threshold, still swept
+            }
+            // The fused cos sweep: every anticommuting slot holds fl(v * cos) when the join runs.
+            coeffs[i] = v[i] * cos_build;
+        }
+        detail::insert_absent_terms<kN>(op, kRows, [&](size_t k, size_t base) {
+            const auto pos = positions_of(terms[k]);
+            op.store->set_positions(base + k, std::span<const PosT>(pos));
+        });
+        op.op_coeffs = coeffs;
+        uint64_t foll_bits = 0;
+        for (size_t i = 0; i < kRows; ++i) {
+            foll_bits |= static_cast<uint64_t>(foll[i]) << i;
+        }
+        scratch.nz = {detail::EvenParityNzWord{.base = 0, .overlap = (uint64_t{1} << kRows) - 1U, .foll = foll_bits}};
+        scratch.marks.begin(kRows, scratch.nz);
+        for (size_t i = 0; i < kRows; ++i) {
+            if (foll[i]) {
+                scratch.marks.set_foll(i);
+            }
+            if (rot[i]) {
+                scratch.marks.set_rot(i);
+            }
+        }
+    }
+
+    // The value-path scan's product: one rot=1 record per rotating row, in ascending row order.
+    auto scan() -> detail::FusedScanResult<kN> {
+        detail::FusedScanResult<kN> res;
+        res.queries.assign(1, VecZ{});
+        res.sent.assign(1, {});
+        res.self.keeps_values = true;
+        for (size_t i = 0; i < kRows; ++i) {
+            if (!rot[i]) {
+                continue;
+            }
+            const auto pos = positions_of(record_key[i]);
+            res.self.push(pos, phase[i], key_of(record_key[i]), /*rot=*/true, v[i]);
+            res.sent[0].push_back(
+                detail::SentRecord{.row = static_cast<TermIndex>(i), .phase = static_cast<int8_t>(phase[i])});
+        }
+        return res;
+    }
+
+    auto sink() -> detail::ContractSink<kN> {
+        return detail::ContractSink<kN>{.fc = fc,
+                                        .fused_scale = true,
+                                        .op_coeffs = op.op_coeffs,
+                                        .cos_build = cos_build,
+                                        .inv_cos = inv_cos,
+                                        .absences_carry_c0 = false};
+    }
+};
+
+// ContractSink with pair-once declared off: the two-record resolution, the oracle.
+struct TwoRecordSink : detail::ContractSink<kN> {
+    static constexpr bool pairs_once = false;
+};
+
+static_assert(detail::sink_pairs_once<detail::ContractSink<kN>>());
+static_assert(!detail::sink_pairs_once<TwoRecordSink>());
+static_assert(!detail::sink_pairs_once<detail::GraphSink<kN>>());
+
+// One half as bits, so a value that differs by one ULP is a difference.
+using HalfBits = std::tuple<TermIndex, int, bool, uint64_t>;
+
+struct Outcome {
+    std::vector<HalfBits> halves;                    // sorted by slot; every slot appears at most once
+    std::vector<std::tuple<bool, bool, bool>> marks; // received, partner_rot, answered per row
+    std::vector<Monomial<kN>> rows;                  // the store after the mints
+    size_t skipped = 0;
+};
+
+template <typename Sink>
+auto run(Gate &g, Sink sink) -> Outcome {
+    detail::LayerBuildEngine<kN, Sink> eng(g.op,
+                                           mpi::Comm{},
+                                           /*R_=*/1,
+                                           /*my_rank_=*/0,
+                                           g.scratch,
+                                           /*combined_size_=*/Gate::kRows,
+                                           std::move(sink));
+    eng.exchange_and_join(g.scan());
+    Outcome out;
+    for (const auto &h : g.fc.halves) {
+        out.halves.emplace_back(h.local_idx,
+                                static_cast<int>(h.phase_signed),
+                                h.is_insert,
+                                std::bit_cast<uint64_t>(h.v_partner));
+    }
+    std::sort(out.halves.begin(), out.halves.end());
+    for (size_t i = 0; i < Gate::kRows; ++i) {
+        out.marks.emplace_back(g.scratch.marks.received(i),
+                               g.scratch.marks.partner_rot(i),
+                               g.scratch.marks.answered(i));
+    }
+    for (size_t i = 0; i < g.op.store->size(); ++i) {
+        out.rows.push_back(g.op.store->row(i));
+    }
+    out.skipped = g.scratch.join.skipped_count();
+    return out;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(pair_once_settles_leader_first_pairs_from_one_record_and_is_bit_identical) {
+    Gate once;
+    Gate twice;
+    const Outcome a = run(once, once.sink());
+    const Outcome b = run(twice, TwoRecordSink{twice.sink()});
+
+    // Some leader-first follower was skipped, no more than one per pair, and nothing at all without
+    // the rule. How many is the transport's business, so it is not pinned here.
+    BOOST_TEST(a.skipped > 0U);
+    BOOST_TEST(a.skipped <= Gate::kPairs);
+    BOOST_TEST(b.skipped == 0U);
+
+    // Every rotating pair endpoint gets exactly one half, plus the two mints: 46 pre-gate slots + 2.
+    BOOST_REQUIRE_EQUAL(a.halves.size(), Gate::kRows - 2 + 2);
+    BOOST_REQUIRE_EQUAL(b.halves.size(), a.halves.size());
+    for (size_t k = 1; k < a.halves.size(); ++k) {
+        BOOST_TEST(std::get<0>(a.halves[k]) != std::get<0>(a.halves[k - 1])); // one half per slot
+    }
+    BOOST_TEST(a.halves == b.halves);
+    BOOST_TEST(a.marks == b.marks);
+    BOOST_TEST(a.rows == b.rows);
+
+    // The identity the saving rests on, pinned on one pair: the leader's half carries the follower's
+    // value recovered from its swept slot, the follower's half the leader's exact pre-cos value.
+    auto half_of = [&](const Outcome &o, size_t slot) {
+        const auto it =
+            std::find_if(o.halves.begin(), o.halves.end(), [&](const HalfBits &h) { return std::get<0>(h) == slot; });
+        BOOST_REQUIRE(it != o.halves.end());
+        return *it;
+    };
+    const HalfBits leader = half_of(a, 0);
+    const HalfBits follower = half_of(a, Gate::kPairs);
+    BOOST_TEST(std::get<3>(leader) == std::bit_cast<uint64_t>((once.v[Gate::kPairs] * once.cos_build) * once.inv_cos));
+    BOOST_TEST(std::get<1>(leader) == -once.phase[0]);
+    BOOST_TEST(std::get<3>(follower) == std::bit_cast<uint64_t>(once.v[0]));
+    BOOST_TEST(std::get<1>(follower) == once.phase[0]);
+    BOOST_TEST(!std::get<2>(leader));
+    BOOST_TEST(!std::get<2>(follower));
+
+    // The mints, in record order: X from I's record, then Y from J's, and the table followed the store.
+    BOOST_REQUIRE_EQUAL(a.rows.size(), Gate::kRows + 2);
+    BOOST_TEST((a.rows[Gate::kRows] == mono({0, 47, Gate::kTag})));
+    BOOST_TEST((a.rows[Gate::kRows + 1] == mono({48, Gate::kTag})));
+    BOOST_TEST(once.op.term_table().rows() == Gate::kRows + 2);
+    const auto x = positions_of(a.rows[Gate::kRows]);
+    BOOST_TEST(once.op.term_table().find(*once.op.store, key_of(a.rows[Gate::kRows]), std::span<const PosT>(x))
+               == Gate::kRows);
+
+    // Marks after the gate: both endpoints of every tracked pair received with the partner's rot; the
+    // silent partners answered their leaders; the absent partners left their senders unanswered.
+    const auto &m = once.scratch.marks;
+    for (size_t i = 0; i < 42; ++i) {
+        BOOST_TEST(m.received(i));
+        BOOST_TEST(m.partner_rot(i));
+        BOOST_TEST(!m.answered(i));
+    }
+    BOOST_TEST((m.received(43) && m.partner_rot(43) && m.answered(42) && !m.received(42)));
+    BOOST_TEST((m.received(45) && m.partner_rot(45) && m.answered(44) && !m.received(44)));
+    BOOST_TEST((!m.received(46) && !m.answered(46)));
+    BOOST_TEST((!m.received(47) && !m.answered(47)));
+}
+
+// The follower-first pair alone, in both resolutions: the leader's record takes the ordinary arm because
+// the follower's already set received on it, and nothing is pushed twice.
+BOOST_AUTO_TEST_CASE(pair_once_follower_first_pair_takes_the_two_record_path) {
+    Gate g;
+    const Outcome a = run(g, g.sink());
+    size_t on_c = 0;
+    size_t on_d = 0;
+    for (const auto &h : a.halves) {
+        on_c += static_cast<size_t>(std::get<0>(h) == 40);
+        on_d += static_cast<size_t>(std::get<0>(h) == 41);
+    }
+    BOOST_TEST(on_c == 1U);
+    BOOST_TEST(on_d == 1U);
+    BOOST_TEST((g.scratch.marks.received(40) && g.scratch.marks.received(41)));
+}
+
+// The probe's skip bookkeeping, on the join alone: a declined query is recorded as skipped, counted as a
+// hit (it can never mint) and never confirmed, and the predicate is consulted once per query in order.
+BOOST_AUTO_TEST_CASE(table_join_records_skipped_queries_as_settled) {
+    std::mt19937_64 rng(16);
+    const auto terms = draw_distinct(rng, 100);
+    Op op;
+    append_terms(op, terms);
+    std::vector<uint32_t> keys;
+    std::vector<std::vector<PosT>> pos;
+    for (const auto &m : terms) {
+        keys.push_back(key_of(m));
+        pos.push_back(positions_of(m));
+    }
+    detail::TableJoin<kN> join;
+    join.begin_queries(terms.size());
+    std::vector<size_t> asked_skip;
+    std::vector<size_t> confirmed;
+    join.run(
+        op.term_table(),
+        *op.store,
+        [&](size_t q) { return keys[q]; },
+        [&](size_t q) { return std::span<const PosT>(pos[q]); },
+        [&](size_t q) {
+            asked_skip.push_back(q);
+            return q % 3 == 0;
+        },
+        [&](size_t q, size_t) { confirmed.push_back(q); });
+    BOOST_TEST(std::is_sorted(asked_skip.begin(), asked_skip.end()));
+    BOOST_TEST(asked_skip.size() == terms.size());
+    size_t skipped = 0;
+    for (size_t q = 0; q < terms.size(); ++q) {
+        if (q % 3 == 0) {
+            BOOST_TEST(join.skipped(q));
+            BOOST_TEST((std::find(confirmed.begin(), confirmed.end(), q) == confirmed.end()));
+            ++skipped;
+        }
+        else {
+            BOOST_TEST(!join.skipped(q));
+            BOOST_TEST(join.hit(q) == q);
+        }
+    }
+    BOOST_TEST(join.skipped_count() == skipped);
+    BOOST_TEST(join.hits() == terms.size()); // confirmed + skipped
+    BOOST_TEST(join.queries() - join.hits() == 0U);
+}
+
+// The same bookkeeping with nothing to probe: an empty table confirms no query, and a declined one is
+// still recorded as skipped rather than as a miss.
+BOOST_AUTO_TEST_CASE(table_join_skips_on_an_empty_table_without_probing) {
+    Op op;
+    const auto asked = mono({1, 3, 5});
+    const auto pos = positions_of(asked);
+    detail::TableJoin<kN> join;
+    join.begin_queries(2);
+    join.run(
+        op.term_table(),
+        *op.store,
+        [&](size_t) { return key_of(asked); },
+        [&](size_t) { return std::span<const PosT>(pos); },
+        [](size_t q) { return q == 0; },
+        [](size_t, size_t) { BOOST_FAIL("an empty table cannot confirm a row"); });
+    BOOST_TEST(join.skipped(0));
+    BOOST_TEST(!join.skipped(1));
+    BOOST_TEST(join.hit(1) == detail::TableJoin<kN>::kMissing);
+    BOOST_TEST(join.skipped_count() == 1U);
+    BOOST_TEST(join.hits() == 1U);
+}

--- a/cpp/tests/sparse_resolve_tests.cpp
+++ b/cpp/tests/sparse_resolve_tests.cpp
@@ -119,7 +119,8 @@ struct AllRowsGate {
             *op.store,
             [&](size_t q) { return pr.tag_of[q]; },
             [&](size_t q) { return pr.positions_at(q); },
-            [](size_t, size_t) {});
+            [](size_t) { return false; },
+            [&](size_t /*q*/, size_t row) { marks.set_matched(row); });
     }
 };
 
@@ -514,6 +515,7 @@ BOOST_AUTO_TEST_CASE(sparse_resolve_join_matches_the_by_value_oracle) {
         *op.store,
         [&](size_t q) { return keys[q]; },
         [&](size_t q) { return std::span<const PosT>(query_pos[q]); },
+        [](size_t) { return false; },
         [](size_t, size_t) {});
 
     size_t spilled = 0;

--- a/cpp/tests/term_table_tests.cpp
+++ b/cpp/tests/term_table_tests.cpp
@@ -117,16 +117,21 @@ auto probe_batch(const Op &op, const std::vector<Monomial<kN>> &asked) -> std::v
         pos.push_back(positions_of(m));
     }
     constexpr TermIndex kMissing = std::numeric_limits<TermIndex>::max();
+    constexpr TermIndex kSkipped = kMissing - 1;
     std::vector<TermIndex> rows(asked.size(), 0);
     size_t on_hit_calls = 0;
-    const size_t hits = op.term_table().find_batch(
+    const auto stats = op.term_table().find_batch(
         *op.store,
         asked.size(),
         [&keys](size_t q) { return keys[q]; },
         [&pos](size_t q) { return std::span<const PosT>(pos[q]); },
+        [](size_t /*q*/) { return false; },
         [&on_hit_calls](size_t /*q*/, size_t /*row*/) { ++on_hit_calls; },
         std::span<TermIndex>(rows),
-        kMissing);
+        kMissing,
+        kSkipped);
+    const size_t hits = stats.hits;
+    BOOST_TEST(stats.skipped == 0U);
     BOOST_TEST(on_hit_calls == hits);
     std::vector<size_t> out;
     out.reserve(asked.size());

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -264,6 +264,23 @@ Graph mode has no coefficients and therefore no silent terms to answer: it keeps
 predicate, sending for every anticommuting term whose partner is structurally admissible, which is
 what its positional in/out pairing is proved on.
 
+A mutual pair whose two terms sit on the *same* slot is settled once rather than twice. Both of its
+records are then staged locally, and whichever is resolved first has the other's row in hand: if that
+is the *leader*'s record — the endpoint that does not carry the pivot bit, the one bit of $G$ that a
+term and its partner always differ on — it applies its own half and, in place of the follower's record,
+the follower's half read straight off the follower's swept coefficient slot. The follower's record is
+then skipped, at its probe as well as at its resolve. That half is bit-identical to the one the
+follower's own record would have delivered, since $\varphi(M \oplus G, G) = -\varphi(M, G)$ and the
+sweep left exactly $\mathrm{fl}(c \cdot \cos)$ in that slot; in the follower-first order both records
+take the ordinary path, so the saving — one probe and one confirm per local mutual pair — is the only
+thing the order decides.
+
+The absent partner's half is skipped outright in the Heisenberg picture. A record whose key missed
+everywhere mints its partner and owes its own side an add of that partner's *pre-gate* coefficient,
+which only the Schrödinger picture scores: in Heisenberg the freshly minted partner had none, so the
+add is $c \mathrel{+}= \sin \cdot (\mp 1) \cdot 0$ — a 16-byte half and one random-access
+read-modify-write per mint of every gate, to add nothing.
+
 Linear routing is a switch and not a dial: the rank index takes every bit of $h$ or none of
 them, and none of them is `splitmix`, which reproduces the dense `hash % (R × S)` bit for
 bit. It therefore requires $R$ to be a power of two; any other rank count has no XOR


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two cases the one-round join (PR 5) still did more work than it needed to.

A mutual pair — both endpoints rotating, both records staged on the same slot — was resolved twice:
each record probed the term table for the other's row and pushed its own half. This PR settles it
once, from the leader's record alone (the endpoint without the pivot bit): when the leader's record is
resolved first it already has both rows in hand, so it pushes both halves and the follower's record is
skipped, at its probe as well as at its resolve. `TermTable::find_batch` takes the caller's skip
predicate and reports `BatchStats{hits, skipped}`; `TableJoin` records a skipped query under its own
sentinel, one below the missing row, so the resolve can tell a skip from a miss.

Separately, `ContractSink::out_unanswered` pushed a 16-byte record for every absent partner, carrying
`c0`, the partner's pre-gate coefficient — but only the Schrödinger picture has such a coefficient; in
Heisenberg the buffered half is `c += sin·(∓1)·0.0`, added for nothing. This PR skips it there
(`absences_carry_c0`, set from `schrodinger` at the one construction site); `GraphSink` is unaffected,
since the graph needs the row and the phase regardless of the value.

This is PR 6 of 7, based on `perf/stack-5-one-round-join`. Both changes are exact, not approximate —
see Measurements. The next PR (`perf/stack-7-pair-exchange`) replaces the collective exchange with a
direct pairwise one when a gate's window names exactly one peer rank.

## Changes

**Engine**
- `cpp/monoprop/detail/operator/TermTable.h` (318 lines): `find_batch` gains a `Skip` predicate and a
  skip sentinel, returns `BatchStats{hits, skipped}`; the existing empty-table early return now also
  consults `skip()`.
- `cpp/monoprop/detail/evolution/layer_build/TableJoin.h` (125 lines): `kSkippedRow`, `skipped(q)`,
  `skipped_count()`, `hits()` = confirmed + skipped.
- `cpp/monoprop/detail/evolution/layer_build/Resolve.h` (405 lines): `sink_pairs_once<Sink>()` and
  `join_self`'s pair-once arm (skip-continue on the follower, leader arm settles both halves); one
  `join.hit(q)` load per query, hoisted above the leader arm but not above the skip test.
- `cpp/monoprop/detail/evolution/layer_build/GateSinks.h` (251 lines): `ContractSink::pairs_once`,
  `absences_carry_c0`, `out_unanswered`'s skip.
- `cpp/monoprop/detail/evolution/layer_build/GateScratch.h`: `RowMarks` doc on why `matched` (probe
  time) and `received` (resolve time) are read separately — the probe runs over the whole gate before
  the resolve does.
- `cpp/monoprop/detail/evolution/layer_build/Engine.h`: `pair_once = sink_pairs_once<Sink>() &&
  n_self != 0 && base < kSkippedRow`; the probe's skip lambda on `marks.matched`/`foll`;
  `.absences_carry_c0 = schrodinger` at the one construction site.

**Tests**
- `cpp/tests/pair_once_tests.cpp` (new, 411 lines): a `Gate` fixture (20 leader-first pairs, one
  follower-first pair, two silent partners, two absent partners) with halves/marks/rows compared bit
  for bit against a two-record-path oracle; skip-bookkeeping cases for `TermTable`/`TableJoin`,
  including the empty-table skip path.
- `cpp/tests/evolution_detail_tests.cpp`: `.absences_carry_c0 = true` on the existing `ContractSink`
  case, plus `contract_sink_skips_the_absence_half_when_no_c0_travels`.
- `cpp/tests/sparse_resolve_tests.cpp`, `term_table_tests.cpp`: a never-skip predicate at the
  join/`find_batch` call sites; `term_table_tests` pins `skipped == 0` on the unaffected paths.

**Docs**
- `docs/content/docs/features/parallelism.mdx`: two paragraphs — the leader-first settlement of a
  mutual pair and its bit-identity argument, and why the absent partner's half is nothing at all in
  the Heisenberg picture.

## Measurements

Gated positional (`--raw-only`) against the x2 raw-bit reference, the same reference PR 5's tail gates
against: gate record md5 `543c105e043a329e52ddd3047c8db5c7`.

Paired A/B, 3 interleaved reps against origin/main c5e88c8 and the predecessor, ratios only:

| rung | time st6/mainB | peak RSS (kernel) st6/mainB | time st5/mainB (predecessor) | peak st5/mainB (predecessor) |
| --- | ---: | ---: | ---: | ---: |
| L1-hubbard | 1.096 | 0.766 | 1.092 | 0.763 |
| L1-pauli | 0.980 | 0.777 | 0.980 | 0.779 |
| M2a-hubbard | 1.078 | 0.770 | 1.080 | 0.768 |

Pair-once is neutral on one node: every rung is within the noise floor of its predecessor. Its
effect is on the cross-rank pair path, which PR 7 introduces.

## Notes for reviewers

- **Exactness argument for the pair-once settlement.** The follower's record would have delivered
  `{source, -phase, fl(fl(v·cos)·inv_cos)}`; the leader's arm instead pushes
  `{source, -phase, op_coeffs[row]·inv_cos}`. Under the fused sweep, `op_coeffs[row] == fl(v·cos)` and
  `phase_foll == -phase_lead`, so the two are the same double; without the sweep both are simply the
  partner's own coefficient. Only in the follower-first order do both records take the ordinary
  (two-probe) arm, so the saving — not the correctness — depends on record order. Mint order is
  unaffected: a skipped query counts as a hit, and hits never mint.
- **Exactness argument for the absence skip.** The dropped operation is an addition of an exact zero,
  `x + (±0.0)`. For every finite `x != 0` that is `x` bit for bit; the one observable case is `x =
  -0.0`, where `-0.0 + 0.0` rounds to `+0.0` and skipping the add leaves `-0.0` — values that compare
  equal, so this is 0 ULP by any value comparison. The implementer's own dump over the 35 golden cells
  (`runs/stack/golden-st6-x2.log`) reports the raw diff's `+-0only` column at 0: no coefficient in that
  set sits at `-0.0` where the dropped half would have flipped its sign bit, so the skip is
  bit-identical in fact here, not only 0 ULP on values. The theoretical case (an operator that does
  hold such a `-0.0`) is a live caveat, recorded in `04c9662`'s commit message rather than guarded in
  code.
- Skip counts are deliberately **not** asserted exactly in `pair_once_tests.cpp` (only `0 < skipped <=
  kPairs`): PR 7's transport change moves them, and the bit-identity checks against the two-record
  oracle do not depend on the count.
- `TableJoin::live_bytes()` stays absent and no `TimeProf` counters (`n_mutual`, `n_skipped`) are
  added: diagnostics stay out of this stack, per the decision recorded in PR 2's Notes.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable (n/a — the repository has no `CHANGELOG`)

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (claude-sonnet-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
