### PR TITLE
perf(mpi): ⚡ exchange a gate's records over one pairwise round when it names one peer

### DIFF
--- a/cpp/monoprop/detail/evolution/layer_build/Common.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Common.h
@@ -24,6 +24,7 @@
 
 #include "monoprop/TypeAliases.h"
 #include "monoprop/core/Monomial.h"
+#include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
 
 namespace monoprop::detail {
@@ -56,6 +57,31 @@ struct SentRecord {
 // it back through its `sent` list. Two words, so the response round reuses the records' transport verb
 // and buffer type.
 inline constexpr size_t kResponseWords = 2;
+
+//! A wire buffer's smallest interesting slot, so the release rule below leaves tiny slots alone.
+inline constexpr size_t kWireFloorWords = 64;
+
+/*!
+ * @brief Re-windows a wire buffer for a new gate, keeping the slot storage the last gate paid for.
+ *
+ * WindowVec::reset assigns an empty vector into each existing element, which CLEARS a slot but keeps
+ * its capacity -- so a buffer reused across gates never allocates again, and never gives a byte back
+ * either. That is the cost model of a buffer that must outlive its gate: pair_exchange's lifetime rule
+ * (PairExchange.h) forbids freeing it at the end of the gate that filled it, so without a rule one wide
+ * gate pins its peak for the rest of the call.
+ *
+ * The rule is the engine's usual one (release_if_oversized): a slot whose capacity has run past 4x what
+ * it last held gives the storage back and re-earns it. The comparison reads the sizes still in place, so
+ * it must run BEFORE the reset that clears them.
+ */
+inline auto reuse_wire(mpi::WindowVec<VecZ> &wire, mpi::SlotWindow window) -> void {
+    for (VecZ &slot : wire) {
+        if (slot.capacity() > 4 * std::max(slot.size(), kWireFloorWords)) {
+            slot = VecZ{};
+        }
+    }
+    wire.reset(window);
+}
 
 // COMMPROF's tallies (MonomialPropagator::report_comm_profile_ prints them): the wire volume of one
 // call's gates, as this slot SENT it. Accumulated across the gates of a call, not reset per gate.

--- a/cpp/monoprop/detail/evolution/layer_build/Common.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Common.h
@@ -70,7 +70,7 @@ inline constexpr size_t kWireFloorWords = 64;
  * (PairExchange.h) forbids freeing it at the end of the gate that filled it, so without a rule one wide
  * gate pins its peak for the rest of the call.
  *
- * The rule is the engine's usual one (release_if_oversized): a slot whose capacity has run past 4x what
+ * The rule is the engine's usual one (TableJoin::begin_queries): a slot whose capacity has run past 4x what
  * it last held gives the storage back and re-earns it. The comparison reads the sizes still in place, so
  * it must run BEFORE the reset that clears them.
  */

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -37,6 +37,7 @@
 #include "monoprop/detail/evolution/layer_build/Scan.h"
 #include "monoprop/detail/evolution/layer_build/TableJoin.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
+#include "monoprop/detail/mpi/PairExchange.h"
 #include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
 
@@ -77,6 +78,8 @@ struct LayerBuildEngine {
     // The flat slots that plan reaches from my_rank: what every per-slot array of this gate is sized to.
     mpi::SlotWindow window;
     Sink sink;
+    bool pair_path = false; // this gate's exchange is one rank pair: mpi::pair_exchange carries it
+    int pair_shift = 0;     // the rank shift it names; 0 is the in-rank exchange
 
     LayerBuildEngine(MPOperator<NumModes> &local_op_,
                      mpi::Comm comm_,
@@ -97,6 +100,14 @@ struct LayerBuildEngine {
           window(window_.count != 0 ? window_ : mpi::SlotWindow{.base = 0, .count = R_}),
           sink(std::move(sink_)) {
         assert(window.stop() <= R);
+        // pair_exchange addresses ONE rank pair, so it covers exactly the gates whose window is one
+        // rank's partitions: linear routing (the peer rank is my_rank ^ shift) and every single-rank
+        // world (the peer is this rank, shift 0). Dense routing over several ranks reaches a window of
+        // ranks x partitions, which only the collective can carry.
+        const auto geom = mpi::geometry(comm);
+        pair_path = R > 1 && window.count == static_cast<size_t>(geom.partitions);
+        pair_shift = plan.sparse ? plan.shift : 0;
+        assert((!pair_path || plan.sparse || geom.ranks == 1) && "a dense multi-rank gate cannot pair");
     }
 
     /*! @brief The round and a half.
@@ -133,15 +144,29 @@ struct LayerBuildEngine {
         std::optional<mpi::PendingAlltoallv<size_t>> pending;
         // Round 1 opens here and closes past the decode: the post, the wait and the decode are one stage
         // because no gate can overlap them with work of its own -- the join's row side needs every record.
-        if (R > 1) {
+        if (R > 1 && !pair_path) {
             pending.emplace(
                 mpi::begin_alltoallv(scan.queries, comm, /*skip_self=*/false, /*known_recv_counts=*/nullptr, plan));
         }
-        if (pending.has_value()) {
-            scratch.reuse_incoming_wire(window);
-            pending->wait_into(scratch.incoming_wire);
-            decode_incoming_records<NumModes>(slot_streams(scratch.incoming_wire, scratch.slot_views),
-                                              scratch.incoming_wire.window(),
+        // The queries live in the scratch pool from here on, not in `scan`: the peers of a pair exchange
+        // read this buffer in place until this partition's NEXT call returns, which is past the end of
+        // `scan`. The move keeps every slot's storage where it is, so nothing is copied to say so, and it
+        // happens before anything can publish the buffer. The parity moves on at the end of the gate.
+        mpi::WindowVec<VecZ> &queries = scratch.wire_queries(Sink::wants_responses);
+        queries = std::move(scan.queries);
+        // The collective's receive buffer is a gate-local: nothing outside the gate reads it. Only a
+        // published SEND buffer outlives its gate (PairExchange.h), and those are the pool's.
+        mpi::WindowVec<VecZ> incoming;
+        if (pair_path) {
+            decode_incoming_records<NumModes>(mpi::pair_exchange(comm, pair_shift, publish_(queries)).from,
+                                              window,
+                                              sink.incoming_form(),
+                                              pr);
+        }
+        else if (pending.has_value()) {
+            pending->wait_into(incoming);
+            decode_incoming_records<NumModes>(slot_streams(incoming, scratch.slot_views),
+                                              incoming.window(),
                                               sink.incoming_form(),
                                               pr);
         }
@@ -192,11 +217,16 @@ struct LayerBuildEngine {
         sink.reserve_halves(join.queries() + n_sent);
         misses.reserve(join.queries() - join.hits());
 
-        // Round 2's send buffer. A sink that answers nothing keeps an empty local rather than naming the
-        // shared one, so nothing charges it what an earlier fused call left there.
-        mpi::WindowVec<VecZ> responses;
+        // Round 2's send buffer is claimed before the first push for the same lifetime reason, and it is
+        // the OTHER slot of the pool: round 1's is still published to the peers. It needs no twin --
+        // only the two-call fused sink stages responses, and its second call is bounded by the NEXT
+        // gate's first, so one buffer is already outlived. A sink that answers nothing keeps an empty
+        // local rather than naming the shared one, so nothing charges it what an earlier fused call left
+        // there.
+        mpi::WindowVec<VecZ> responses_none;
+        mpi::WindowVec<VecZ> &responses = Sink::wants_responses ? scratch.wire_r : responses_none;
         if constexpr (Sink::wants_responses) {
-            responses.reset(window);
+            reuse_wire(responses, window);
         }
         size_t answered = 0;
         if (n_self != 0) {
@@ -214,9 +244,12 @@ struct LayerBuildEngine {
         answered += join_incoming<NumModes>(pr, join, /*q_base=*/n_self, marks, base, misses, sink, responses);
 
         // Round 1 at its widest: the scan's arrays, the delivered records and the staged responses.
-        stamp_gate_buffers_(scan, scratch.incoming_wire, responses, /*extra=*/0);
-        run_round_two_(scan, responses, base);
+        stamp_gate_buffers_(scan, queries, incoming, responses, /*extra=*/0);
+        run_round_two_(scan, queries, incoming, responses, base);
         absence_pass<NumModes>(marks, scan.sent, scan.sent_c0, sink);
+        // Past every read of this gate's queries, so the next gate's scan takes the OTHER buffer and this
+        // one stays intact for the peers that may still hold views into it.
+        ++scratch.wire_gate;
 
         scratch.counters.gates += 1;
         scratch.counters.records += n_sent;
@@ -238,21 +271,35 @@ private:
      *  result depends on, and that is what fixes their place here (mint indices were assigned against
      *  `base` before this call).
      */
-    auto run_round_two_(const FusedScanResult<NumModes> &scan, mpi::WindowVec<VecZ> &responses, size_t base) -> void {
+    auto run_round_two_(const FusedScanResult<NumModes> &scan,
+                        const mpi::WindowVec<VecZ> &queries,
+                        const mpi::WindowVec<VecZ> &incoming,
+                        mpi::WindowVec<VecZ> &responses,
+                        size_t base) -> void {
         std::optional<mpi::PendingAlltoallv<size_t>> answering;
         if constexpr (Sink::wants_responses) {
-            if (R > 1) {
+            if (R > 1 && !pair_path) {
                 answering.emplace(
                     mpi::begin_alltoallv(responses, comm, /*skip_self=*/false, /*known_recv_counts=*/nullptr, plan));
             }
         }
+        // On the pair path the inserts move AHEAD of the exchange rather than under it: pair_exchange is
+        // synchronous, so there is no post to overlap. Their order against apply_responses is what the
+        // result depends on, and that is unchanged.
         insert_misses<NumModes>(local_op, scratch.misses, base);
         if constexpr (Sink::wants_responses) {
-            if (answering.has_value()) {
+            if (pair_path) {
+                const auto answers = mpi::pair_exchange(comm, pair_shift, publish_(responses)).from;
+                // Round 2 at its widest: round 1's buffers are all still in scope under the answers,
+                // which are views into the transport's own buffer -- hence `extra` 0 on this path.
+                stamp_gate_buffers_(scan, queries, incoming, responses, /*extra=*/0);
+                apply_responses<NumModes>(scratch.marks, scan.sent, answers, window, sink);
+            }
+            else if (answering.has_value()) {
                 mpi::WindowVec<VecZ> answers;
                 answering->wait_into(answers);
                 // Round 2 at its widest: round 1's buffers are all still in scope under the answers.
-                stamp_gate_buffers_(scan, scratch.incoming_wire, responses, wire_bytes_(answers));
+                stamp_gate_buffers_(scan, queries, incoming, responses, wire_bytes_(answers));
                 apply_responses<NumModes>(scratch.marks,
                                           scan.sent,
                                           slot_streams(answers, scratch.slot_views),
@@ -260,6 +307,19 @@ private:
                                           sink);
             }
         }
+    }
+
+    /*! @brief The gate's per-slot send descriptors, for pair_exchange.
+     *
+     *  The verb copies the outer array before its barrier, so one reusable array serves both rounds. The
+     *  BUFFERS it names are the ones the lifetime rule binds, and those are the scratch pool's.
+     */
+    auto publish_(const mpi::WindowVec<VecZ> &buf) -> mpi::SubStreams {
+        scratch.wire_spans.resize(window.count);
+        for (size_t k = 0; k < window.count; ++k) {
+            scratch.wire_spans[k] = std::span<const size_t>(buf[mpi::WindowIndex{k}]);
+        }
+        return mpi::SubStreams{scratch.wire_spans};
     }
 
     static auto wire_bytes_(const mpi::WindowVec<VecZ> &wire) -> size_t {
@@ -279,10 +339,11 @@ private:
      *  diagnostic beside the ledger and never a term in it.
      */
     auto stamp_gate_buffers_(const FusedScanResult<NumModes> &scan,
+                             const mpi::WindowVec<VecZ> &queries,
                              const mpi::WindowVec<VecZ> &incoming,
                              const mpi::WindowVec<VecZ> &responses,
                              size_t extra) -> void {
-        size_t bytes = extra + wire_bytes_(scan.queries) + wire_bytes_(incoming) + wire_bytes_(responses)
+        size_t bytes = extra + wire_bytes_(queries) + wire_bytes_(incoming) + wire_bytes_(responses)
                        + scratch.misses.memory_bytes() + scratch.incoming_records.memory_bytes()
                        + (scan.self.pos_flat.capacity() * sizeof(RowPosT))
                        + (scan.self.pos_off.capacity() * sizeof(size_t)) + (scan.self.k_of.capacity() * 2)

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -74,6 +74,8 @@ struct LayerBuildEngine {
     // Which destination ranks this gate's records can reach. Dense unless the router is GF(2)-linear;
     // see mpi::PeerPlan. Derived once per layer in build_layer, never per record.
     mpi::PeerPlan plan;
+    // The flat slots that plan reaches from my_rank: what every per-slot array of this gate is sized to.
+    mpi::SlotWindow window;
     Sink sink;
 
     LayerBuildEngine(MPOperator<NumModes> &local_op_,
@@ -83,7 +85,8 @@ struct LayerBuildEngine {
                      GateScratch<NumModes> &scratch_,
                      size_t combined_size_,
                      Sink &&sink_,
-                     mpi::PeerPlan plan_ = {}) // dense by default: the tests build the engine directly
+                     mpi::PeerPlan plan_ = {},     // dense by default: the tests build the engine directly
+                     mpi::SlotWindow window_ = {}) // likewise: an empty window means the whole world
         : local_op(local_op_),
           comm(comm_),
           R(R_),
@@ -91,7 +94,10 @@ struct LayerBuildEngine {
           scratch(scratch_),
           combined_size(combined_size_),
           plan(plan_),
-          sink(std::move(sink_)) {}
+          window(window_.count != 0 ? window_ : mpi::SlotWindow{.base = 0, .count = R_}),
+          sink(std::move(sink_)) {
+        assert(window.stop() <= R);
+    }
 
     /*! @brief The round and a half.
      *
@@ -107,10 +113,22 @@ struct LayerBuildEngine {
         MissStage<NumModes> &misses = scratch.misses;
         IncomingRecords<NumModes> &pr = scratch.incoming_records;
         const size_t base = local_op.store->size();
+        // The scan sized its arrays to the same plan, so the two windows must agree exactly -- a
+        // mismatch would re-base every slot against the wrong base.
+        assert(scan.window.base == window.base && scan.window.count == window.count);
         misses.clear();
+        pr.window = window;
         pr.nq_total = 0;
-        pr.goff.assign(R + 1, 0);
-        assert(scan.queries[my_rank].empty() && "self-owned records are staged, never encoded");
+        pr.goff.assign(window.count + 1, 0);
+        // Self is inside the window only when this generator's rank shift is zero; otherwise the window
+        // names another rank outright and the scan cannot have staged a self-owned partner. The self
+        // block of the wire array is empty either way (staged, never encoded).
+        if (window.contains(my_rank)) {
+            assert(scan.queries.at_slot(my_rank).empty() && "self-owned records are staged, never encoded");
+        }
+        else {
+            assert(scan.self.size() == 0 && "a self-owned partner outside this generator's peer window");
+        }
 
         std::optional<mpi::PendingAlltoallv<size_t>> pending;
         // Round 1 opens here and closes past the decode: the post, the wait and the decode are one stage
@@ -119,17 +137,20 @@ struct LayerBuildEngine {
             pending.emplace(
                 mpi::begin_alltoallv(scan.queries, comm, /*skip_self=*/false, /*known_recv_counts=*/nullptr, plan));
         }
-        std::vector<std::span<const size_t>> views;
         if (pending.has_value()) {
-            scratch.reuse_incoming_wire(R);
+            scratch.reuse_incoming_wire(window);
             pending->wait_into(scratch.incoming_wire);
-            decode_incoming_records<NumModes>(slot_streams(scratch.incoming_wire, views), sink.incoming_form(), pr);
+            decode_incoming_records<NumModes>(slot_streams(scratch.incoming_wire, scratch.slot_views),
+                                              scratch.incoming_wire.window(),
+                                              sink.incoming_form(),
+                                              pr);
         }
 
         // Query order IS mint order: the self stage first, then the incoming sources in ascending slot
         // order, each in its sender's stream order.
         const size_t n_self = scan.self.size();
-        const std::span<const SentRecord> sent_self(scan.sent[my_rank]);
+        const std::span<const SentRecord> sent_self =
+            n_self != 0 ? std::span<const SentRecord>(scan.sent.at_slot(my_rank)) : std::span<const SentRecord>{};
         assert(sent_self.size() == n_self && "one sent record per self query");
         // Pair-once needs the self stage's sent records (the source row of each self query) and a skip
         // sentinel no hit row can equal (TableJoin::kSkippedRow): hit rows are below `base`.
@@ -167,14 +188,15 @@ struct LayerBuildEngine {
         for (const auto &records : scan.sent) {
             n_sent += records.size();
         }
+
         sink.reserve_halves(join.queries() + n_sent);
         misses.reserve(join.queries() - join.hits());
 
         // Round 2's send buffer. A sink that answers nothing keeps an empty local rather than naming the
         // shared one, so nothing charges it what an earlier fused call left there.
-        std::vector<VecZ> responses;
+        mpi::WindowVec<VecZ> responses;
         if constexpr (Sink::wants_responses) {
-            responses.assign(R, VecZ{});
+            responses.reset(window);
         }
         size_t answered = 0;
         if (n_self != 0) {
@@ -193,7 +215,7 @@ struct LayerBuildEngine {
 
         // Round 1 at its widest: the scan's arrays, the delivered records and the staged responses.
         stamp_gate_buffers_(scan, scratch.incoming_wire, responses, /*extra=*/0);
-        run_round_two_(scan, responses, views, base);
+        run_round_two_(scan, responses, base);
         absence_pass<NumModes>(marks, scan.sent, scan.sent_c0, sink);
 
         scratch.counters.gates += 1;
@@ -216,10 +238,7 @@ private:
      *  result depends on, and that is what fixes their place here (mint indices were assigned against
      *  `base` before this call).
      */
-    auto run_round_two_(const FusedScanResult<NumModes> &scan,
-                        std::vector<VecZ> &responses,
-                        std::vector<std::span<const size_t>> &views,
-                        size_t base) -> void {
+    auto run_round_two_(const FusedScanResult<NumModes> &scan, mpi::WindowVec<VecZ> &responses, size_t base) -> void {
         std::optional<mpi::PendingAlltoallv<size_t>> answering;
         if constexpr (Sink::wants_responses) {
             if (R > 1) {
@@ -230,17 +249,21 @@ private:
         insert_misses<NumModes>(local_op, scratch.misses, base);
         if constexpr (Sink::wants_responses) {
             if (answering.has_value()) {
-                std::vector<VecZ> answers;
+                mpi::WindowVec<VecZ> answers;
                 answering->wait_into(answers);
                 // Round 2 at its widest: round 1's buffers are all still in scope under the answers.
                 stamp_gate_buffers_(scan, scratch.incoming_wire, responses, wire_bytes_(answers));
-                apply_responses<NumModes>(scratch.marks, scan.sent, slot_streams(answers, views), sink);
+                apply_responses<NumModes>(scratch.marks,
+                                          scan.sent,
+                                          slot_streams(answers, scratch.slot_views),
+                                          answers.window(),
+                                          sink);
             }
         }
     }
 
-    static auto wire_bytes_(const std::vector<VecZ> &wire) -> size_t {
-        size_t bytes = wire.capacity() * sizeof(VecZ);
+    static auto wire_bytes_(const mpi::WindowVec<VecZ> &wire) -> size_t {
+        size_t bytes = wire.size() * sizeof(VecZ);
         for (const VecZ &slot : wire) {
             bytes += slot.capacity() * sizeof(size_t);
         }
@@ -256,8 +279,8 @@ private:
      *  diagnostic beside the ledger and never a term in it.
      */
     auto stamp_gate_buffers_(const FusedScanResult<NumModes> &scan,
-                             const std::vector<VecZ> &incoming,
-                             const std::vector<VecZ> &responses,
+                             const mpi::WindowVec<VecZ> &incoming,
+                             const mpi::WindowVec<VecZ> &responses,
                              size_t extra) -> void {
         size_t bytes = extra + wire_bytes_(scan.queries) + wire_bytes_(incoming) + wire_bytes_(responses)
                        + scratch.misses.memory_bytes() + scratch.incoming_records.memory_bytes()
@@ -316,6 +339,9 @@ auto build_layer(MPOperator<NumModes> &local_op,
     // rank_shift(gen), so the exchange knows its peer before it starts. Dense otherwise.
     const auto plan =
         mpi::PeerPlan{.sparse = router.is_linear(), .shift = static_cast<int>(router.rank_shift<NumModes>(gen))};
+    // The reachable slots, once per generator: S of the R*S world under linear routing, all of it
+    // otherwise. Every per-slot structure from the scan to the wire is sized to this run.
+    const mpi::SlotWindow scan_window = plan.window(my_rank, router.ranks(), router.partitions());
     // Fused contraction runs at all rank counts (R>1 via the cross-rank half-rotation exchange).
     const bool use_fused = (fused_contract != nullptr);
     const auto cut_st = build_majorana_evolution_cutoff_state(atol, local_coeffs, upper_atol, param);
@@ -361,6 +387,7 @@ auto build_layer(MPOperator<NumModes> &local_op,
                                                                           coeffs,
                                                                           only_rotate_len_k,
                                                                           over_cutoff_possible,
+                                                                          scan_window,
                                                                           my_rank,
                                                                           router,
                                                                           scratch,
@@ -391,7 +418,8 @@ auto build_layer(MPOperator<NumModes> &local_op,
                                              scratch,
                                              /*combined_size=*/local_op.store->size(),
                                              std::move(sink),
-                                             plan);
+                                             plan,
+                                             scan_window);
         if (!identity_gen) {
             eng.exchange_and_join(std::move(fused));
         }

--- a/cpp/monoprop/detail/evolution/layer_build/Engine.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Engine.h
@@ -256,6 +256,9 @@ struct LayerBuildEngine {
         if constexpr (Sink::wants_responses) {
             scratch.counters.responses += answered;
         }
+        // Past every read of the mints and the delivered records, and past both stamps that price them:
+        // their storage goes back here rather than resting in the scratch until the call ends.
+        scratch.release_gate_stages();
     }
 
     auto finish(CosMask &&cos_all, CosMask *out_cos = nullptr) -> std::shared_ptr<LayerCore> {

--- a/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
+++ b/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
@@ -252,9 +252,26 @@ struct GateScratch {
     // pay ~12 allocations and log2(mints) reallocations for buffers the previous gate had already sized.
     MissStage<NumModes> misses;
     IncomingRecords<NumModes> incoming_records;
-    mpi::WindowVec<VecZ> incoming_wire; // the collective's receive buffer, one slot per window slot
-    // Re-used span table for the stream views a decode pass reads; owns nothing, and is only ever
-    // valid while the buffer it was filled from is.
+    /*
+     * The send buffers pair_exchange's lifetime rule needs. Peers read a published buffer IN PLACE, and
+     * the first moment every peer is proved done with it is the return of this partition's next call, so
+     * a gate's records must outlive the gate -- the second reason (with `self_records_hint`) something
+     * here crosses a gate boundary.
+     *
+     * ONE buffer per round rather than a pool alternated per call: sharing would let a round-2 staging
+     * inherit the capacity a round-1 gate left in the same slot (reuse_wire clears a slot but keeps its
+     * storage), making the response buffer as wide as the query buffer. Two query buffers because a
+     * one-call (graph) gate's queries are still being read while the next gate's scan is already writing;
+     * the response buffer needs no twin, since only the two-call fused sink stages responses at all.
+     */
+    std::array<mpi::WindowVec<VecZ>, 2> wire_q;
+    mpi::WindowVec<VecZ> wire_r;
+    size_t wire_gate = 0; // parity of `wire_q`; bumped once per gate that exchanges
+    // The outer descriptor array pair_exchange takes, which the verb copies before its barrier and the
+    // caller may reuse on return.
+    std::vector<std::span<const size_t>> wire_spans;
+    // Slot views of an alltoallv result, so the collective path reaches the same decode surface. Owns
+    // nothing, and is only valid while the buffer it was filled from is.
     std::vector<std::span<const size_t>> slot_views;
     // How many records the previous gate of this partition staged for itself: what the next gate's
     // self-slot reserve is sized from (Scan.h). A hint only -- wrong in either direction it costs at most
@@ -266,24 +283,37 @@ struct GateScratch {
     // alongside `counters`.
     size_t buffers_hwm_bytes{0uz};
 
-    //! Re-windows the collective receive buffer onto `window`, under the release rule.
-    auto reuse_incoming_wire(mpi::SlotWindow window) -> void {
-        for (VecZ &slot : incoming_wire) {
-            release_if_oversized(slot, slot.size());
-            slot.clear();
-        }
-        incoming_wire.rewindow(window);
+    /*!
+     * @brief This gate's round-1 buffer. The scan takes it, the engine puts it back.
+     *
+     * `two_rounds` is the sink's `wants_responses`: a sink that answers needs no twin, because its OWN
+     * round-2 call is the one the lifetime rule measures the queries against, and that call is inside
+     * the same gate. A sink that makes one call per gate does need the twin -- its queries are still
+     * published when the next gate's scan starts writing -- so it alternates.
+     */
+    [[nodiscard]] auto wire_queries(bool two_rounds) -> mpi::WindowVec<VecZ> & {
+        return wire_q[two_rounds ? 0U : (wire_gate & 1U)];
     }
 
     [[nodiscard]] auto memory_bytes() const -> size_t {
-        size_t wire =
-            (incoming_wire.capacity() * sizeof(VecZ)) + (slot_views.capacity() * sizeof(std::span<const size_t>));
-        for (const VecZ &slot : incoming_wire) {
-            wire += slot.capacity() * sizeof(size_t);
-        }
         return join.memory_bytes() + marks.memory_bytes() + (nz.capacity() * sizeof(EvenParityNzWord))
                + (partner.capacity() * sizeof(PosT)) + (gen.capacity() * sizeof(uint16_t)) + misses.memory_bytes()
-               + incoming_records.memory_bytes() + wire;
+               + incoming_records.memory_bytes() + wire_bytes()
+               + ((wire_spans.capacity() + slot_views.capacity()) * sizeof(std::span<const size_t>));
+    }
+
+    //! The wire buffers, which outlive their gate and so are NOT covered by the gate-buffer stamp.
+    [[nodiscard]] auto wire_bytes() const -> size_t {
+        return wire_slot_bytes_(wire_q[0]) + wire_slot_bytes_(wire_q[1]) + wire_slot_bytes_(wire_r);
+    }
+
+private:
+    static auto wire_slot_bytes_(const mpi::WindowVec<VecZ> &wire) -> size_t {
+        size_t bytes = wire.capacity() * sizeof(VecZ);
+        for (const VecZ &slot : wire) {
+            bytes += slot.capacity() * sizeof(size_t);
+        }
+        return bytes;
     }
 };
 

--- a/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
+++ b/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
@@ -19,7 +19,6 @@
 // only to keep its capacity, and a copied propagator starts with an empty one. `counters` is the one
 // exception: it accumulates over a call, and its owner resets it (MonomialPropagator::run_gate_loop_).
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -224,20 +223,6 @@ struct IncomingRecords {
     }
 };
 
-/*! @brief Gives a per-gate buffer back when it has run far past what it last held.
- *
- *  The engine's release rule, one definition: a buffer whose capacity has run past 4x its content
- *  gives the storage back and re-earns it, so one very wide gate cannot pin the partition's footprint
- *  for the rest of the call. `kFloor` keeps the tiny buffers alone.
- */
-template <typename Vector>
-inline auto release_if_oversized(Vector &v, size_t held) -> void {
-    constexpr size_t kFloor = 64;
-    if (v.capacity() > 4 * std::max(held, kFloor)) {
-        v = Vector{};
-    }
-}
-
 template <size_t NumModes>
 struct GateScratch {
     using PosT = typename OperatorIndex<NumModes>::PosT;
@@ -247,9 +232,9 @@ struct GateScratch {
     std::vector<EvenParityNzWord> nz; // the fold's nonzero words: Anti(G), read by the emit pass and the join
     std::vector<PosT> partner;        // one partner's positions; sized 2*NumModes, the partner's upper bound
     std::vector<uint16_t> gen;        // the generator's ascending positions, the merge's second input
-    // The gate's mints, in join order, and the records the exchange delivered. Both die with the gate,
-    // and both are here rather than on the engine so that their storage does not: a gate would otherwise
-    // pay ~12 allocations and log2(mints) reallocations for buffers the previous gate had already sized.
+    // The gate's mints, in join order, and the records the exchange delivered. Both are here because the
+    // decode and the join write them through out-parameters, NOT so that their storage outlives the gate:
+    // it does not, and release_gate_stages() below is where it goes back.
     MissStage<NumModes> misses;
     IncomingRecords<NumModes> incoming_records;
     /*
@@ -293,6 +278,23 @@ struct GateScratch {
      */
     [[nodiscard]] auto wire_queries(bool two_rounds) -> mpi::WindowVec<VecZ> & {
         return wire_q[two_rounds ? 0U : (wire_gate & 1U)];
+    }
+
+    /*! @brief Gives the two per-gate stages their storage back, at the end of the gate that filled them.
+     *
+     *  They are the one part of this scratch whose capacity must NOT survive its gate. The wire buffers
+     *  above have to (a peer may still be reading a published one), and everything else -- the join's hit
+     *  slots, `marks`, `nz` -- only ever grows to the operator's own width, so its resting figure already
+     *  is its peak. A gate's mints and the records it decoded are proportional to THAT gate's |Anti(G)|:
+     *  kept, the widest gate of the call would rest in the partition's footprint for the remainder of it,
+     *  which is 27.2 MB of ledger and 23.6 MB of kernel VmHWM on the 9.26 M-term cell at P=16 and
+     *  215.6 MiB at the 250 M-term rung. Freed, they cost the gate that follows the allocations the
+     *  engine paid when it owned them by value, and the gate stamp still prices them at their widest
+     *  instant (Engine.h stamp_gate_buffers_), which is the figure a per-gate slab would have to serve.
+     */
+    auto release_gate_stages() -> void {
+        misses = MissStage<NumModes>{};
+        incoming_records = IncomingRecords<NumModes>{};
     }
 
     [[nodiscard]] auto memory_bytes() const -> size_t {

--- a/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
+++ b/cpp/monoprop/detail/evolution/layer_build/GateScratch.h
@@ -29,6 +29,7 @@
 #include "monoprop/TypeAliases.h"
 #include "monoprop/detail/evolution/layer_build/Common.h"
 #include "monoprop/detail/evolution/layer_build/TableJoin.h"
+#include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/operator/OperatorIndex.h"
 
 namespace monoprop::detail {
@@ -183,15 +184,17 @@ struct MissStage {
 
 /*! @brief The records one exchange delivered, decoded (Resolve.h decode_incoming_records fills it).
  *
- *  Record g belongs to the sender at slot s iff goff[s] <= g < goff[s+1]; within a sender they are in
- *  the sender's stream order.
+ *  Record g belongs to the sender at window index k iff goff[k] <= g < goff[k+1]; within a sender they
+ *  are in the sender's stream order.
  */
 template <size_t NumModes>
 struct IncomingRecords {
     // The operator store's position width, not the wire's: these positions exist to become rows.
     using PosT = typename OperatorIndex<NumModes>::PosT;
 
-    std::vector<size_t> goff;           // slots+1 flat offsets: g = goff[s] + q
+    // The slots these records came from: record g belongs to window index k iff goff[k] <= g < goff[k+1].
+    mpi::SlotWindow window;
+    std::vector<size_t> goff;           // window.count+1 flat offsets: g = goff[k] + q
     DefaultInitVector<int8_t> phase_of; // g -> record phase
     DefaultInitVector<uint8_t> rot_of;  // g -> record rot bit
     DefaultInitVector<double> val_of;   // g -> record value; sized only for the Fused form
@@ -249,7 +252,10 @@ struct GateScratch {
     // pay ~12 allocations and log2(mints) reallocations for buffers the previous gate had already sized.
     MissStage<NumModes> misses;
     IncomingRecords<NumModes> incoming_records;
-    std::vector<VecZ> incoming_wire; // the collective's receive buffer, one slot per flat slot
+    mpi::WindowVec<VecZ> incoming_wire; // the collective's receive buffer, one slot per window slot
+    // Re-used span table for the stream views a decode pass reads; owns nothing, and is only ever
+    // valid while the buffer it was filled from is.
+    std::vector<std::span<const size_t>> slot_views;
     // How many records the previous gate of this partition staged for itself: what the next gate's
     // self-slot reserve is sized from (Scan.h). A hint only -- wrong in either direction it costs at most
     // a few pushes their geometric grow -- which is why it may cross gates although nothing else here does.
@@ -260,17 +266,18 @@ struct GateScratch {
     // alongside `counters`.
     size_t buffers_hwm_bytes{0uz};
 
-    //! Re-windows the collective receive buffer for a world of `slots`, under the release rule.
-    auto reuse_incoming_wire(size_t slots) -> void {
+    //! Re-windows the collective receive buffer onto `window`, under the release rule.
+    auto reuse_incoming_wire(mpi::SlotWindow window) -> void {
         for (VecZ &slot : incoming_wire) {
             release_if_oversized(slot, slot.size());
             slot.clear();
         }
-        incoming_wire.resize(slots);
+        incoming_wire.rewindow(window);
     }
 
     [[nodiscard]] auto memory_bytes() const -> size_t {
-        size_t wire = incoming_wire.capacity() * sizeof(VecZ);
+        size_t wire =
+            (incoming_wire.capacity() * sizeof(VecZ)) + (slot_views.capacity() * sizeof(std::span<const size_t>));
         for (const VecZ &slot : incoming_wire) {
             wire += slot.capacity() * sizeof(size_t);
         }

--- a/cpp/monoprop/detail/evolution/layer_build/Resolve.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Resolve.h
@@ -25,6 +25,7 @@
 #include "monoprop/detail/evolution/layer_build/PartnerMerge.h"
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
 #include "monoprop/detail/evolution/layer_build/TableJoin.h"
+#include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
 #include "monoprop/detail/operator/RowKey.h"
@@ -58,11 +59,13 @@ namespace monoprop::detail {
 // reaches the decode through it: today the collective's receive buffer, whose slots are viewed in place.
 using WireStreams = std::span<const std::span<const size_t>>;
 
-//! Views of a per-slot wire buffer's slots, ascending, into caller-owned storage.
-inline auto slot_streams(const std::vector<VecZ> &wire, std::vector<std::span<const size_t>> &into) -> WireStreams {
-    into.resize(wire.size());
-    for (size_t s = 0; s < wire.size(); ++s) {
-        into[s] = std::span<const size_t>(wire[s]);
+//! Views of a WindowVec's slots, ascending, into caller-owned storage: the collective path's adapter.
+template <typename T>
+auto slot_streams(const mpi::WindowVec<std::vector<T>> &wv, std::vector<std::span<const T>> &into)
+    -> std::span<const std::span<const T>> {
+    into.resize(wv.size());
+    for (size_t k = 0; k < wv.size(); ++k) {
+        into[k] = std::span<const T>(wv[mpi::WindowIndex{k}]);
     }
     return {into};
 }
@@ -78,10 +81,15 @@ inline auto slot_streams(const std::vector<VecZ> &wire, std::vector<std::span<co
  *  tag is folded inside the same loop, while the positions this record owns are still in cache.
  */
 template <size_t NumModes>
-auto decode_incoming_records(WireStreams incoming, QueryForm form, IncomingRecords<NumModes> &pr) -> void {
+auto decode_incoming_records(WireStreams incoming,
+                             mpi::SlotWindow window,
+                             QueryForm form,
+                             IncomingRecords<NumModes> &pr) -> void {
     using QW = QueryWire<NumModes>;
     using PosT = typename IncomingRecords<NumModes>::PosT;
-    const size_t senders = incoming.size();
+    pr.window = window;
+    const size_t senders = window.count;
+    assert(incoming.size() == senders && "one incoming stream per window slot");
 
     pr.goff.assign(senders + 1, 0);
     for (size_t s = 0; s < senders; ++s) {
@@ -307,10 +315,12 @@ auto join_incoming(const IncomingRecords<NumModes> &pr,
                    size_t base,
                    MissStage<NumModes> &misses,
                    Sink &sink,
-                   std::vector<VecZ> &responses) -> size_t {
+                   mpi::WindowVec<VecZ> &responses) -> size_t {
     size_t staged = 0;
-    for (size_t s = 0; s + 1 < pr.goff.size(); ++s) {
-        for (size_t g = pr.goff[s]; g < pr.goff[s + 1]; ++g) {
+    for (size_t k = 0; k + 1 < pr.goff.size(); ++k) {
+        const mpi::WindowIndex wi{k};
+        const size_t s = pr.window.slot(wi);
+        for (size_t g = pr.goff[k]; g < pr.goff[k + 1]; ++g) {
             const size_t row = join.hit(q_base + g);
             // The value column exists only for the fused form, and that is a property of the sink, so
             // the branch value_at() would cost per record is settled at compile time here.
@@ -330,7 +340,7 @@ auto join_incoming(const IncomingRecords<NumModes> &pr,
                                                       sink);
             if constexpr (Sink::wants_responses) {
                 if (answer) {
-                    push_response(responses[s], g - pr.goff[s], sink.silent_value(row));
+                    push_response(responses[wi], g - pr.goff[k], sink.silent_value(row));
                     ++staged;
                 }
             }
@@ -347,13 +357,16 @@ auto join_incoming(const IncomingRecords<NumModes> &pr,
  */
 template <size_t NumModes, typename Sink>
 auto apply_responses(RowMarks &marks,
-                     const std::vector<std::vector<SentRecord>> &sent,
+                     const mpi::WindowVec<std::vector<SentRecord>> &sent,
                      WireStreams responses,
+                     mpi::SlotWindow w,
                      Sink &sink) -> void {
-    assert(responses.size() == sent.size() && "one answer stream per slot");
-    for (size_t s = 0; s < responses.size(); ++s) {
-        const std::span<const size_t> buf = responses[s];
-        const std::vector<SentRecord> &records = sent[s];
+    assert(responses.size() == w.count && "one answer stream per window slot");
+    for (size_t k = 0; k < w.count; ++k) {
+        const mpi::WindowIndex wi{k};
+        const std::span<const size_t> buf = responses[k];
+        const std::vector<SentRecord> &records = sent[wi];
+        const size_t s = w.slot(wi);
         for (size_t off = 0; off + kResponseWords <= buf.size(); off += kResponseWords) {
             const size_t idx = buf[off];
             assert(idx < records.size() && "a response named a record this slot never sent to that peer");
@@ -382,18 +395,21 @@ auto apply_responses(RowMarks &marks,
  */
 template <size_t NumModes, typename Sink>
 auto absence_pass(const RowMarks &marks,
-                  const std::vector<std::vector<SentRecord>> &sent,
-                  const std::vector<std::vector<double>> &sent_c0,
+                  const mpi::WindowVec<std::vector<SentRecord>> &sent,
+                  const mpi::WindowVec<std::vector<double>> &sent_c0,
                   Sink &sink) -> void {
+    const mpi::SlotWindow w = sent.window();
     const bool has_c0 = sent_c0.size() == sent.size();
-    for (size_t s = 0; s < sent.size(); ++s) {
-        const std::vector<SentRecord> &records = sent[s];
+    for (size_t k = 0; k < w.count; ++k) {
+        const mpi::WindowIndex wi{k};
+        const size_t s = w.slot(wi);
+        const std::vector<SentRecord> &records = sent[wi];
         for (size_t j = 0; j < records.size(); ++j) {
             const size_t row = static_cast<size_t>(records[j].row);
             const int phase = static_cast<int>(records[j].phase);
             const bool received = marks.received(row);
             if (marks.rot(row) && !received && !marks.answered(row)) {
-                sink.out_unanswered(s, row, has_c0 ? sent_c0[s][j] : 0.0, phase);
+                sink.out_unanswered(s, row, has_c0 ? sent_c0[wi][j] : 0.0, phase);
             }
             else if (received && !marks.foll(row) && (marks.rot(row) || marks.partner_rot(row))) {
                 sink.out_pair(s, row, phase);

--- a/cpp/monoprop/detail/evolution/layer_build/Scan.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Scan.h
@@ -34,6 +34,7 @@
 #include "monoprop/detail/evolution/layer_build/PartnerMerge.h"
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
 #include "monoprop/detail/graph_encoding/MPGraphEncodingTypes.h"
+#include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
 #include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/InvertedIndex.h"
@@ -236,19 +237,24 @@ template <size_t NumModes, Algebra A, typename PosT, typename GenT>
 template <size_t NumModes>
 struct FusedScanResult {
     std::vector<CosMask> cos_blocks; // ascending, disjoint, chunk order
+    // The per-slot arrays below are indexed by DESTINATION SLOT through WindowVec::at_slot, and cover
+    // only the slots THIS generator can reach: one rank's partitions under linear routing, the whole
+    // world under splitmix. See mpi::PeerPlan::window.
+    mpi::SlotWindow window;
     // The wire records (QueryWire.h) per destination slot, in stream order = ascending source row. Fused
     // (value word after each record) iff capture_values.
-    std::vector<VecZ> queries;
+    mpi::WindowVec<VecZ> queries;
     // Per destination slot, the SOURCE row and emit phase of each record, parallel to the records of that
     // slot (the self slot's parallel to `self`). Ascending in row, because the scan walks rows ascending:
     // the absence pass and the graph sink's out lists rely on that order.
-    std::vector<std::vector<SentRecord>> sent;
+    mpi::WindowVec<std::vector<SentRecord>> sent;
     // Parallel to `sent`: the pre-gate coefficient the partner would be minted with (Schrodinger: the
     // state score of a fully paired partner, else 0). Only filled when a state mask is given, i.e. for
     // the fused Schrodinger picture; read by the absence pass alone.
-    std::vector<std::vector<double>> sent_c0;
-    // Records addressed to this slot itself, staged as positions instead of encoded into the wire's self
-    // slot, and joined inline.
+    mpi::WindowVec<std::vector<double>> sent_c0;
+    // Records addressed to this slot itself, staged as positions instead of encoded into the window's
+    // self slot, and joined inline. Empty unless the window contains my_rank, i.e. unless this
+    // generator's rank shift is zero.
     SelfQueryStage<NumModes> self;
 };
 
@@ -284,6 +290,7 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
                             const VecD &coeffs,
                             std::optional<size_t> only_rotate_len_k,
                             bool over_cutoff_possible,
+                            mpi::SlotWindow window,
                             size_t my_rank,
                             const routing::Router &router,
                             GateScratch<NumModes> &scratch,
@@ -299,13 +306,15 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
     // ContractSink::wants_responses), and so the path whose send predicate is E(M) alone.
     constexpr bool kAnswerSilentHits = CaptureValues;
 
+    assert(window.stop() <= rank_count && window.count != 0);
     FusedScanResult<NumModes> res;
-    res.queries.assign(rank_count, VecZ{});
-    res.sent.assign(rank_count, std::vector<SentRecord>{});
+    res.window = window;
+    res.queries.reset(window);
+    res.sent.reset(window);
     res.self.keeps_values = CaptureValues;
     // Sized on the early-return paths below too, so the engine's per-slot access is always in bounds.
     if (state_mask != nullptr) {
-        res.sent_c0.assign(rank_count, std::vector<double>{});
+        res.sent_c0.reset(window);
     }
     // No anticommuting words on an early return: nothing is sent, so the per-row marks stay untouched.
     scratch.nz.clear();
@@ -410,15 +419,17 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
                 res.self.push(pos, phase, tag_partner, rot, v_src);
             }
             else {
-                VecZ &buf = res.queries[r_prime];
+                // at_slot is the only re-basing door and asserts membership: a destination outside this
+                // generator's window means the shift is wrong, and would otherwise land on another peer.
+                VecZ &buf = res.queries.at_slot(r_prime);
                 QueryWire<NumModes>::push(buf, pos, phase, rot);
                 if constexpr (CaptureValues) {
                     QueryWire<NumModes>::push_value(buf, v_src);
                 }
             }
-            res.sent[r_prime].push_back(SentRecord{static_cast<TermIndex>(row), static_cast<int8_t>(phase)});
+            res.sent.at_slot(r_prime).push_back(SentRecord{static_cast<TermIndex>(row), static_cast<int8_t>(phase)});
             if (mask != nullptr) {
-                res.sent_c0[r_prime].push_back(c0);
+                res.sent_c0.at_slot(r_prime).push_back(c0);
             }
         };
 
@@ -552,11 +563,14 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
         // propagate. The previous gate's emitted count with a margin is a good enough estimate to leave
         // one allocation, is capped by the fold's own bound, and when it falls short push() doubles as it
         // always has.
-        if (rank_count == 1) {
+        // Whenever the window holds this slot -- every gate at one rank, and the zero-shift gates of a
+        // multi-rank run -- not only when the world is one slot: at R > 1 roughly one gate in R has a
+        // zero shift, and those staged their whole self side from an empty vector.
+        if (window.contains(my_rank)) {
             const size_t hint = scratch.self_records_hint;
             const size_t want = std::min(n_anti, std::max(kSelfReserveFloor, hint + (hint / 4)));
             res.self.reserve(want, QueryWire<NumModes>::kReservePositionsPerQuery);
-            res.sent[my_rank].reserve(want);
+            res.sent.at_slot(my_rank).reserve(want);
         }
 
         // Everything the per-row loops read on every anticommuting row, hoisted out of them: through a

--- a/cpp/monoprop/detail/evolution/layer_build/Scan.h
+++ b/cpp/monoprop/detail/evolution/layer_build/Scan.h
@@ -309,7 +309,13 @@ auto fused_find_and_collect(const MPOperator<NumModes> &op,
     assert(window.stop() <= rank_count && window.count != 0);
     FusedScanResult<NumModes> res;
     res.window = window;
-    res.queries.reset(window);
+    // The round-1 buffer comes out of the scratch and goes back in exchange_and_join: it must outlive
+    // the gate (PairExchange.h), and taking it here is also what keeps the last gate's slot storage
+    // instead of allocating one vector per slot afresh. reuse_wire applies the release rule on the way
+    // in. `CaptureValues` selects the fused sink downstream, which is exactly the sink that answers, so
+    // it is also the flag that says whether the round-1 buffer needs a twin (GateScratch).
+    res.queries = std::move(scratch.wire_queries(CaptureValues));
+    reuse_wire(res.queries, window);
     res.sent.reset(window);
     res.self.keeps_values = CaptureValues;
     // Sized on the early-return paths below too, so the engine's per-slot access is always in bounds.

--- a/cpp/monoprop/detail/mpi/Comm.h
+++ b/cpp/monoprop/detail/mpi/Comm.h
@@ -103,6 +103,51 @@ struct SlotWindow {
 };
 
 /*!
+ * @brief A vector over a SlotWindow, addressed by flat slot through at_slot().
+ *
+ * `operator[]` takes a WindowIndex, so a flat slot used as a raw index does not compile. Re-basing an
+ * array is only safe if every index site shifts together, and these two accessors are the only sites.
+ */
+template <typename T>
+class WindowVec {
+public:
+    using value_type = T;
+
+    WindowVec() = default;
+    explicit WindowVec(SlotWindow w) : win_(w), v_(w.count) {}
+
+    auto reset(SlotWindow w) -> void {
+        win_ = w;
+        v_.assign(w.count, T{});
+    }
+
+    //! @brief Re-bases onto @a w keeping the elements: for a T that owns storage the caller reuses,
+    //! having cleared each element under its own release rule first.
+    auto rewindow(SlotWindow w) -> void {
+        win_ = w;
+        v_.resize(w.count);
+    }
+
+    [[nodiscard]] auto window() const -> SlotWindow { return win_; }
+    [[nodiscard]] auto size() const -> size_t { return v_.size(); }
+    [[nodiscard]] auto capacity() const -> size_t { return v_.capacity(); }
+
+    [[nodiscard]] auto operator[](WindowIndex i) -> T & { return v_[i.value]; }
+    [[nodiscard]] auto operator[](WindowIndex i) const -> const T & { return v_[i.value]; }
+    [[nodiscard]] auto at_slot(size_t slot) -> T & { return v_[win_.index(slot).value]; }
+    [[nodiscard]] auto at_slot(size_t slot) const -> const T & { return v_[win_.index(slot).value]; }
+
+    [[nodiscard]] auto begin() { return v_.begin(); }
+    [[nodiscard]] auto end() { return v_.end(); }
+    [[nodiscard]] auto begin() const { return v_.begin(); }
+    [[nodiscard]] auto end() const { return v_.end(); }
+
+private:
+    SlotWindow win_{};
+    std::vector<T> v_;
+};
+
+/*!
  * @brief Which destination RANKS a round can touch, when the caller knows.
  *
  * Two states, matching routing::Router: dense, or sparse over the single peer GF(2)-linear routing

--- a/cpp/monoprop/detail/mpi/HybridComm.h
+++ b/cpp/monoprop/detail/mpi/HybridComm.h
@@ -22,8 +22,10 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <format>
 #include <optional>
 #include <print>
+#include <span>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
@@ -33,6 +35,8 @@
 #include "monoprop/detail/mpi/CheckedCount.h"
 #include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/HybridStaging.h"
+#include "monoprop/detail/mpi/PairSlots.h"
+#include "monoprop/detail/mpi/Pairwise.h"
 #include "monoprop/detail/mpi/PartitionBarrier.h"
 
 // Composes R MPI ranks x S in-process partitions into one flat P=R*S SPMD world. Global id is rank-major
@@ -59,6 +63,7 @@ public:
         : parent_(parent),
           s_(n_local_partitions),
           slots_(static_cast<size_t>(n_local_partitions)),
+          pair_(n_local_partitions),
           barrier_(n_local_partitions) {
         MPI_Comm_size(parent_, &r_);
         MPI_Comm_rank(parent_, &mpi_rank_);
@@ -70,6 +75,11 @@ public:
                                             "mpi::init / mpi4py requests SERIALIZED or MULTIPLE.");
         }
         staging_.emplace(parent_, mpi_rank_, r_, s_);
+        const size_t ss = static_cast<size_t>(s_) * static_cast<size_t>(s_);
+        pair_hdr_send_.resize(ss);
+        pair_row_start_.resize(static_cast<size_t>(s_));
+        pair_blocklens_.reserve(ss + 1);
+        pair_displs_.reserve(ss + 1);
     }
 
     HybridComm(const HybridComm &) = delete;
@@ -84,11 +94,18 @@ public:
      *
      *  Diagnostic only. The two payload buffers are sized to the widest message the run has needed and
      *  never shrink, so on a run whose widest gate came early they are resident for the whole of it
-     *  while nothing resting names them. One HybridComm serves all S partitions of a rank, so this is
-     *  a per-RANK figure: a caller summing over partitions must ask exactly one of them.
+     *  while nothing resting names them. `pair_recv_` is the one pair_exchange fills: it sends in place
+     *  through a derived datatype, so it has no send-side staging at all. One HybridComm serves all S
+     *  partitions of a rank, so this is a per-RANK figure: a caller summing over partitions must ask
+     *  exactly one of them.
      */
     [[nodiscard]] auto staging_bytes() const -> size_t {
-        return staging_->bytes() + slots_.capacity() * sizeof(Slot) + red_vec_.capacity() * sizeof(double);
+        const auto cap = [](const auto &v) {
+            return v.capacity() * sizeof(typename std::decay_t<decltype(v)>::value_type);
+        };
+        return staging_->bytes() + slots_.capacity() * sizeof(Slot) + cap(red_vec_) + cap(pair_recv_)
+               + cap(pair_hdr_send_) + cap(pair_blocklens_) + cap(pair_displs_) + cap(pair_row_start_)
+               + pair_.staging_bytes();
     }
 
     auto alltoall_counts(int local_partition,
@@ -135,6 +152,13 @@ public:
     auto allreduce_sum(int local_partition, T local_val) -> T {
         return guard_partition0_(local_partition, "allreduce_sum", [this, local_partition, local_val] {
             return allreduce_sum_impl_<T>(local_partition, local_val);
+        });
+    }
+
+    //! @brief The gate exchange; PairExchange.h states the contract. Partition 0 alone reaches MPI.
+    auto pair_exchange(int local_partition, int rank_shift, SubStreams send) -> PairRecv {
+        return guard_partition0_(local_partition, "pair_exchange", [this, local_partition, rank_shift, send] {
+            return pair_exchange_impl_(local_partition, rank_shift, send);
         });
     }
 
@@ -394,6 +418,113 @@ private:
         // No trailing barrier: red_vec_ is rewritten only inside a future verb's barriered phases.
     }
 
+    /*! @brief The gate exchange's barrier discipline. Arguments are the verb's to validate
+     *  (PairExchange.h), before any barrier; here they are asserted.
+     */
+    auto pair_exchange_impl_(int local_partition, int rank_shift, SubStreams send) -> PairRecv {
+        assert(static_cast<int>(send.size()) == s_);
+        assert(rank_shift >= 0 && (mpi_rank_ ^ rank_shift) < r_);
+        pair_.publish(local_partition, send);
+        if (rank_shift == 0) {
+            sync(); // B1: descriptors published; the gather reads peers' buffers in place (PairExchange.h)
+            return pair_.gather_in_rank(local_partition);
+        }
+        sync(); // B1: every partition's descriptors are published
+        if (local_partition == 0) {
+            pair_exchange_with_rank_(mpi_rank_ ^ rank_shift);
+        }
+        sync(); // B2: pair_recv_ holds the peer rank's header and payload, pair_row_start_ its row starts
+        return pair_views_(local_partition);
+    }
+
+    /*! @brief Partition 0's one message each way, between B1 and B2.
+     *
+     *  The outgoing message is one hindexed datatype over absolute addresses: block 0 is the S*S
+     *  word-count header, then the (t, u) sub-streams destination-major so that each receiving
+     *  partition's run is contiguous; empty blocks are left out and the header carries their zero. The
+     *  incoming message is sized by probing it -- its header is inside it -- and lands in one contiguous
+     *  buffer, so neither side stages a byte. Isend before the blocking probe: both ranks do the same, so
+     *  neither waits on a send the other has not posted.
+     */
+    auto pair_exchange_with_rank_(int peer) -> void {
+        const size_t ss = static_cast<size_t>(s_) * static_cast<size_t>(s_);
+        pair_blocklens_.clear();
+        pair_displs_.clear();
+        MPI_Aint addr = 0;
+        MPI_Get_address(pair_hdr_send_.data(), &addr);
+        pair_blocklens_.push_back(checked_mpi_count(static_cast<long long>(ss), "Pair header length"));
+        pair_displs_.push_back(addr);
+        for (int t = 0; t < s_; ++t) {
+            for (int u = 0; u < s_; ++u) {
+                const std::span<const size_t> sp = pair_.stream(/*reader=*/0, u, t);
+                pair_hdr_send_[static_cast<size_t>(t) * static_cast<size_t>(s_) + static_cast<size_t>(u)] = sp.size();
+                if (sp.empty()) {
+                    continue;
+                }
+                MPI_Get_address(sp.data(), &addr);
+                pair_blocklens_.push_back(
+                    checked_mpi_count(static_cast<long long>(sp.size()), "Pair sub-stream length"));
+                pair_displs_.push_back(addr);
+            }
+        }
+        MPI_Datatype dt = MPI_DATATYPE_NULL;
+        MPI_Type_create_hindexed(static_cast<int>(pair_blocklens_.size()),
+                                 pair_blocklens_.data(),
+                                 pair_displs_.data(),
+                                 MPI_UINT64_T,
+                                 &dt);
+        MPI_Type_commit(&dt);
+        MPI_Request req = MPI_REQUEST_NULL;
+        MPI_Isend(MPI_BOTTOM, 1, dt, peer, kPairExchangeTag, parent_, &req);
+
+        MPI_Message msg = MPI_MESSAGE_NULL;
+        MPI_Status status;
+        MPI_Mprobe(peer, kPairExchangeTag, parent_, &msg, &status);
+        int total = 0;
+        MPI_Get_count(&status, MPI_UINT64_T, &total);
+        // Classic counts: a rank pair's gate payload above INT_MAX words is out of range and aborts here.
+        if (total == MPI_UNDEFINED || static_cast<size_t>(total) < ss) {
+            throw std::runtime_error(std::format("pair_exchange: peer rank {} sent {} words, below the {}-word header "
+                                                 "or beyond the MPI count range",
+                                                 peer,
+                                                 total,
+                                                 ss));
+        }
+        grow_to(pair_recv_, static_cast<size_t>(total)); // never shrunk: views into it outlive this gate
+        MPI_Mrecv(pair_recv_.data(), total, MPI_UINT64_T, &msg, MPI_STATUS_IGNORE);
+        MPI_Wait(&req, MPI_STATUS_IGNORE);
+        MPI_Type_free(&dt);
+
+        // S*S serial adds here so that each partition's gather past B2 walks only its own S counts.
+        size_t off = ss;
+        for (int t = 0; t < s_; ++t) {
+            pair_row_start_[static_cast<size_t>(t)] = off;
+            for (int u = 0; u < s_; ++u) {
+                off += pair_recv_[static_cast<size_t>(t) * static_cast<size_t>(s_) + static_cast<size_t>(u)];
+            }
+        }
+        if (off != static_cast<size_t>(total)) {
+            throw std::runtime_error(
+                std::format("pair_exchange: peer rank {}'s header sums to {} words but its message holds {}",
+                            peer,
+                            off,
+                            total));
+        }
+    }
+
+    //! @brief Past B2: partition t's views into pair_recv_, one per source partition ascending.
+    auto pair_views_(int local_partition) -> PairRecv {
+        const size_t t = static_cast<size_t>(local_partition);
+        auto row = pair_.from_row(local_partition);
+        const size_t *counts = pair_recv_.data() + t * static_cast<size_t>(s_);
+        size_t off = pair_row_start_[t];
+        for (int u = 0; u < s_; ++u) {
+            row[static_cast<size_t>(u)] = std::span<const size_t>(pair_recv_.data() + off, counts[u]);
+            off += counts[u];
+        }
+        return PairRecv{row};
+    }
+
     [[noreturn]] auto abort_rank_(const char *verb, const char *what) -> void {
         std::print(stderr,
                    "monoprop: rank {} cannot complete the collective '{}' ({}). Its peer ranks are "
@@ -420,6 +551,15 @@ private:
     std::vector<double> red_vec_;
     // alltoallv's wire plan, partition 0 only: written in B1->B2, read in B3->B4. See derived_wire_plan.
     PeerPlan wire_plan_;
+
+    // pair_exchange. The descriptor table has per-partition rows (see PairSlots); the rest is partition
+    // 0's alone, written between B1 and B2 and read by every partition past B2.
+    PairSlots pair_;
+    std::vector<size_t> pair_hdr_send_; // [S*S] (t, u) word counts: the outgoing message's leading block
+    std::vector<int> pair_blocklens_;   // hindexed block list scratch, S*S + 1 at most
+    std::vector<MPI_Aint> pair_displs_;
+    std::vector<size_t> pair_recv_;      // [S*S header][payload, (t, u)-major]; HWM-sized, views alias it
+    std::vector<size_t> pair_row_start_; // [S] word offset of partition t's run in pair_recv_
 
     PartitionBarrier barrier_;
 };

--- a/cpp/monoprop/detail/mpi/MPICompat.h
+++ b/cpp/monoprop/detail/mpi/MPICompat.h
@@ -148,6 +148,49 @@ inline auto staging_bytes(Comm comm) -> size_t {
 monoprop_EXPORT auto alltoall_counts(const int *send_counts, int *recv_counts, int n, Comm comm, PeerPlan plan = {})
     -> void;
 
+// The per-slot block arrays begin_alltoallv and wait_into accept: a plain [P] vector-of-vectors, or a
+// WindowVec over the slots a PeerPlan can reach. These four overload pairs are the whole difference --
+// the verbs below are one code path walking one SlotWindow.
+template <typename Blocks>
+using SlotBlockValue = typename Blocks::value_type::value_type;
+
+template <typename T>
+inline auto slot_window_of(const std::vector<std::vector<T>> &v) -> SlotWindow {
+    return SlotWindow{.base = 0, .count = v.size()};
+}
+template <typename T>
+inline auto slot_window_of(const WindowVec<std::vector<T>> &v) -> SlotWindow {
+    return v.window();
+}
+
+template <typename T>
+inline auto slot_block(const std::vector<std::vector<T>> &v, size_t slot) -> const std::vector<T> & {
+    return v[slot];
+}
+template <typename T>
+inline auto slot_block(std::vector<std::vector<T>> &v, size_t slot) -> std::vector<T> & {
+    return v[slot];
+}
+template <typename T>
+inline auto slot_block(const WindowVec<std::vector<T>> &v, size_t slot) -> const std::vector<T> & {
+    return v.at_slot(slot);
+}
+template <typename T>
+inline auto slot_block(WindowVec<std::vector<T>> &v, size_t slot) -> std::vector<T> & {
+    return v.at_slot(slot);
+}
+
+// A plain destination keeps the full-world shape (a non-peer's block is empty, not absent); a WindowVec
+// takes the round's window.
+template <typename T>
+inline auto reset_slots(std::vector<std::vector<T>> &v, SlotWindow /*w*/, size_t world) -> void {
+    v.assign(world, std::vector<T>{});
+}
+template <typename T>
+inline auto reset_slots(WindowVec<std::vector<T>> &v, SlotWindow w, size_t /*world*/) -> void {
+    v.reset(w);
+}
+
 // In-flight variable-size all-to-all owning its buffers + layout, so several can be in flight.
 // recv_counts is valid on return from begin_alltoallv; wait_into completes the payload transfer (a
 // no-op on the synchronous Shm / single-process paths) and unpacks by source.
@@ -169,7 +212,8 @@ struct PendingAlltoallv {
                                             // and both move with the handle, so the pointers hold
 #endif
 
-    auto wait_into(std::vector<std::vector<T>> &recv_data) -> void {
+    template <typename Dest>
+    auto wait_into(Dest &recv_data) -> void {
 #ifdef monoprop_ENABLE_MPI
         if (request != MPI_REQUEST_NULL) {
             MPI_Wait(&request, MPI_STATUS_IGNORE);
@@ -180,24 +224,24 @@ struct PendingAlltoallv {
             posted = 0;
         }
 #endif
-        // Full-world shape whatever the window was: a non-peer's block is empty, not absent.
-        recv_data.assign(static_cast<size_t>(num_ranks), std::vector<T>{});
+        reset_slots(recv_data, window, static_cast<size_t>(num_ranks));
         for (size_t k = 0; k < window.count; ++k) {
             const size_t i = window.slot(WindowIndex{k});
             const auto lo = recv_buffer.begin() + recv_displs[i];
-            recv_data[i].assign(lo, lo + recv_counts[i]);
+            slot_block(recv_data, i).assign(lo, lo + recv_counts[i]);
         }
     }
 };
 
-// Debug-only: a caller may supply the whole [P] array under a sparse plan, and anything it left outside
-// the window is DROPPED rather than refused -- the silent failure mode a wrong-but-agreed shift produces.
-template <typename T>
-inline auto assert_outside_window_is_empty_([[maybe_unused]] const std::vector<std::vector<T>> &send_data,
+// Debug-only: a caller may supply more slots than the plan reaches, and anything it left outside the
+// window is DROPPED rather than refused -- the silent failure mode a wrong-but-agreed shift produces.
+template <typename Blocks>
+inline auto assert_outside_window_is_empty_([[maybe_unused]] const Blocks &send_data,
+                                            [[maybe_unused]] SlotWindow supplied,
                                             [[maybe_unused]] SlotWindow window) -> void {
 #ifndef NDEBUG
-    for (size_t i = 0; i < send_data.size(); ++i) {
-        assert((window.contains(i) || send_data[i].empty())
+    for (size_t i = supplied.base; i < supplied.stop(); ++i) {
+        assert((window.contains(i) || slot_block(send_data, i).empty())
                && "a block outside the plan's peer window would be dropped in silence");
     }
 #endif
@@ -208,8 +252,8 @@ inline auto assert_outside_window_is_empty_([[maybe_unused]] const std::vector<s
 // skip_self: do not send the self slot (the caller handles self inline) — self send/recv = 0.
 // known_recv_counts: recv counts already known (e.g. the transpose of the query counts), so skip the
 // count exchange. The self slot is also zeroed when skip_self is set.
-template <typename T>
-inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
+template <typename Blocks, typename T = SlotBlockValue<Blocks>>
+inline auto begin_alltoallv(const Blocks &send_data,
                             Comm comm,
                             bool skip_self = false,
                             const std::vector<int> *known_recv_counts = nullptr,
@@ -217,21 +261,27 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
     const int num_ranks = size(comm);
     const int me = rank(comm);
     const auto geom = geometry(comm);
-    if (static_cast<int>(send_data.size()) != num_ranks) {
-        throw CollectiveArgumentError(
-            std::format("begin_alltoallv: send_data size ({}) must equal number of ranks ({})",
-                        send_data.size(),
-                        num_ranks));
-    }
     PendingAlltoallv<T> h;
     h.num_ranks = num_ranks;
-    // The plan IS the mask, dense included -- it is the count == P value of the same window. The caller
-    // still hands a whole [P] array; assert_outside_window_is_empty_ catches what it leaves outside,
-    // which is the silent drop a wrong-but-agreed shift produces.
+    // The plan IS the mask, dense included -- it is the count == P value of the same window. A caller may
+    // hand a whole [P] array under a sparse plan (the tests do), so the supplied array only has to COVER
+    // the window; assert_outside_window_is_empty_ catches what it leaves outside, which is the silent
+    // drop a wrong-but-agreed shift produces.
     h.window =
         plan.window(static_cast<size_t>(me), static_cast<size_t>(geom.ranks), static_cast<size_t>(geom.partitions));
-    assert(h.window.stop() <= static_cast<size_t>(num_ranks));
-    assert_outside_window_is_empty_(send_data, h.window);
+    const SlotWindow supplied = slot_window_of(send_data);
+    if (h.window.stop() > static_cast<size_t>(num_ranks) || supplied.base > h.window.base
+        || supplied.stop() < h.window.stop()) {
+        throw CollectiveArgumentError(
+            std::format("begin_alltoallv: send_data covers slots [{}, {}), which does not cover the plan's "
+                        "[{}, {}) in a {}-slot world",
+                        supplied.base,
+                        supplied.stop(),
+                        h.window.base,
+                        h.window.stop(),
+                        num_ranks));
+    }
+    assert_outside_window_is_empty_(send_data, supplied, h.window);
     h.send_counts.assign(static_cast<size_t>(num_ranks), 0);
     h.send_displs.assign(static_cast<size_t>(num_ranks), 0);
     h.recv_displs.assign(static_cast<size_t>(num_ranks), 0);
@@ -243,7 +293,7 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
     long long running_send = 0;
     for (size_t k = 0; k < h.window.count; ++k) {
         const size_t i = h.window.slot(WindowIndex{k});
-        const size_t n = (static_cast<int>(i) == self) ? 0 : send_data[i].size();
+        const size_t n = (static_cast<int>(i) == self) ? 0 : slot_block(send_data, i).size();
         const int c = checked_mpi_count(n, "Send count");
         h.send_counts[i] = c;
         h.send_displs[i] = checked_mpi_count(running_send, "Send displacement");
@@ -256,7 +306,8 @@ inline auto begin_alltoallv(const std::vector<std::vector<T>> &send_data,
         if (c == 0) {
             continue;
         }
-        std::copy(send_data[i].begin(), send_data[i].begin() + c, h.send_buffer.begin() + h.send_displs[i]);
+        const auto &block = slot_block(send_data, i);
+        std::copy(block.begin(), block.begin() + c, h.send_buffer.begin() + h.send_displs[i]);
     }
 
     h.recv_counts.assign(static_cast<size_t>(num_ranks), 0);

--- a/cpp/monoprop/detail/mpi/PairExchange.h
+++ b/cpp/monoprop/detail/mpi/PairExchange.h
@@ -1,0 +1,181 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <span>
+#include <vector>
+
+#include "monoprop/detail/mpi/CheckedCount.h"
+#include "monoprop/detail/mpi/Comm.h"
+#include "monoprop/detail/mpi/PairSlots.h"
+#include "monoprop/detail/mpi/ShmComm.h"
+#ifdef monoprop_ENABLE_MPI
+#include <mpi.h>
+
+#include "monoprop/detail/mpi/HybridComm.h"
+#include "monoprop/detail/mpi/Pairwise.h"
+#endif
+
+/*!
+ * @file
+ * @brief pair_exchange: the one-round symmetric gate exchange, over every transport.
+ *
+ * Called by EVERY participant of `comm` -- every partition master of every rank -- once per gate, in
+ * program order, with the same rank-replicated `rank_shift`. Peer rank = my_rank ^ rank_shift, and
+ * shift 0 keeps the exchange inside the rank and touches no MPI. Sub-stream (rank r, partition u) ->
+ * (rank r ^ shift, partition t) for every u, t; `from[u]` is ascending in u, which the caller's index
+ * assignment depends on. Keeps `#ifdef monoprop_ENABLE_MPI` out of the consumers: a non-MPI build has
+ * the in-rank transports and a size-1 raw communicator. The cost per gate and the derivation of the
+ * deferred second barrier are in docs/content/docs/features/parallelism.mdx.
+ *
+ * Arguments are validated before any barrier and throw CollectiveArgumentError; they are replicated, so
+ * every participant throws or none does and nobody is left waiting. A failure past a HybridComm's first
+ * barrier aborts the job, as every verb there does: the peer rank is committed inside MPI.
+ *
+ * @warning The buffer lifetime rule, the same on every transport so a caller need not know which it
+ * holds:
+ * 1. The memory behind the S `send` spans must stay valid and unmodified until this participant's NEXT
+ *    pair_exchange on the same comm RETURNS -- peers read it in place after this call returned, and the
+ *    next gate's barrier is the first point that proves they are done. A caller therefore alternates two
+ *    sets of send buffers gate by gate. The outer array of descriptors is copied before the barrier and
+ *    may be reused on return.
+ * 2. A participant's LAST gate on a comm has no next call to bound it: that set stays alive until every
+ *    participant has consumed its views, which any later collective on the same comm, or joining the
+ *    partitions, proves.
+ * 3. The `from` views are valid until this participant's next pair_exchange on the same comm is ENTERED.
+ *    In-rank they alias peers' send buffers, which rule 1 frees once every partition has entered the
+ *    next gate; across ranks they alias the rank master's receive buffer, which the next cross-rank gate
+ *    overwrites after its first barrier -- grown, never shrunk, so no gate can shrink a view still being
+ *    read.
+ * 4. The `Kind::Mpi` receive state is per thread, not per comm: one participant per process is what that
+ *    kind means, and rule 3 then also covers a next call on a different raw communicator.
+ */
+
+namespace monoprop::mpi {
+
+namespace detail {
+
+// A single-partition rank cannot address a sibling, so `send` has one sub-stream and `from` one view.
+inline constexpr size_t kMpiKindStreams = 1;
+
+/*!
+ * @brief The raw-communicator receive side. Grown and never shrunk (rule 3 of the file's lifetime
+ * warning), and reached through a function-local thread_local so there is one instance per thread
+ * across translation units.
+ */
+struct MpiPairState {
+    std::vector<size_t> recv;                                    //!< the peer's sub-stream, HWM-sized
+    std::array<std::span<const size_t>, kMpiKindStreams> from{}; //!< the one view handed back
+};
+
+inline auto mpi_pair_state() -> MpiPairState & {
+    static thread_local MpiPairState state;
+    return state;
+}
+
+inline auto check_pair_args(const Comm &comm, int rank_shift, SubStreams send, int partitions, int ranks) -> void {
+    if (static_cast<int>(send.size()) != partitions) {
+        throw CollectiveArgumentError(
+            std::format("pair_exchange: {} sub-streams for a rank of {} partitions", send.size(), partitions));
+    }
+    // The XOR pairing is an involution only over a power-of-two world; there every shift below `ranks`
+    // names a peer below `ranks`. Both conditions are rank-replicated, so no rank can throw alone.
+    if (rank_shift < 0 || rank_shift >= ranks || (rank_shift != 0 && (ranks & (ranks - 1)) != 0)) {
+        throw CollectiveArgumentError(
+            std::format("pair_exchange: rank_shift {} does not name a peer in a {}-rank world (kind {})",
+                        rank_shift,
+                        ranks,
+                        static_cast<int>(comm.kind)));
+    }
+}
+
+#ifdef monoprop_ENABLE_MPI
+// One participant per process: one message each way, the receive sized by probing. Zero words is still
+// a message, so both ends always post one and a silent side cannot desynchronise the pair.
+inline auto mpi_kind_exchange(MPI_Comm comm, int peer, std::span<const size_t> mine) -> std::span<const size_t> {
+    MpiPairState &st = mpi_pair_state();
+    MPI_Request req = MPI_REQUEST_NULL;
+    MPI_Isend(mine.data(),
+              checked_mpi_count(static_cast<long long>(mine.size()), "Pair sub-stream length"),
+              MPI_UINT64_T,
+              peer,
+              kPairExchangeTag,
+              comm,
+              &req);
+    MPI_Message msg = MPI_MESSAGE_NULL;
+    MPI_Status status;
+    MPI_Mprobe(peer, kPairExchangeTag, comm, &msg, &status);
+    int total = 0;
+    MPI_Get_count(&status, MPI_UINT64_T, &total);
+    if (total == MPI_UNDEFINED) {
+        throw CollectiveArgumentError("pair_exchange: the peer's sub-stream exceeds the MPI count range");
+    }
+    if (st.recv.size() < static_cast<size_t>(total)) {
+        st.recv.resize(static_cast<size_t>(total));
+    }
+    MPI_Mrecv(st.recv.data(), total, MPI_UINT64_T, &msg, MPI_STATUS_IGNORE);
+    MPI_Wait(&req, MPI_STATUS_IGNORE);
+    return {st.recv.data(), static_cast<size_t>(total)};
+}
+#endif
+
+} // namespace detail
+
+/*!
+ * @brief The one-round gate exchange; the contract is this file's @brief and lifetime warning.
+ *
+ * Dispatches on the comm kind: the in-rank transports gather in place after one barrier, HybridComm adds the cross-rank
+ * message when `rank_shift` != 0, a raw communicator is the S == 1 case of the same protocol.
+ */
+inline auto pair_exchange(Comm comm, int rank_shift, SubStreams send) -> PairRecv {
+    static_assert(sizeof(size_t) == sizeof(uint64_t), "pair_exchange sends words as MPI_UINT64_T");
+    switch (comm.kind) {
+        case Comm::Kind::Shm:
+            detail::check_pair_args(comm, rank_shift, send, comm.shm->size(), /*ranks=*/1);
+            return comm.shm->pair_exchange(comm.shm_rank, send);
+        case Comm::Kind::Hybrid:
+#ifdef monoprop_ENABLE_MPI
+            detail::check_pair_args(comm, rank_shift, send, comm.hyb->partitions(), comm.hyb->ranks());
+            return comm.hyb->pair_exchange(comm.shm_rank, rank_shift, send);
+#else
+            throw CollectiveArgumentError("pair_exchange: a Hybrid comm in a build without MPI");
+#endif
+        case Comm::Kind::Mpi:
+            break;
+    }
+    detail::MpiPairState &st = detail::mpi_pair_state();
+#ifdef monoprop_ENABLE_MPI
+    int ranks = 1;
+    int me = 0;
+    MPI_Comm_size(comm.mpi, &ranks);
+    MPI_Comm_rank(comm.mpi, &me);
+    detail::check_pair_args(comm, rank_shift, send, static_cast<int>(detail::kMpiKindStreams), ranks);
+    if (rank_shift != 0) {
+        st.from[0] = detail::mpi_kind_exchange(comm.mpi, me ^ rank_shift, send[0]);
+        return PairRecv{st.from};
+    }
+#else
+    detail::check_pair_args(comm, rank_shift, send, static_cast<int>(detail::kMpiKindStreams), /*ranks=*/1);
+#endif
+    // The self peer: a view of the caller's own sub-stream, under the same lifetime rule as in-rank.
+    st.from[0] = send[0];
+    return PairRecv{st.from};
+}
+
+} // namespace monoprop::mpi

--- a/cpp/monoprop/detail/mpi/PairSlots.h
+++ b/cpp/monoprop/detail/mpi/PairSlots.h
@@ -1,0 +1,175 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+// The pair_exchange vocabulary and its in-rank descriptor table. Apart from PairExchange.h because
+// ShmComm.h and HybridComm.h own an instance each, and the verb's header includes both of them.
+
+namespace monoprop::mpi {
+
+/*!
+ * @brief One partition's outgoing records for a gate: sub-stream `t` is destined for partition `t` of the peer
+ * rank. Exactly S entries, empty ones included. Under flat-linear routing all but one are empty; the verb
+ * does not care which.
+ */
+using SubStreams = std::span<const std::span<const size_t>>;
+
+/*!
+ * @brief What one partition receives from a gate exchange. Ascending source order is part of the contract: the
+ * caller's index assignment depends on it. The views alias memory the verb does not own for the caller --
+ * a peer's send buffer in-rank, the rank master's receive buffer across ranks -- and are valid until this
+ * participant's next pair_exchange on the same comm. PairExchange.h states the full lifetime rule.
+ */
+struct PairRecv {
+    std::span<const std::span<const size_t>> from; //!< `from[u]`: from partition u of the peer rank, u ascending
+};
+
+/*!
+ * @brief The in-rank half of pair_exchange, shared by ShmComm and HybridComm: each of S partitions publishes
+ * its S span descriptors, and after the owner's barrier every partition gathers its own column, or the
+ * rank master reads the whole table. Holds no barrier and no payload: the descriptors alias the callers'
+ * buffers, which is what makes the in-rank exchange copy-free.
+ *
+ * Descriptors are double-buffered by call parity because an in-rank gate takes ONE barrier: a partition
+ * that has passed gate g's barrier may publish gate g+1 while a slower peer is still gathering gate g.
+ * Parity puts the two gates in disjoint lines, and gate g+2 cannot reuse gate g's lines before the slow
+ * peer has passed gate g+1's barrier -- which it reaches only after its gather of gate g returned. Every
+ * participant makes every call, so the per-partition counters agree at each barrier.
+ *
+ * Each partition writes only its own descriptor rows and its own from-row, each padded to whole 64-byte
+ * lines, so the pre-barrier writes need no ordering beyond the barrier's release.
+ */
+class PairSlots {
+public:
+    explicit PairSlots(int n)
+        : n_(n),
+          stride_(round_up_(static_cast<size_t>(n), kSpansPerLine)),
+          // One spare line each: the allocator guarantees alignof(span), not 64, so row 0 must be realigned.
+          desc_store_(2 * static_cast<size_t>(n) * stride_ + kSpansPerLine),
+          from_store_(static_cast<size_t>(n) * stride_ + kSpansPerLine),
+          calls_(static_cast<size_t>(n)) {
+        desc_ = align_to_line_(desc_store_.data());
+        from_ = align_to_line_(from_store_.data());
+        assert(desc_ + 2 * static_cast<size_t>(n) * stride_ <= desc_store_.data() + desc_store_.size());
+        assert(from_ + static_cast<size_t>(n) * stride_ <= from_store_.data() + from_store_.size());
+    }
+
+    PairSlots(const PairSlots &) = delete;
+    auto operator=(const PairSlots &) -> PairSlots & = delete;
+
+    //! Partition `u` stores its S descriptors for this call, before the owner's barrier. Own rows only.
+    auto publish(int u, SubStreams send) -> void {
+        assert(static_cast<int>(send.size()) == n_);
+        ++calls_[static_cast<size_t>(u)].calls;
+        calls_[static_cast<size_t>(u)].published = calls_[static_cast<size_t>(u)].calls;
+        std::span<const size_t> *row = desc_row_(parity_(u), u);
+        for (int t = 0; t < n_; ++t) {
+            row[t] = send[static_cast<size_t>(t)];
+        }
+    }
+
+    //! After the barrier: partition `t` gathers descriptor (u -> t) of every u, ascending, into its from-row.
+    auto gather_in_rank(int t) -> PairRecv {
+        const unsigned par = parity_(t);
+        auto row = from_row(t);
+        for (int u = 0; u < n_; ++u) {
+            assert_same_generation_(t, u);
+            row[static_cast<size_t>(u)] = desc_row_(par, u)[t];
+        }
+        return PairRecv{row};
+    }
+
+    /*!
+     * Descriptor (u -> t) of the current call. `reader` names the partition asking, whose own call count
+     * selects the parity: it equals u's, every participant having made the same calls.
+     */
+    [[nodiscard]] auto stream(int reader, int u, int t) const -> std::span<const size_t> {
+        assert_same_generation_(reader, u);
+        return desc_row_(parity_(reader), u)[t];
+    }
+
+    //! Partition t's own from-row, for a cross-rank path to fill with views into its receive buffer.
+    [[nodiscard]] auto from_row(int t) -> std::span<std::span<const size_t>> {
+        return {from_ + static_cast<size_t>(t) * stride_, static_cast<size_t>(n_)};
+    }
+
+    /*! @brief Bytes this table holds, for the memory ledger's `d_wire_staging_bytes`.
+     *
+     *  Descriptors and counters only: the table holds no payload by construction -- the descriptors
+     *  alias the callers' own buffers, which is what makes the in-rank exchange copy-free. It is
+     *  (S)-fixed and line-padded twice over (two parities, whole lines per row), so what it costs is
+     *  quadratic in the partition count and worth counting rather than assuming negligible.
+     */
+    [[nodiscard]] auto staging_bytes() const -> size_t {
+        return desc_store_.capacity() * sizeof(std::span<const size_t>)
+               + from_store_.capacity() * sizeof(std::span<const size_t>) + calls_.capacity() * sizeof(Counter);
+    }
+
+private:
+    struct alignas(64) Counter {
+        uint64_t calls = 0;     //!< this partition's publish count; its low bit is the descriptor parity
+        uint64_t published = 0; //!< the call number the rows now in this partition's parity lines carry
+    };
+
+    /*! @brief Debug-only: the descriptors a reader is about to take were published for the reader's own
+     *  call, not for the one two gates back that shares their parity lines.
+     *
+     *  The barrier is what makes the two counts equal, so a violation is a missing or mismatched barrier
+     *  -- exactly the state in which a reader would take a stale descriptor and read plausible words out
+     *  of a buffer the publisher was allowed to reuse.
+     */
+    auto assert_same_generation_([[maybe_unused]] int reader, [[maybe_unused]] int u) const -> void {
+        assert(calls_[static_cast<size_t>(u)].published == calls_[static_cast<size_t>(reader)].calls
+               && "pair_exchange: a descriptor from another gate; the barrier between them is missing");
+    }
+
+    static constexpr size_t kLineBytes = 64;
+    static constexpr size_t kSpansPerLine = kLineBytes / sizeof(std::span<const size_t>);
+    static_assert(kLineBytes % sizeof(std::span<const size_t>) == 0);
+
+    static auto round_up_(size_t n, size_t m) -> size_t { return ((n + m - 1) / m) * m; }
+
+    template <typename T>
+    static auto align_to_line_(T *p) -> T * {
+        const auto addr = reinterpret_cast<uintptr_t>(p);
+        const size_t pad = (kLineBytes - static_cast<size_t>(addr % kLineBytes)) % kLineBytes;
+        return p + pad / sizeof(T);
+    }
+
+    [[nodiscard]] auto parity_(int u) const -> unsigned {
+        return static_cast<unsigned>(calls_[static_cast<size_t>(u)].calls & 1U);
+    }
+
+    // Row (parity, u): partition u's S descriptors for the calls of that parity.
+    [[nodiscard]] auto desc_row_(unsigned par, int u) const -> std::span<const size_t> * {
+        return desc_ + (static_cast<size_t>(par) * static_cast<size_t>(n_) + static_cast<size_t>(u)) * stride_;
+    }
+
+    int n_;
+    size_t stride_; // spans per row, whole lines
+    std::vector<std::span<const size_t>> desc_store_;
+    std::vector<std::span<const size_t>> from_store_;
+    std::span<const size_t> *desc_ = nullptr;
+    std::span<const size_t> *from_ = nullptr;
+    std::vector<Counter> calls_;
+};
+
+} // namespace monoprop::mpi

--- a/cpp/monoprop/detail/mpi/Pairwise.h
+++ b/cpp/monoprop/detail/mpi/Pairwise.h
@@ -25,7 +25,7 @@
 
 namespace monoprop::mpi {
 
-// One tag per (transport, verb), all five here so no two can collide unseen: one thread per rank calls
+// One tag per (transport, verb), all six here so no two can collide unseen: one thread per rank calls
 // MPI, so the tag is all that keeps a count round in flight from being matched by a payload receive.
 //
 // Why consecutive gate exchanges (one round per gate) may reuse kFlatPayloadTag on one communicator:
@@ -40,6 +40,12 @@ inline constexpr int kFlatCountTag = 0x6D73;
 // Graph REPLAY payload (Exchange.h). Its own value, so a replay leg can match neither the build path's
 // counts nor its payload even though both run over the same communicator.
 inline constexpr int kFlatReplayTag = 0x6D74;
+// pair_exchange (PairExchange.h): the S*S word counts and the payload travel in ONE message, so one tag.
+// A gate g+1 message cannot be matched by gate g's receive: every participant calls the verb in program
+// order with the rank-replicated shift, so a rank posts gate g+1's send only after gate g's receive has
+// completed, and the peer's sends to this rank sit on one (src, dst, tag, comm) sequence that MPI does
+// not reorder -- the probe that sizes gate g's receive therefore always meets gate g's message.
+inline constexpr int kPairExchangeTag = 0x6D75;
 
 //! @brief Per-peer element counts and offsets. Null @c counts is the fixed-block case: @c block each,
 //! at @c b*block.

--- a/cpp/monoprop/detail/mpi/ShmComm.h
+++ b/cpp/monoprop/detail/mpi/ShmComm.h
@@ -26,6 +26,7 @@
 
 #include "monoprop/detail/mpi/CheckedCount.h"
 #include "monoprop/detail/mpi/Comm.h"
+#include "monoprop/detail/mpi/PairSlots.h"
 #include "monoprop/detail/mpi/PartitionBarrier.h"
 
 // In-process shared-memory SPMD transport: S partition-master threads each call the same collective
@@ -38,7 +39,7 @@ namespace monoprop::mpi {
 
 class ShmComm {
 public:
-    explicit ShmComm(int n) : n_(n), slots_(static_cast<size_t>(n)), barrier_(n) {}
+    explicit ShmComm(int n) : n_(n), slots_(static_cast<size_t>(n)), pair_(n), barrier_(n) {}
 
     ShmComm(const ShmComm &) = delete;
     auto operator=(const ShmComm &) -> ShmComm & = delete;
@@ -51,7 +52,9 @@ public:
      *  a peer reads the publisher's own send buffer in place through `slots_` -- so the only bytes here
      *  are one cache-line slot per partition.
      */
-    [[nodiscard]] auto staging_bytes() const -> size_t { return slots_.capacity() * sizeof(Slot); }
+    [[nodiscard]] auto staging_bytes() const -> size_t {
+        return slots_.capacity() * sizeof(Slot) + pair_.staging_bytes();
+    }
 
     // recv_counts[s] = what rank s sends to me (the transpose of the send-count matrix).
     auto alltoall_counts(int rank, const int *send_counts, int *recv_counts) -> void {
@@ -175,6 +178,18 @@ public:
         sync(); // peers write into our buffer (and read from it) until here
     }
 
+    /*! @brief The in-rank gate exchange; PairExchange.h states the contract.
+     *
+     *  ONE barrier, unlike the verbs above: the gather after it reads peers' buffers in place and no copy
+     *  is made, so the moment a peer may reuse its buffer is proved by the NEXT gate's barrier rather
+     *  than by a second one here.
+     */
+    auto pair_exchange(int rank, SubStreams send) -> PairRecv {
+        pair_.publish(rank, send);
+        sync();
+        return pair_.gather_in_rank(rank);
+    }
+
     // See PartitionBarrier::poison / ::reset for when each is legal to call.
     auto poison() -> void { barrier_.poison(); }
 
@@ -196,6 +211,7 @@ private:
 
     int n_;
     std::vector<Slot> slots_;
+    PairSlots pair_; // pair_exchange's descriptor table; holds no payload (see PairSlots)
     PartitionBarrier barrier_;
 };
 

--- a/cpp/tests/evolution_detail_tests.cpp
+++ b/cpp/tests/evolution_detail_tests.cpp
@@ -383,6 +383,22 @@ BOOST_AUTO_TEST_CASE(one_and_half_round_answers_a_silent_hit_and_leaves_it_out_o
     BOOST_TEST(t.received(2));
 }
 
+// A gate's mints and the records it decoded are the one part of GateScratch whose capacity must not
+// survive the gate: they are proportional to that gate's |Anti(G)|, so kept, the widest gate of a call
+// would rest in the partition's footprint for the remainder of it. The gate stamp still prices them.
+BOOST_AUTO_TEST_CASE(a_gate_gives_its_mint_and_record_stages_back_when_it_is_over) {
+    Scenario sc;
+    detail::LayerBuildEngine<kN, AnsweringSink> eng(sc.op, mpi::Comm{}, 1, 0, sc.scratch, 6, AnsweringSink{});
+    eng.exchange_and_join(sc.value_scan());
+
+    // The gate did mint and did decode -- the stamp saw both at their widest instant ...
+    BOOST_TEST(sc.scratch.buffers_hwm_bytes > 0U);
+    // ... and neither stage holds a byte once the gate is over.
+    BOOST_TEST(sc.scratch.misses.memory_bytes() == 0U);
+    BOOST_TEST(sc.scratch.incoming_records.memory_bytes() == 0U);
+    BOOST_TEST(sc.scratch.misses.size() == 0U);
+}
+
 // The fused sink turns those joins into half-rotations: +phi_rec*v_rec on hits and mints (mints flagged as
 // inserts), -phi_own*v_mu for an answer, -phi_own*c0 for an absence, nothing for the answered leader.
 BOOST_AUTO_TEST_CASE(one_round_contract_sink_records_one_half_per_touched_slot) {

--- a/cpp/tests/evolution_detail_tests.cpp
+++ b/cpp/tests/evolution_detail_tests.cpp
@@ -42,6 +42,7 @@
 #include "monoprop/detail/evolution/layer_build/Scan.h"
 #include "monoprop/detail/evolution/layer_build/TableJoin.h"
 #include "monoprop/detail/graph_encoding/MPGraphEncodingStorage.h"
+#include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/MPICompat.h"
 #include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
@@ -181,21 +182,22 @@ struct Scenario {
     //! An R = 1 scan result: every record is self-addressed, so the wire's own slot stays empty.
     static auto empty_scan() -> detail::FusedScanResult<kN> {
         detail::FusedScanResult<kN> res;
-        res.queries.assign(1, VecZ{});
-        res.sent.assign(1, {});
+        res.window = mpi::SlotWindow{.base = 0, .count = 1};
+        res.queries.reset(res.window);
+        res.sent.reset(res.window);
         return res;
     }
 
     auto scan(bool with_c0) -> detail::FusedScanResult<kN> {
         auto res = empty_scan();
         if (with_c0) {
-            res.sent_c0.assign(1, {});
-            res.sent_c0[0] = {-1.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+            res.sent_c0.reset(res.window);
+            res.sent_c0.at_slot(0) = {-1.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         }
         auto push = [&](const Monomial<kN> &key, int phase, bool rot, double v, size_t row) {
             res.self.keeps_values = true;
             res.self.push(positions_of(key), phase, tag_of(key), rot, v);
-            res.sent[0].push_back(
+            res.sent.at_slot(0).push_back(
                 detail::SentRecord{.row = static_cast<TermIndex>(row), .phase = static_cast<int8_t>(phase)});
         };
         push(terms[1], 1, true, 0.5, 0);
@@ -218,12 +220,12 @@ struct Scenario {
     // Own rot bits are the fixture's {t0, t1, t3, t5}; t2 and t4 are the silent rows.
     auto value_scan() -> detail::FusedScanResult<kN> {
         auto res = empty_scan();
-        res.sent_c0.assign(1, {});
-        res.sent_c0[0] = {0.0, 0.0, 0.0, -1.0};
+        res.sent_c0.reset(res.window);
+        res.sent_c0.at_slot(0) = {0.0, 0.0, 0.0, -1.0};
         auto push = [&](const Monomial<kN> &key, int phase, double v, size_t row) {
             res.self.keeps_values = true;
             res.self.push(positions_of(key), phase, tag_of(key), /*rot=*/true, v);
-            res.sent[0].push_back(
+            res.sent.at_slot(0).push_back(
                 detail::SentRecord{.row = static_cast<TermIndex>(row), .phase = static_cast<int8_t>(phase)});
         };
         push(terms[1], 1, 0.5, 0);
@@ -319,7 +321,7 @@ BOOST_AUTO_TEST_CASE(one_round_absence_pass_reports_unanswered_and_answered_lead
                           /*base=*/6,
                           misses,
                           sink,
-                          std::span<const detail::SentRecord>(scan.sent[0]));
+                          std::span<const detail::SentRecord>(scan.sent.at_slot(0)));
     sink.recs.clear();
     detail::absence_pass<kN>(sc.scratch.marks, scan.sent, scan.sent_c0, sink);
     BOOST_REQUIRE_EQUAL(sink.recs.size(), 2U);
@@ -458,9 +460,11 @@ BOOST_AUTO_TEST_CASE(contract_sink_skips_the_absence_half_when_no_c0_travels) {
 BOOST_AUTO_TEST_CASE(one_and_half_round_response_names_the_record_and_the_sender_maps_it_back) {
     Scenario sc;
     // Two flat slots. The peer's stream holds two records; the second hits the silent row t2.
-    std::vector<VecZ> wire(2);
+    const mpi::SlotWindow window{.base = 0, .count = 2};
+    mpi::WindowVec<VecZ> wire;
+    wire.reset(window);
     using QW = detail::QueryWire<kN>;
-    VecZ &peer = wire[1];
+    VecZ &peer = wire.at_slot(1);
     QW::push(peer, positions_of(sc.terms[1]), 1, /*rot=*/true);
     QW::push_value(peer, 0.5);
     QW::push(peer, positions_of(sc.terms[2]), -1, /*rot=*/true);
@@ -468,27 +472,30 @@ BOOST_AUTO_TEST_CASE(one_and_half_round_response_names_the_record_and_the_sender
 
     std::vector<std::span<const size_t>> views;
     detail::IncomingRecords<kN> pr;
-    detail::decode_incoming_records<kN>(detail::slot_streams(wire, views), detail::QueryForm::Fused, pr);
+    detail::decode_incoming_records<kN>(detail::slot_streams(wire, views), window, detail::QueryForm::Fused, pr);
     BOOST_REQUIRE_EQUAL(pr.nq_total, 2U);
     sc.probe(pr.nq_total, [&](size_t g) { return pr.tag_of[g]; }, [&](size_t g) { return pr.positions_at(g); });
 
     AnsweringSink sink;
     detail::MissStage<kN> misses;
-    std::vector<VecZ> responses(2);
+    mpi::WindowVec<VecZ> responses;
+    responses.reset(window);
     detail::join_incoming<kN>(pr, sc.scratch.join, /*q_base=*/0, sc.scratch.marks, /*base=*/6, misses, sink, responses);
     // t1's own rot is set, so that hit needs no answer; t2's is not, so record 1 of slot 1's stream does.
-    BOOST_TEST(responses[0].empty());
-    BOOST_REQUIRE_EQUAL(responses[1].size(), detail::kResponseWords);
-    BOOST_TEST(responses[1][0] == 1U);
-    BOOST_TEST(detail::decode_value(responses[1][1]) == 102.0); // silent_value(2)
+    BOOST_TEST(responses.at_slot(0).empty());
+    BOOST_REQUIRE_EQUAL(responses.at_slot(1).size(), detail::kResponseWords);
+    BOOST_TEST(responses.at_slot(1)[0] == 1U);
+    BOOST_TEST(detail::decode_value(responses.at_slot(1)[1]) == 102.0); // silent_value(2)
 
     // The other direction: an answer to record 1 of this slot's own stream to slot 1.
-    std::vector<std::vector<detail::SentRecord>> sent(2);
-    sent[1] = {detail::SentRecord{.row = 4, .phase = 1}, detail::SentRecord{.row = 5, .phase = -1}};
-    std::vector<VecZ> answers(2);
-    detail::push_response(answers[1], 1, 7.5);
+    mpi::WindowVec<std::vector<detail::SentRecord>> sent;
+    sent.reset(window);
+    sent.at_slot(1) = {detail::SentRecord{.row = 4, .phase = 1}, detail::SentRecord{.row = 5, .phase = -1}};
+    mpi::WindowVec<VecZ> answers;
+    answers.reset(window);
+    detail::push_response(answers.at_slot(1), 1, 7.5);
     sink.recs.clear();
-    detail::apply_responses<kN>(sc.scratch.marks, sent, detail::slot_streams(answers, views), sink);
+    detail::apply_responses<kN>(sc.scratch.marks, sent, detail::slot_streams(answers, views), answers.window(), sink);
     BOOST_REQUIRE_EQUAL(sink.recs.size(), 1U);
     BOOST_TEST(sink.recs[0].kind == "answer");
     BOOST_TEST(sink.recs[0].slot == 1U);
@@ -782,6 +789,7 @@ BOOST_AUTO_TEST_CASE(scan_c0_is_the_state_score_of_a_paired_absent_partner) {
     const detail::CutoffEvaluator<kM> eval(fn);
     const auto cut = detail::build_majorana_evolution_cutoff_state(std::nullopt, std::cref(coeffs), std::nullopt, 0.3);
     const auto router = routing::Router::splitmix(1);
+    const mpi::SlotWindow window{.base = 0, .count = 1};
     const auto mask = initial_state_mask<kM>(VecZ{1});
     detail::GateScratch<kM> scratch;
     const auto res = detail::fused_find_and_collect<kM, A, /*CaptureValues=*/true>(op,
@@ -791,6 +799,7 @@ BOOST_AUTO_TEST_CASE(scan_c0_is_the_state_score_of_a_paired_absent_partner) {
                                                                                    coeffs,
                                                                                    std::nullopt,
                                                                                    /*over_cutoff_possible=*/false,
+                                                                                   window,
                                                                                    /*my_rank=*/0,
                                                                                    router,
                                                                                    scratch,
@@ -804,8 +813,8 @@ BOOST_AUTO_TEST_CASE(scan_c0_is_the_state_score_of_a_paired_absent_partner) {
     }
     BOOST_REQUIRE_EQUAL(n_anti, 3U);
     BOOST_REQUIRE_EQUAL(res.self.size(), 3U); // R = 1: every record is self-addressed and staged
-    const auto &sent = res.sent[0];
-    const auto &c0 = res.sent_c0[0];
+    const auto &sent = res.sent.at_slot(0);
+    const auto &c0 = res.sent_c0.at_slot(0);
     BOOST_REQUIRE_EQUAL(sent.size(), 3U);
     BOOST_REQUIRE_EQUAL(c0.size(), 3U);
     for (size_t j = 0; j < 3; ++j) {
@@ -830,6 +839,7 @@ BOOST_AUTO_TEST_CASE(scan_c0_is_the_state_score_of_a_paired_absent_partner) {
                                                                   coeffs,
                                                                   std::nullopt,
                                                                   false,
+                                                                  window,
                                                                   0,
                                                                   router,
                                                                   scratch_h,
@@ -837,7 +847,7 @@ BOOST_AUTO_TEST_CASE(scan_c0_is_the_state_score_of_a_paired_absent_partner) {
                                                                   1.0,
                                                                   nullptr);
     BOOST_TEST(heis.sent_c0.size() == 0U);
-    BOOST_TEST(heis.sent[0].size() == 3U);
+    BOOST_TEST(heis.sent.at_slot(0).size() == 3U);
 }
 
 // The position-form state score agrees with the dense one in both algebras.

--- a/cpp/tests/evolution_detail_tests.cpp
+++ b/cpp/tests/evolution_detail_tests.cpp
@@ -32,6 +32,7 @@
 #include <utility>
 #include <vector>
 
+#include "ThreadHarness.h"
 #include "monoprop/MonomialPropagator.h"
 #include "monoprop/TypeAliases.h"
 #include "monoprop/algebra/Algebra.h"
@@ -39,12 +40,14 @@
 #include "monoprop/detail/evolution/layer_build/Common.h"
 #include "monoprop/detail/evolution/layer_build/Engine.h"
 #include "monoprop/detail/evolution/layer_build/GateSinks.h"
+#include "monoprop/detail/evolution/layer_build/QueryWire.h"
 #include "monoprop/detail/evolution/layer_build/Scan.h"
 #include "monoprop/detail/evolution/layer_build/TableJoin.h"
 #include "monoprop/detail/graph_encoding/MPGraphEncodingStorage.h"
 #include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/MPICompat.h"
 #include "monoprop/detail/mpi/Routing.h"
+#include "monoprop/detail/mpi/ShmComm.h"
 #include "monoprop/detail/operator/MPOperator.h"
 #include "monoprop/detail/operator/RowAccess.h"
 
@@ -421,6 +424,98 @@ BOOST_AUTO_TEST_CASE(one_round_contract_sink_records_one_half_per_touched_slot) 
     }
     std::ranges::sort(touched);
     BOOST_TEST((std::ranges::adjacent_find(touched) == touched.end()));
+}
+
+/*
+ * The two arms of one gate, compared bitwise: pair_exchange against the collective, on the same records.
+ *
+ * Two partitions of an in-process ShmComm, each sending every one of its records to the other -- so
+ * nothing is staged and the whole gate goes through the transport. The engine chooses the pair path for
+ * a window that is one rank's partitions, which is every gate of this world, so the collective arm is
+ * reached by forcing `pair_path` off. The exchange is a transport, not a rule: the halves it produces
+ * must agree to the bit, in the same order, on both arms and on both partitions.
+ *
+ * The scratch objects outlive the threads on purpose. A published send buffer is read in place by the
+ * peer AFTER this partition's call returned, and the last gate on a comm has no next call to bound that
+ * (rule 1 of PairExchange.h's lifetime warning), so a scratch destroyed with its thread would be a
+ * use-after-free the arms' agreement could not see.
+ */
+BOOST_AUTO_TEST_CASE(one_gate_pair_and_collective_arms_agree_bitwise) {
+    constexpr size_t kSlots = 2;
+    const VecD coeffs = {0.5, 0.25, 12.0, 1.5, 14.0, 3.0};
+
+    // Partition u's records, all addressed to its peer: two hits on rotating rows, one hit on the silent
+    // row t2 (answered in round 2) and one miss (minted).
+    const auto fill_cross = [&](Scenario &sc, size_t peer) {
+        detail::FusedScanResult<kN> res;
+        res.window = mpi::SlotWindow{.base = 0, .count = kSlots};
+        res.queries.reset(res.window);
+        res.sent.reset(res.window);
+        res.sent_c0.reset(res.window);
+        VecZ &buf = res.queries.at_slot(peer);
+        const auto push = [&](const Monomial<kN> &key, int phase, double v) {
+            detail::QueryWire<kN>::push(buf, positions_of(key), phase, /*rot=*/true);
+            detail::QueryWire<kN>::push_value(buf, v);
+        };
+        push(sc.terms[1], 1, 0.5);
+        push(sc.terms[0], -1, 0.25);
+        push(sc.terms[2], -1, 1.5);
+        push(sc.absent_x, 1, 3.0);
+        res.sent.at_slot(peer) = {detail::SentRecord{.row = 0, .phase = 1},
+                                  detail::SentRecord{.row = 1, .phase = -1},
+                                  detail::SentRecord{.row = 3, .phase = -1},
+                                  detail::SentRecord{.row = 5, .phase = 1}};
+        res.sent_c0.at_slot(peer) = {0.0, 0.0, 0.0, -1.0};
+        return res;
+    };
+
+    const auto run_arm = [&](bool force_collective) {
+        std::vector<Scenario> scs(kSlots); // outlives the threads: see the note above
+        std::vector<detail::FusedContract> fcs(kSlots);
+        mpi::ShmComm sh(static_cast<int>(kSlots));
+        auto errs = test_utils::run_comm_threads(sh, static_cast<int>(kSlots), [&](mpi::ShmComm &comm, int u) {
+            Scenario &sc = scs[static_cast<size_t>(u)];
+            detail::LayerBuildEngine<kN, detail::ContractSink<kN>> eng(
+                sc.op,
+                mpi::Comm::make_shm(&comm, u),
+                kSlots,
+                static_cast<size_t>(u),
+                sc.scratch,
+                6,
+                detail::ContractSink<kN>{.fc = fcs[static_cast<size_t>(u)],
+                                         .fused_scale = true,
+                                         .op_coeffs = coeffs,
+                                         .absences_carry_c0 = true});
+            BOOST_REQUIRE(eng.pair_path); // every gate of a one-rank world pairs; the arm is forced below
+            if (force_collective) {
+                eng.pair_path = false;
+            }
+            eng.exchange_and_join(fill_cross(sc, static_cast<size_t>(u ^ 1)));
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        return fcs;
+    };
+
+    const auto pair_arm = run_arm(/*force_collective=*/false);
+    const auto coll_arm = run_arm(/*force_collective=*/true);
+    for (size_t u = 0; u < kSlots; ++u) {
+        BOOST_TEST_CONTEXT("partition " << u) {
+            BOOST_REQUIRE_EQUAL(pair_arm[u].halves.size(), coll_arm[u].halves.size());
+            BOOST_REQUIRE_GT(pair_arm[u].halves.size(), 0U);
+            for (size_t k = 0; k < pair_arm[u].halves.size(); ++k) {
+                const auto &a = pair_arm[u].halves[k];
+                const auto &b = coll_arm[u].halves[k];
+                BOOST_TEST_CONTEXT("half " << k) {
+                    BOOST_TEST(a.local_idx == b.local_idx);
+                    BOOST_TEST(a.phase_signed == b.phase_signed);
+                    BOOST_TEST(a.is_insert == b.is_insert);
+                    BOOST_TEST(std::bit_cast<uint64_t>(a.v_partner) == std::bit_cast<uint64_t>(b.v_partner));
+                }
+            }
+        }
+    }
 }
 
 // The same scenario without a c0 side channel -- the Heisenberg shape, where absence_pass substitutes

--- a/cpp/tests/mpi_utils_tests.cpp
+++ b/cpp/tests/mpi_utils_tests.cpp
@@ -28,6 +28,7 @@
 #include "monoprop/algebra/MajoranaAlgebra.h"
 #include "monoprop/detail/evolution/CutoffContext.h"
 #include "monoprop/detail/evolution/layer_build/Scan.h"
+#include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/MPIUtils.h"
 #include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
@@ -114,26 +115,31 @@ auto build_op(const std::vector<Monomial<32>> &terms) -> detail::MPOperator<32> 
     return op;
 }
 
-auto check_bucket_ownership(const std::vector<VecZ> &buckets, const routing::Router &router, size_t &checked) -> void {
+auto check_bucket_ownership(const mpi::WindowVec<VecZ> &buckets, const routing::Router &router, size_t &checked)
+    -> void {
     // Every offset comes from the record walk: widths vary, so a hardcoded stride would compare a
-    // monomial decoded at the wrong offset against the wrong rank.
+    // monomial decoded at the wrong offset against the wrong rank. The bucket index is re-based, so the
+    // rank compared against is window.slot(k) -- a wrong window base shows up here.
     using QW = detail::QueryWire<32>;
     const detail::QueryForm form = detail::QueryForm::Plain;
-    for (size_t r = 0; r < buckets.size(); ++r) {
+    const mpi::SlotWindow w = buckets.window();
+    for (size_t k = 0; k < w.count; ++k) {
+        const mpi::WindowIndex wi{k};
+        const VecZ &bucket = buckets[wi];
         size_t off = 0;
-        while (off < buckets[r].size()) {
-            const size_t k = QW::k_at(buckets[r], off);
-            std::vector<QW::PosT> pos(k);
-            (void)QW::read_positions(buckets[r], off, pos);
+        while (off < bucket.size()) {
+            const size_t kq = QW::k_at(bucket, off);
+            std::vector<QW::PosT> pos(kq);
+            (void)QW::read_positions(bucket, off, pos);
             Monomial<32> mono;
-            for (size_t j = 0; j < k; ++j) {
+            for (size_t j = 0; j < kq; ++j) {
                 mono.set(static_cast<size_t>(pos[j]));
             }
-            BOOST_REQUIRE_EQUAL(find_rank<32>(mono, router), r);
-            off = QW::next_off(buckets[r], form, off);
+            BOOST_REQUIRE_EQUAL(find_rank<32>(mono, router), w.slot(wi));
+            off = QW::next_off(bucket, form, off);
             ++checked;
         }
-        BOOST_REQUIRE_EQUAL(off, buckets[r].size());
+        BOOST_REQUIRE_EQUAL(off, bucket.size());
     }
 }
 
@@ -190,6 +196,7 @@ BOOST_AUTO_TEST_CASE(mpi_utils_scan_routing_agrees_with_find_rank) {
             const auto router = routing::Router::for_modes<kN>(ranks, /*partitions=*/1, linear);
             BOOST_REQUIRE_EQUAL(router.is_linear(), linear);
             const size_t shift = router.rank_shift<kN>(gen);
+            const mpi::PeerPlan plan{.sparse = router.is_linear(), .shift = static_cast<int>(shift)};
             // Per router, not summed over them: the floors are what stops the loop passing on an empty
             // scan, and a sum lets one router carry the other.
             size_t checked = 0;
@@ -203,6 +210,7 @@ BOOST_AUTO_TEST_CASE(mpi_utils_scan_routing_agrees_with_find_rank) {
                 }
                 BOOST_REQUIRE(!owned.empty());
                 auto op = build_op(owned);
+                const mpi::SlotWindow window = plan.window(my_rank, ranks, /*parts=*/1);
                 VecD coeffs(op.store->size(), 1.0);
                 const auto cut = detail::build_majorana_evolution_cutoff_state(std::nullopt,
                                                                                std::cref(coeffs),
@@ -217,6 +225,7 @@ BOOST_AUTO_TEST_CASE(mpi_utils_scan_routing_agrees_with_find_rank) {
                     coeffs,
                     std::nullopt,
                     /*over_cutoff_possible=*/false,
+                    window,
                     my_rank,
                     router,
                     scratch,
@@ -224,24 +233,31 @@ BOOST_AUTO_TEST_CASE(mpi_utils_scan_routing_agrees_with_find_rank) {
                     1.0);
                 // The fold found anticommuting rows: they are what the join's row side is built from.
                 BOOST_REQUIRE(!scratch.nz.empty());
-                BOOST_REQUIRE_EQUAL(res.queries.size(), ranks);
-                BOOST_REQUIRE_EQUAL(res.sent.size(), ranks);
-                // The scan routes a self-owned partner to the stage, so my own bucket must be empty,
-                // and the stage's parallel record list is the one for the self slot.
-                BOOST_REQUIRE(res.queries[my_rank].empty());
-                BOOST_REQUIRE_EQUAL(res.sent[my_rank].size(), res.self.size());
+                BOOST_REQUIRE_EQUAL(res.queries.size(), window.count);
+                BOOST_REQUIRE_EQUAL(res.sent.size(), window.count);
+                if (window.contains(my_rank)) {
+                    // The scan routes a self-owned partner to the stage, so my own bucket must be empty,
+                    // and the stage's parallel record list is the one for the self slot.
+                    BOOST_REQUIRE(res.queries.at_slot(my_rank).empty());
+                    BOOST_REQUIRE_EQUAL(res.sent.at_slot(my_rank).size(), res.self.size());
+                }
+                else {
+                    // A non-zero shift puts self outside the window entirely, so nothing may be staged.
+                    BOOST_REQUIRE_EQUAL(res.self.size(), 0U);
+                }
                 // One record per sending source, so the per-slot source lists account for every record
                 // and are ascending in row: the absence pass and the graph sink's out lists rely on that.
-                for (size_t r = 0; r < ranks; ++r) {
+                for (size_t k = 0; k < window.count; ++k) {
+                    const mpi::WindowIndex wi{k};
                     std::vector<TermIndex> rows;
-                    for (const auto &rec : res.sent[r]) {
+                    for (const auto &rec : res.sent[wi]) {
                         rows.push_back(rec.row);
                     }
                     BOOST_REQUIRE(std::is_sorted(rows.begin(), rows.end()));
                     BOOST_REQUIRE((std::adjacent_find(rows.begin(), rows.end()) == rows.end()));
-                    if (r != my_rank) {
+                    if (window.slot(wi) != my_rank) {
                         BOOST_REQUIRE_EQUAL(
-                            detail::QueryWire<kN>::count_queries(res.queries[r], detail::QueryForm::Plain),
+                            detail::QueryWire<kN>::count_queries(res.queries[wi], detail::QueryForm::Plain),
                             rows.size());
                     }
                     for (const auto row : rows) {

--- a/cpp/tests/pair_exchange_tests.cpp
+++ b/cpp/tests/pair_exchange_tests.cpp
@@ -1,0 +1,502 @@
+// Copyright 2026 Algorithmiq
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// pair_exchange, the one-round gate exchange, over every transport it dispatches to: ShmComm in-rank,
+// HybridComm in-rank and across ranks, and a raw communicator. Every word names its (source, destination,
+// index), so a block that lands on the wrong partition, arrives out of source order, or is torn changes a
+// value or a length rather than passing unnoticed. The MPI cases self-skip below two ranks.
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <span>
+#include <thread>
+#include <vector>
+
+#ifdef monoprop_ENABLE_MPI
+#include <mpi.h>
+#endif
+
+#include "ThreadHarness.h"
+#include "monoprop/detail/mpi/CheckedCount.h"
+#include "monoprop/detail/mpi/Comm.h"
+#include "monoprop/detail/mpi/MPICompat.h"
+#include "monoprop/detail/mpi/PairExchange.h"
+#include "monoprop/detail/mpi/ShmComm.h"
+#ifdef monoprop_ENABLE_MPI
+#include "monoprop/detail/mpi/HybridComm.h"
+#endif
+
+using monoprop::mpi::CollectiveArgumentError;
+using monoprop::mpi::Comm;
+using monoprop::mpi::PairRecv;
+using monoprop::mpi::ShmComm;
+using monoprop::mpi::ShmCommPoisoned;
+using monoprop::mpi::SubStreams;
+
+namespace {
+
+// Global ids: slot = rank * S + partition, the same rank-major numbering HybridComm uses.
+auto tag_word(size_t src_slot, size_t dst_slot, size_t j) -> size_t {
+    return (src_slot << 44) | (dst_slot << 24) | j;
+}
+
+auto mix(uint64_t x) -> uint64_t {
+    x += 0x9E3779B97F4A7C15ULL;
+    x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    x = (x ^ (x >> 27)) * 0x94D049BB133111EBULL;
+    return x ^ (x >> 31);
+}
+
+// The traffic shapes. Each is a function of (gate, source, destination) both ends can evaluate, so the
+// receiver knows the exact length it must see from every source.
+enum class Pattern : std::uint8_t {
+    Random,     // 0..200 words per (u, t), independent
+    AllEmpty,   // every sub-stream empty: the header alone crosses
+    OneSource,  // only the last partition of each rank sends, to every destination
+    OneDest,    // every partition sends only to destination partition 0
+    FlatLinear, // u sends only to t = u ^ d, d = gate % S -- the routing the engine actually produces
+    LowerSilent // the lower-numbered rank of a pair sends nothing: the payload is zero on one side
+};
+
+constexpr std::array kInRankPatterns{Pattern::Random,
+                                     Pattern::AllEmpty,
+                                     Pattern::OneSource,
+                                     Pattern::OneDest,
+                                     Pattern::FlatLinear};
+constexpr std::array kCrossRankPatterns{Pattern::Random,
+                                        Pattern::AllEmpty,
+                                        Pattern::OneSource,
+                                        Pattern::OneDest,
+                                        Pattern::FlatLinear,
+                                        Pattern::LowerSilent};
+
+auto expected_len(Pattern p, uint64_t gate, int S, int src_rank, int src_part, int dst_rank, int dst_part) -> size_t {
+    const auto random = [&] {
+        return static_cast<size_t>(mix((gate * 1000003ULL + static_cast<uint64_t>(src_rank * S + src_part)) * 7919ULL
+                                       + static_cast<uint64_t>(dst_rank * S + dst_part))
+                                   % 201);
+    };
+    switch (p) {
+        case Pattern::Random:
+            return random();
+        case Pattern::AllEmpty:
+            return 0;
+        case Pattern::OneSource:
+            return src_part == S - 1 ? 100 + static_cast<size_t>(dst_part) : 0;
+        case Pattern::OneDest:
+            return dst_part == 0 ? 50 + static_cast<size_t>(src_part) : 0;
+        case Pattern::FlatLinear:
+            return dst_part == (src_part ^ static_cast<int>(gate % static_cast<uint64_t>(S)))
+                       ? 60 + 3 * static_cast<size_t>(src_part)
+                       : 0;
+        case Pattern::LowerSilent:
+            return src_rank < dst_rank ? 0 : random();
+    }
+    return 0;
+}
+
+// One gate's outgoing buffers of one partition. A caller alternates two of these (the lifetime rule in
+// PairExchange.h), so `fill` reuses the storage a gate two back last handed out.
+struct Outgoing {
+    std::vector<std::vector<size_t>> bufs;
+    std::vector<std::span<const size_t>> spans;
+
+    auto fill(Pattern p, uint64_t gate, int S, int my_rank, int u, int peer_rank) -> void {
+        bufs.resize(static_cast<size_t>(S));
+        spans.resize(static_cast<size_t>(S));
+        for (int t = 0; t < S; ++t) {
+            auto &b = bufs[static_cast<size_t>(t)];
+            const size_t n = expected_len(p, gate, S, my_rank, u, peer_rank, t);
+            b.resize(n);
+            for (size_t j = 0; j < n; ++j) {
+                b[j] = tag_word(static_cast<size_t>(my_rank * S + u), static_cast<size_t>(peer_rank * S + t), j);
+            }
+            spans[static_cast<size_t>(t)] = b;
+        }
+    }
+    [[nodiscard]] auto view() const -> SubStreams { return spans; }
+};
+
+// What partition t of `my_rank` must have received from every partition of `peer_rank`. Counts every
+// comparison so a case whose loops never ran cannot read as a pass.
+auto verify(const PairRecv &got,
+            Pattern p,
+            uint64_t gate,
+            int S,
+            int my_rank,
+            int t,
+            int peer_rank,
+            std::atomic<int> &failures,
+            std::atomic<long> &checks) -> void {
+    if (static_cast<int>(got.from.size()) != S) {
+        failures.fetch_add(1);
+        return;
+    }
+    for (int u = 0; u < S; ++u) {
+        const auto blk = got.from[static_cast<size_t>(u)];
+        const size_t want = expected_len(p, gate, S, peer_rank, u, my_rank, t);
+        checks.fetch_add(1);
+        if (blk.size() != want) {
+            failures.fetch_add(1);
+            continue;
+        }
+        for (size_t j = 0; j < want; ++j) {
+            checks.fetch_add(1);
+            if (blk[j] != tag_word(static_cast<size_t>(peer_rank * S + u), static_cast<size_t>(my_rank * S + t), j)) {
+                failures.fetch_add(1);
+            }
+        }
+    }
+}
+
+template <typename Body>
+auto run_shm(int s, Body body) -> std::vector<std::exception_ptr> {
+    ShmComm sh(s);
+    return test_utils::run_comm_threads(sh, s, body);
+}
+
+} // namespace
+
+// Every (u -> t) block of every shape arrives intact and in ascending source order, at S from one partition
+// to eight. Each gate here is a fresh ShmComm: the back-to-back rule has its own case below.
+BOOST_AUTO_TEST_CASE(pair_exchange_shm_delivers_every_block) {
+    for (const int S : {1, 2, 3, 4, 8}) {
+        for (const Pattern p : kInRankPatterns) {
+            std::atomic<int> failures{0};
+            std::atomic<long> checks{0};
+            // Owned outside the threads: a partition that returns first must not free what its peers
+            // still view (rule 1 in PairExchange.h has no next call to bound the last gate).
+            std::vector<Outgoing> outs(static_cast<size_t>(S));
+            auto errs = run_shm(S, [&](ShmComm &sh, int u) {
+                Comm c = Comm::make_shm(&sh, u);
+                Outgoing &out = outs[static_cast<size_t>(u)];
+                out.fill(p, /*gate=*/1, S, /*my_rank=*/0, u, /*peer_rank=*/0);
+                const PairRecv got = monoprop::mpi::pair_exchange(c, /*rank_shift=*/0, out.view());
+                verify(got, p, 1, S, 0, u, 0, failures, checks);
+            });
+            for (const auto &e : errs) {
+                BOOST_CHECK(e == nullptr);
+            }
+            BOOST_CHECK_GT(checks.load(), 0);
+            BOOST_CHECK_EQUAL(failures.load(), 0);
+        }
+    }
+}
+
+// Ten gates on one ShmComm, the shape changing every gate and the caller alternating two buffer sets as
+// the lifetime rule requires. A peer publishing gate g+1 while this partition still holds gate g's views
+// is the race the descriptor parity exists for, so gate g is re-verified after gate g+1's buffers are
+// prepared and the peers have had time to run ahead into their next call.
+BOOST_AUTO_TEST_CASE(pair_exchange_shm_back_to_back_gates) {
+    constexpr int kGates = 10;
+    for (const int S : {2, 3, 4, 8}) {
+        std::atomic<int> failures{0};
+        std::atomic<long> checks{0};
+        std::vector<std::array<Outgoing, 2>> all_sets(static_cast<size_t>(S)); // outlives the threads
+        auto errs = run_shm(S, [&](ShmComm &sh, int u) {
+            Comm c = Comm::make_shm(&sh, u);
+            std::array<Outgoing, 2> &sets = all_sets[static_cast<size_t>(u)];
+            PairRecv prev{};
+            Pattern prev_pattern = Pattern::AllEmpty;
+            for (int g = 0; g < kGates; ++g) {
+                const Pattern p = kInRankPatterns[static_cast<size_t>(g) % kInRankPatterns.size()];
+                Outgoing &out = sets[static_cast<size_t>(g & 1)];
+                out.fill(p, static_cast<uint64_t>(g), S, 0, u, 0);
+                if (g > 0) {
+                    std::this_thread::yield();
+                    verify(prev, prev_pattern, static_cast<uint64_t>(g - 1), S, 0, u, 0, failures, checks);
+                }
+                prev = monoprop::mpi::pair_exchange(c, 0, out.view());
+                prev_pattern = p;
+                verify(prev, p, static_cast<uint64_t>(g), S, 0, u, 0, failures, checks);
+            }
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        BOOST_CHECK_GT(checks.load(), 0);
+        BOOST_CHECK_EQUAL(failures.load(), 0);
+    }
+}
+
+/*
+ * The lifetime rule's boundary, in the direction a bug is silent: a `from` view must never alias the
+ * buffer set the caller has already been allowed to reuse.
+ *
+ * Rule 1 (PairExchange.h) frees gate g-1's set the moment gate g RETURNS -- every peer has then passed
+ * gate g's barrier, so none of them is still reading gate g-1's descriptors. This case takes that
+ * permission literally: as soon as gate g returns it scribbles a poison word over every byte of gate
+ * g-1's set, and only then verifies gate g's views. A transport that handed back a view into the older
+ * set (an alternation off by one, or a descriptor parity that did not advance) reads the poison and the
+ * comparison fails, where without the scribble it would read a plausible previous gate's words.
+ */
+BOOST_AUTO_TEST_CASE(pair_exchange_shm_views_never_alias_a_released_buffer_set) {
+    constexpr size_t kPoison = 0xDEADBEEFDEADBEEFULL;
+    constexpr int kGates = 8;
+    for (const int S : {2, 3, 8}) {
+        std::atomic<int> failures{0};
+        std::atomic<long> checks{0};
+        std::vector<std::array<Outgoing, 2>> all_sets(static_cast<size_t>(S)); // outlives the threads
+        auto errs = run_shm(S, [&](ShmComm &sh, int u) {
+            Comm c = Comm::make_shm(&sh, u);
+            std::array<Outgoing, 2> &sets = all_sets[static_cast<size_t>(u)];
+            for (int g = 0; g < kGates; ++g) {
+                const Pattern p = kInRankPatterns[static_cast<size_t>(g) % kInRankPatterns.size()];
+                Outgoing &out = sets[static_cast<size_t>(g & 1)];
+                out.fill(p, static_cast<uint64_t>(g), S, 0, u, 0);
+                const PairRecv got = monoprop::mpi::pair_exchange(c, 0, out.view());
+                if (g > 0) {
+                    for (auto &b : sets[static_cast<size_t>((g - 1) & 1)].bufs) {
+                        std::fill(b.begin(), b.end(), kPoison);
+                    }
+                }
+                verify(got, p, static_cast<uint64_t>(g), S, 0, u, 0, failures, checks);
+            }
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        BOOST_CHECK_GT(checks.load(), 0);
+        BOOST_CHECK_EQUAL(failures.load(), 0);
+    }
+}
+
+// The argument checks run before any barrier and on replicated inputs, so every participant throws and
+// nobody is left spinning. A single-rank world has no peer: any non-zero shift is an error, as is a
+// sub-stream count that is not S.
+BOOST_AUTO_TEST_CASE(pair_exchange_shm_rejects_bad_arguments) {
+    const int S = 3;
+    {
+        auto errs = run_shm(S, [&](ShmComm &sh, int u) {
+            Comm c = Comm::make_shm(&sh, u);
+            Outgoing out;
+            out.fill(Pattern::Random, 0, S, 0, u, 0);
+            monoprop::mpi::pair_exchange(c, /*rank_shift=*/1, out.view());
+        });
+        for (const auto &e : errs) {
+            BOOST_REQUIRE(e != nullptr);
+            BOOST_CHECK_THROW(std::rethrow_exception(e), CollectiveArgumentError);
+        }
+    }
+    {
+        auto errs = run_shm(S, [&](ShmComm &sh, int u) {
+            Comm c = Comm::make_shm(&sh, u);
+            Outgoing out;
+            out.fill(Pattern::Random, 0, S + 1, 0, u, 0); // S+1 sub-streams
+            monoprop::mpi::pair_exchange(c, 0, out.view());
+        });
+        for (const auto &e : errs) {
+            BOOST_REQUIRE(e != nullptr);
+            BOOST_CHECK_THROW(std::rethrow_exception(e), CollectiveArgumentError);
+        }
+    }
+}
+
+// A participant that unwinds instead of arriving must release the peers spinning in the verb's barrier.
+BOOST_AUTO_TEST_CASE(pair_exchange_shm_poison_releases_waiters) {
+    for (const int S : {2, 4, 8}) {
+        auto errs = run_shm(S, [&](ShmComm &sh, int u) {
+            if (u == 0) {
+                sh.poison();
+                return;
+            }
+            Comm c = Comm::make_shm(&sh, u);
+            Outgoing out;
+            out.fill(Pattern::Random, 0, S, 0, u, 0);
+            monoprop::mpi::pair_exchange(c, 0, out.view());
+        });
+        BOOST_CHECK(errs[0] == nullptr);
+        for (int u = 1; u < S; ++u) {
+            BOOST_REQUIRE(errs[static_cast<size_t>(u)] != nullptr);
+            BOOST_CHECK_THROW(std::rethrow_exception(errs[static_cast<size_t>(u)]), ShmCommPoisoned);
+        }
+    }
+}
+
+#ifdef monoprop_ENABLE_MPI
+
+using monoprop::mpi::HybridComm;
+
+namespace {
+
+template <typename Body>
+auto run_hybrid(int s, Body body) -> std::vector<std::exception_ptr> {
+    HybridComm hyb(MPI_COMM_WORLD, s);
+    return test_utils::run_comm_threads(hyb, s, body);
+}
+
+auto world_size() -> int {
+    int n = 0;
+    MPI_Comm_size(MPI_COMM_WORLD, &n);
+    return n;
+}
+auto world_rank() -> int {
+    int r = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &r);
+    return r;
+}
+
+// The shifts a case runs: the in-rank one and the two cross-rank ones the engine's routing produces most
+// (deduplicated at R == 2, where they coincide).
+auto shifts_for(int R) -> std::vector<int> {
+    std::vector<int> s{0, 1};
+    if (R - 1 != 1) {
+        s.push_back(R - 1);
+    }
+    return s;
+}
+
+auto power_of_two(int n) -> bool {
+    return n >= 2 && (n & (n - 1)) == 0;
+}
+
+} // namespace
+
+// Every (rank r, partition u) -> (rank r ^ shift, partition t) block arrives bit for bit, in ascending u,
+// on every shape including empty rows, empty columns, and a side with nothing to send at all.
+BOOST_AUTO_TEST_CASE(pair_exchange_hybrid_delivers_every_block) {
+    const int R = world_size();
+    if (!power_of_two(R)) {
+        return;
+    }
+    const int me = world_rank();
+    for (const int S : {1, 2, 4}) {
+        for (const int shift : shifts_for(R)) {
+            const int peer = me ^ shift;
+            for (const Pattern p : kCrossRankPatterns) {
+                std::atomic<int> failures{0};
+                std::atomic<long> checks{0};
+                std::vector<Outgoing> outs(static_cast<size_t>(S)); // outlives the threads
+                auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+                    Comm c = Comm::make_hybrid(&hyb, u);
+                    Outgoing &out = outs[static_cast<size_t>(u)];
+                    out.fill(p, 3, S, me, u, peer);
+                    const PairRecv got = monoprop::mpi::pair_exchange(c, shift, out.view());
+                    verify(got, p, 3, S, me, u, peer, failures, checks);
+                });
+                for (const auto &e : errs) {
+                    BOOST_CHECK(e == nullptr);
+                }
+                BOOST_CHECK_GT(checks.load(), 0);
+                BOOST_CHECK_EQUAL(failures.load(), 0);
+            }
+        }
+    }
+}
+
+// Consecutive gates with different shifts on one HybridComm: cross-rank (two barriers, one message each
+// way) and in-rank (one barrier) gates interleave, the receive buffer grows and is reused, and the
+// caller alternates its buffer sets. Gate g's views are re-verified after gate g+1 is prepared.
+BOOST_AUTO_TEST_CASE(pair_exchange_hybrid_consecutive_gates_change_shift) {
+    const int R = world_size();
+    if (!power_of_two(R)) {
+        return;
+    }
+    const int me = world_rank();
+    const std::vector<int> shifts{1, 0, R - 1, 1, 1, 0, 0, R - 1, 1, R - 1, 0, 1};
+    for (const int S : {1, 2, 4}) {
+        std::atomic<int> failures{0};
+        std::atomic<long> checks{0};
+        std::vector<std::array<Outgoing, 2>> all_sets(static_cast<size_t>(S)); // outlives the threads
+        auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+            Comm c = Comm::make_hybrid(&hyb, u);
+            std::array<Outgoing, 2> &sets = all_sets[static_cast<size_t>(u)];
+            PairRecv prev{};
+            Pattern prev_pattern = Pattern::AllEmpty;
+            int prev_peer = me;
+            for (size_t g = 0; g < shifts.size(); ++g) {
+                const int shift = shifts[g];
+                const int peer = me ^ shift;
+                const Pattern p = kCrossRankPatterns[g % kCrossRankPatterns.size()];
+                Outgoing &out = sets[g & 1];
+                out.fill(p, g, S, me, u, peer);
+                if (g > 0) {
+                    std::this_thread::yield();
+                    verify(prev, prev_pattern, g - 1, S, me, u, prev_peer, failures, checks);
+                }
+                prev = monoprop::mpi::pair_exchange(c, shift, out.view());
+                prev_pattern = p;
+                prev_peer = peer;
+                verify(prev, p, g, S, me, u, peer, failures, checks);
+            }
+        });
+        for (const auto &e : errs) {
+            BOOST_CHECK(e == nullptr);
+        }
+        BOOST_CHECK_GT(checks.load(), 0);
+        BOOST_CHECK_EQUAL(failures.load(), 0);
+    }
+}
+
+// The raw-communicator kind is the S == 1 world: one sub-stream out, one view back, the self peer at
+// shift 0 and one probed message each way otherwise. Back-to-back gates reuse the per-thread receive
+// buffer across a growth and a silent side.
+BOOST_AUTO_TEST_CASE(pair_exchange_plain_mpi_comm) {
+    const int R = world_size();
+    if (!power_of_two(R)) {
+        return;
+    }
+    const int me = world_rank();
+    Comm c{MPI_COMM_WORLD};
+    std::atomic<int> failures{0};
+    std::atomic<long> checks{0};
+    std::array<Outgoing, 2> sets;
+    uint64_t gate = 0;
+    for (const int shift : shifts_for(R)) {
+        const int peer = me ^ shift;
+        for (const Pattern p : kCrossRankPatterns) {
+            Outgoing &out = sets[gate & 1];
+            out.fill(p, gate, 1, me, 0, peer);
+            const PairRecv got = monoprop::mpi::pair_exchange(c, shift, out.view());
+            verify(got, p, gate, 1, me, 0, peer, failures, checks);
+            ++gate;
+        }
+    }
+    BOOST_CHECK_GT(checks.load(), 0);
+    BOOST_CHECK_EQUAL(failures.load(), 0);
+}
+
+// A shift that names no rank -- `R` itself sets a bit above every rank index -- is rejected on every
+// participant before any barrier or MPI call, so the check cannot strand a rank. Both the hybrid and the
+// raw kind.
+BOOST_AUTO_TEST_CASE(pair_exchange_rejects_shift_outside_the_world) {
+    const int R = world_size();
+    if (!power_of_two(R)) {
+        return;
+    }
+    const int me = world_rank();
+    const int S = 2;
+    auto errs = run_hybrid(S, [&](HybridComm &hyb, int u) {
+        Comm c = Comm::make_hybrid(&hyb, u);
+        Outgoing out;
+        out.fill(Pattern::Random, 0, S, me, u, me);
+        monoprop::mpi::pair_exchange(c, /*rank_shift=*/R, out.view());
+    });
+    for (const auto &e : errs) {
+        BOOST_REQUIRE(e != nullptr);
+        BOOST_CHECK_THROW(std::rethrow_exception(e), CollectiveArgumentError);
+    }
+    Comm raw{MPI_COMM_WORLD};
+    Outgoing out;
+    out.fill(Pattern::Random, 0, 1, me, 0, me);
+    BOOST_CHECK_THROW(monoprop::mpi::pair_exchange(raw, R, out.view()), CollectiveArgumentError);
+}
+
+#endif // monoprop_ENABLE_MPI

--- a/cpp/tests/pair_once_tests.cpp
+++ b/cpp/tests/pair_once_tests.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // Pair-once (Resolve.h join_self): the value path settles a mutual pair from the leader's record alone
 // when that record is resolved first, and skips the follower's record at the probe. This runs the real
 // engine with the real ContractSink over a hand-built gate that has every case at once -- twenty
@@ -188,8 +187,9 @@ struct Gate {
     // The value-path scan's product: one rot=1 record per rotating row, in ascending row order.
     auto scan() -> detail::FusedScanResult<kN> {
         detail::FusedScanResult<kN> res;
-        res.queries.assign(1, VecZ{});
-        res.sent.assign(1, {});
+        res.window = mpi::SlotWindow{.base = 0, .count = 1};
+        res.queries.reset(res.window);
+        res.sent.reset(res.window);
         res.self.keeps_values = true;
         for (size_t i = 0; i < kRows; ++i) {
             if (!rot[i]) {
@@ -197,7 +197,7 @@ struct Gate {
             }
             const auto pos = positions_of(record_key[i]);
             res.self.push(pos, phase[i], key_of(record_key[i]), /*rot=*/true, v[i]);
-            res.sent[0].push_back(
+            res.sent.at_slot(0).push_back(
                 detail::SentRecord{.row = static_cast<TermIndex>(i), .phase = static_cast<int8_t>(phase[i])});
         }
         return res;

--- a/cpp/tests/sparse_resolve_tests.cpp
+++ b/cpp/tests/sparse_resolve_tests.cpp
@@ -32,6 +32,7 @@
 #include "monoprop/detail/evolution/layer_build/QueryWire.h"
 #include "monoprop/detail/evolution/layer_build/Resolve.h"
 #include "monoprop/detail/evolution/layer_build/TableJoin.h"
+#include "monoprop/detail/mpi/Comm.h"
 #include "monoprop/detail/mpi/Routing.h"
 #include "monoprop/detail/operator/MPOperator.h"
 #include "monoprop/detail/operator/OperatorIndex.h"
@@ -168,10 +169,11 @@ auto record_value(size_t q) -> double {
 }
 
 template <size_t NumModes>
-auto serialize(const std::vector<std::vector<Monomial<NumModes>>> &queries, bool fused) -> std::vector<VecZ> {
-    std::vector<VecZ> incoming(queries.size());
+auto serialize(const std::vector<std::vector<Monomial<NumModes>>> &queries, bool fused, mpi::SlotWindow window)
+    -> mpi::WindowVec<VecZ> {
+    mpi::WindowVec<VecZ> incoming(window);
     for (size_t s = 0; s < queries.size(); ++s) {
-        VecZ &buf = incoming[s];
+        VecZ &buf = incoming[mpi::WindowIndex{s}];
         for (size_t q = 0; q < queries[s].size(); ++q) {
             const auto pos = positions_of<NumModes>(queries[s][q]);
             detail::QueryWire<NumModes>::push(buf, pos, record_phase(q), record_rot(q));
@@ -210,8 +212,14 @@ struct RecordingSink {
 };
 
 template <size_t NumModes>
-auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t n_query, size_t rank_count, bool fused)
-    -> void {
+auto check_probe_matches_the_queries(std::mt19937_64 &rng,
+                                     size_t n_seed,
+                                     size_t n_query,
+                                     size_t rank_count,
+                                     bool fused,
+                                     size_t window_base = 0) -> void {
+    // A non-zero base is the case a re-basing bug survives: the sink must still see the flat slot.
+    const mpi::SlotWindow window{.base = window_base, .count = rank_count};
     const auto seed_terms = draw_distinct<NumModes>(rng, n_seed);
     const auto fresh_terms = draw_distinct<NumModes>(rng, n_query);
 
@@ -253,15 +261,17 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
         }
     }
 
-    const auto incoming = serialize<NumModes>(queries, fused);
+    const auto incoming = serialize<NumModes>(queries, fused, window);
     const detail::QueryForm form = fused ? detail::QueryForm::Fused : detail::QueryForm::Plain;
 
     auto op = make_op<NumModes>(seed_terms);
     AllRowsGate<NumModes> gate(op);
     std::vector<std::span<const size_t>> views;
     detail::IncomingRecords<NumModes> pr;
-    detail::decode_incoming_records<NumModes>(detail::slot_streams(incoming, views), form, pr);
+    detail::decode_incoming_records<NumModes>(detail::slot_streams(incoming, views), incoming.window(), form, pr);
     gate.match(op, pr);
+    BOOST_REQUIRE_EQUAL(pr.window.base, window.base);
+    BOOST_REQUIRE_EQUAL(pr.window.count, window.count);
     BOOST_REQUIRE_EQUAL(pr.nq_total, expect_mono.size());
     BOOST_REQUIRE(pr.nq_total > 0);
     BOOST_REQUIRE_EQUAL(pr.goff.size(), rank_count + 1);
@@ -314,7 +324,7 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
         }
         else if (expect_rot[g]) {
             expected_mints.push_back(want);
-            expected_mint_slot.push_back(s);
+            expected_mint_slot.push_back(window.base + s);
         }
         else {
             ++dropped_seen;
@@ -337,7 +347,7 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
     const size_t base = op.store->size();
     detail::MissStage<NumModes> misses;
     RecordingSink sink;
-    std::vector<VecZ> responses; // wants_responses is false, so the join never touches it
+    mpi::WindowVec<VecZ> responses; // wants_responses is false, so the join never touches it
     detail::join_incoming<NumModes>(pr, gate.join, /*q_base=*/0, gate.marks, base, misses, sink, responses);
     BOOST_REQUIRE_EQUAL(misses.size(), expected_mints.size());
     size_t mints_seen = 0;
@@ -358,7 +368,7 @@ auto check_probe_matches_the_queries(std::mt19937_64 &rng, size_t n_seed, size_t
             ++hit_calls;
             BOOST_TEST(r.idx < base);
             BOOST_TEST((std::find(expected_hit_row.begin(), expected_hit_row.end(), r.idx) != expected_hit_row.end()));
-            BOOST_TEST(r.slot < rank_count);
+            BOOST_TEST(window.contains(r.slot));
         }
     }
     BOOST_TEST(mints_seen == expected_mints.size());
@@ -422,7 +432,8 @@ BOOST_AUTO_TEST_CASE(sparse_resolve_probe_matches_wide_positions) {
                                          /*n_seed=*/60,
                                          /*n_query=*/140,
                                          /*rank_count=*/4,
-                                         /*fused=*/false);
+                                         /*fused=*/false,
+                                         /*window_base=*/16);
 }
 
 BOOST_AUTO_TEST_CASE(sparse_resolve_probe_matches_fused_layout) {
@@ -431,7 +442,8 @@ BOOST_AUTO_TEST_CASE(sparse_resolve_probe_matches_fused_layout) {
                                          /*n_seed=*/50,
                                          /*n_query=*/120,
                                          /*rank_count=*/2,
-                                         /*fused=*/true);
+                                         /*fused=*/true,
+                                         /*window_base=*/6);
 }
 
 BOOST_AUTO_TEST_CASE(sparse_resolve_probe_matches_single_sender) {

--- a/docs/content/docs/features/parallelism.mdx
+++ b/docs/content/docs/features/parallelism.mdx
@@ -281,6 +281,26 @@ which only the Schrödinger picture scores: in Heisenberg the freshly minted par
 add is $c \mathrel{+}= \sin \cdot (\mp 1) \cdot 0$ — a 16-byte half and one random-access
 read-modify-write per mint of every gate, to add nothing.
 
+Under linear routing that round needs no collective at all. Every partition of a rank has exactly
+one peer partition per generator, so the exchange is a *pair* exchange: one call per gate in which
+each participant hands over its $S$ sub-streams — one per destination partition of the peer rank —
+and receives the peer rank's $S$ sub-streams back, in ascending source order. Inside a rank
+(including every zero-shift gate of a multi-rank run) it costs **one barrier and no copy**: each
+partition publishes $S$ span descriptors, and past the barrier its peers read those buffers in
+place. Across ranks it costs two barriers and **one message each way**, sent in place through a
+derived datatype whose leading block is the $S \times S$ word counts, with the receive sized by
+probing the peer's message — so a side with nothing to send still posts exactly one message and
+there is no count round and no zero-length asymmetry to keep symmetric.
+
+The single in-rank barrier is what a copy-free gather costs, and it is paid by *deferring* the
+second one rather than dropping it. A two-barrier collective uses its second barrier to prove that
+every peer has finished reading the publisher's buffer; here the next gate's barrier proves the
+same thing, so a caller may reuse a send buffer only from the gate after next and alternates two
+sets of them gate by gate. A partition that has passed gate $g$'s barrier may already be publishing
+gate $g+1$ while a slower peer is still gathering gate $g$, so the descriptor table is
+double-buffered by call parity, and gate $g+2$ cannot reach gate $g$'s lines before that slow peer
+has passed gate $g+1$'s barrier — which it reaches only after its own gather of gate $g$ returned.
+
 Linear routing is a switch and not a dial: the rank index takes every bit of $h$ or none of
 them, and none of them is `splitmix`, which reproduces the dense `hash % (R × S)` bit for
 bit. It therefore requires $R$ to be a power of two; any other rank count has no XOR


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Under linear routing (PR 2), a gate's window reaches exactly one peer rank's partitions once the rank
count is above one — so every per-slot array the collective exchange built carried `R - S` empty
blocks, and the exchange itself paid a count round and a full send-buffer copy for a peer set of one.
This PR adds `mpi::pair_exchange`, a direct pairwise exchange for that case: each participant hands
over its `S` sub-streams and takes the peer rank's `S` back, in ascending source order. In-rank that is
one barrier and no copy — peers read the publisher's buffers in place through `PairSlots`' descriptor
table, double-buffered by call parity; across ranks it is two barriers and one message each way, sent
in place with the receive sized by `MPI_Mprobe`, so a silent side still posts exactly one message.

Getting there needed the per-slot arrays re-based onto the peer window first (`mpi::WindowVec`,
deferred here from PR 3): `at_slot()` is the one re-basing door, and `operator[]` takes a `WindowIndex`
so a flat slot index cannot compile as a raw one. The engine's two exchange rounds then move onto
`pair_exchange` when the gate's window names one rank pair, and onto the existing collective
otherwise; round 2's inserts move ahead of the exchange (the verb is synchronous) with no change to
their order against `apply_responses`.

The buffers `pair_exchange` publishes must outlive the gate that filled them — a send buffer may be
reused only from the gate after next — so round-1's records move out of the scan result into a
two-slot scratch pool the gate parity alternates, and `reuse_wire` applies the engine's usual 4×
release rule to a pool no gate boundary can free.

This is PR 7 of 7, based on `perf/stack-6-pair-once`. It targets **peak memory** (the count round and
send-buffer copy this PR removes) and time, both at `R > 1`, where PR 5's protocol currently costs
8-9% time on Hubbard (see PR 5's Measurements). The whole stack's tip is measured against `origin/main`
in a longer, higher-rep ladder once this PR is gated; those numbers are quoted separately, not in this
body.

## Changes

**Engine**
- `cpp/monoprop/detail/mpi/Comm.h` (252 lines): `WindowVec<T>`
  (`reset`/`rewindow`/`at_slot`/`operator[](WindowIndex)`/`capacity`).
- `cpp/monoprop/detail/mpi/PairSlots.h` (new, 175 lines): the peer descriptor table, plus a
  debug-only generation assert that catches a reader taking a descriptor from another gate.
- `cpp/monoprop/detail/mpi/PairExchange.h` (new, 181 lines): `pair_exchange`, with the lifetime
  contract written down as a numbered `@warning` (a published buffer set must outlive the gate after
  next).
- `cpp/monoprop/detail/mpi/HybridComm.h` (567 lines), `ShmComm.h` (218 lines): `pair_` member,
  `pair_exchange`/`_impl_`/`_with_rank_`/`pair_views_`, `staging_bytes` over both the collective and
  pairwise paths.
- `cpp/monoprop/detail/mpi/MPICompat.h` (425 lines): `SlotBlockValue`/`slot_window_of`/`slot_block`/
  `reset_slots` overload pairs; `wait_into`/`begin_alltoallv` templated on the block array.
- `cpp/monoprop/detail/mpi/Pairwise.h` (122 lines): `kPairExchangeTag`, one message per gate.
- `cpp/monoprop/detail/evolution/layer_build/Engine.h` (515 lines): `window` member (default = whole
  world), `pair_path`/`pair_shift` derived from `mpi::geometry(comm)` and the window; both rounds take
  either the pairwise or the collective arm; the collective's receive buffer is now gate-local rather
  than a scratch member, since only a published buffer must outlive its gate.
- `cpp/monoprop/detail/evolution/layer_build/Scan.h` (675 lines): `FusedScanResult::window` and
  `WindowVec`-typed `queries`/`sent`/`sent_c0`; self reserve now fires on `window.contains(my_rank)`
  rather than `rank_count == 1` (O8) — at `R > 1` roughly one gate in `R` has a zero rank shift, and
  those previously staged their whole self side from an empty vector.
- `cpp/monoprop/detail/evolution/layer_build/Resolve.h` (421 lines): `slot_streams`/
  `decode_incoming_records`/`join_incoming`/`apply_responses`/`absence_pass` take an explicit window
  argument.
- `cpp/monoprop/detail/evolution/layer_build/GateScratch.h` (320 lines): the wire pool
  (`wire_q[2]`, `wire_r`, `wire_gate`, `wire_spans`, `slot_views`, `wire_queries(two_rounds)`,
  `wire_bytes()`) replaces `incoming_wire`/`reuse_incoming_wire`.
- `cpp/monoprop/detail/evolution/layer_build/Common.h` (159 lines): `kWireFloorWords`,
  `reuse_wire(WindowVec, SlotWindow)`.

**Tests**
- `cpp/tests/pair_exchange_tests.cpp` (new, 502 lines): five in-rank patterns, six cross-rank, a
  back-to-back-gates case, argument refusal, a poison-release check, hybrid and raw kinds, plus
  `pair_exchange_shm_views_never_alias_a_released_buffer_set`.
- `cpp/tests/evolution_detail_tests.cpp` (1024 lines): `one_gate_pair_and_collective_arms_agree_bitwise`
  — two partitions of an in-process `ShmComm`, one gate, run twice (`eng.pair_path` forced off for the
  second arm), `HalfRotationRec` compared field by field with `v_partner` bit-cast.
- `cpp/tests/sparse_resolve_tests.cpp`, `mpi_utils_tests.cpp`, `pair_once_tests.cpp`: the
  `window_base=16`/`=6` arms restored on `WindowVec`; `check_bucket_ownership` and the per-slot
  sent-ordinal lists over window indices.

**Docs**
- `docs/content/docs/features/parallelism.mdx`: the pair exchange's cost per gate, and why the single
  in-rank barrier is a deferred second barrier rather than a dropped one (two send-buffer sets,
  descriptor parity).

## Measurements

Gated positional against the x2 raw-bit reference, the same reference PR 5's tail and PR 6 gate against:
gate record md5 `f03de2e9ac158dc6e40f752b5145330b` (`df6d9af2…` before the last commit).

Paired A/B, 3 interleaved reps against origin/main c5e88c8 and the predecessor, ratios only:

| rung | time st7/mainB | peak RSS (kernel) st7/mainB | time st6/mainB (predecessor) | peak st6/mainB (predecessor) |
| --- | ---: | ---: | ---: | ---: |
| L1-hubbard | 1.091 | 0.761 | 1.091 | 0.765 |
| L1-pauli | 1.004 | 0.784 | 0.989 | 0.783 |
| M2a-hubbard | 1.012 | 0.761 | 1.076 | 0.765 |

The in-place pair exchange recovers the P=16 time PR 5 cost (1.076 → 1.012 at M2a); the P=1 Hubbard
rung keeps PR 5's cost, which the tip ladder below quotes against main at full size.

Tip ladder, 7 interleaved reps per rung against origin/main c5e88c8 (`**` = 7/7 agreement, sign test p = 0.016):

| rung | shape | time st7/main | peak RSS st7/main | ledger bytes/term st7/main |
| --- | --- | ---: | ---: | ---: |
| L1-hubbard (9.95 M terms) | R=1, P=1 | 1.089 ** | 0.768 ** | 0.721 ** |
| L1-pauli (10.07 M terms) | R=1, P=1 | 1.001 | 0.783 ** | 0.718 ** |
| L2a-hubbard (250 M terms) | R=1, P=16 | 1.003 | 0.824 ** | 0.742 ** |
| L2b-hubbard (250 M terms) | R=4, P=4, ranks summed | 0.962 ** | 0.833 ** | 0.739 ** |

The last commit (`c796bcd`) closes the one exact difference the ladder showed against the same engine measured
earlier as one branch: the gate's mint and decoded-record stages were members of `GateScratch` with no release,
so the widest gate's storage stayed resident in every partition for the rest of the call. They are now handed
back at the end of `exchange_and_join`, matching per-gate ownership. Sizing only, bit-identical by construction
(re-gated positionally). Re-measured at M2a-hubbard (R=1, P=16, 3 reps): `gate_scratch_bytes` 103 → 70 MiB,
`d_gate_buffers_hwm_bytes` 39 → 6 MiB, ledger 0.733 → 0.721 of main, peak 0.764 → 0.759, time within noise.

## Notes for reviewers

- **The P=1 golden gate cannot exercise the pair path** — `pair_path` requires `R > 1`, and the
  positional gate above runs at `monoprop_PARTITIONS=1`. It is still the right gate for what it covers
  (the collective arm, and everything PR 5/PR 6 already established), but the pairwise transport's own
  bit-identity needs separate evidence, which the implementer produced and is quoted here rather than
  re-derived:
  - `monoprop_PARTITIONS=4` (every gate takes the pair path): the full 35-cell golden dump compared
    positionally against PR 6's own `P=4` dump (the collective path, same partitioning) is
    bit-identical on every column. The same `P=4` dump compared against the `P=1` reference is
    value-identical (`msetne 0`) with the layout and gradient reduction order moved, as expected of a
    partition-count change.
  - MPI ranks (`n=2`, `n=4`): a per-rank, per-cell sha256 of the local coefficient array's IEEE-754
    bits and the expval bits, over 21 cells (7 fixtures × `c4`/`c6_la1e-6`/`c6_schro`), is identical
    between PR 6 and this PR at both rank counts.
- **The released-buffer lifetime is covered by a poison test.** `pair_exchange`'s buffers may be reused
  from the gate after next; `pair_exchange_shm_views_never_alias_a_released_buffer_set` scribbles a
  poison word over the just-released buffer set the instant the next gate returns, so a view that
  aliased it fails on a value rather than reading a plausible earlier gate. A mutation check (forcing
  `gather_in_rank` onto the released parity) confirmed the test actually catches this: it failed on
  3/19 value assertions before the fix was reverted. A debug-only generation assert in `PairSlots`
  catches the same fault from the publisher's side.
- `PendingAlltoallv::staging_bytes()` is not carried here — it belongs to the buffers-HWM work already
  landed in PR 4/PR 5, and `Engine`'s own wire-byte accounting covers the same instant.
- The engine keeps PR 5's out-parameter decode (`scratch.incoming_records`) and its misses/join inside
  the scratch, rather than by-value records and an engine-owned miss stage: that refactor is outside
  this PR's commits and does not change the result.

## Checklist

- [x] Tests added or updated to cover the changes
- [x] Documentation updated (docstrings, `docs/`, `CONTRIBUTING.md`) if needed
- [ ] `CHANGELOG` / release notes updated if applicable (n/a — the repository has no `CHANGELOG`)

## AI/LLM disclosure

- [ ] I did not use LLM tooling, or used it only privately for ideation
- [x] I used the following tool to help write this PR description: Claude Code (claude-sonnet-5)
- [x] I used the following tool to generate or modify code: Claude Code (claude-opus-5)

> [!IMPORTANT]
> By opening this PR I confirm that I have read [CONTRIBUTING.md](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CONTRIBUTING.md) and I agree to the terms of the [Contributor License Agreement](https://github.com/Algorithmiq/monoprop/blob/fa820c3e5a90f773417c367fedbf2bd50683b496/CLA.md).

> [!WARNING]
> If you're contributing on behalf of your employer, contact [cla@algorithmiq.fi](mailto:cla@algorithmiq.fi) to arrange a Corporate CLA.
